### PR TITLE
add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ make mpris
 ~/.local/share/cargo/bin/termusic
 ```
 
+### Distro Packages
+
+#### Arch Linux
+
+Arch Linux users can install `termusic` from the [AUR](https://aur.archlinux.org/) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example:
+
+```
+paru termusic
+```
+
 ## ChangeLog
 
 ### [v0.3.13]


### PR DESCRIPTION
I created and started maintaining the [termusic](https://aur.archlinux.org/packages/termusic/) package so currently there are 2 packages in the AUR:

- https://aur.archlinux.org/packages/termusic/
- https://aur.archlinux.org/packages/termusic-git/

I thought README.md should mention the installation instructions for these packages.

