### PR TITLE
Note the config file path for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Finally, you can run it with:
 ~/.local/share/cargo/bin/termusic
 ```
 
-You can copy it anywhere in your `$PATH`. The configuration file is located in `~/.config/termusic/config.toml`.
+You can copy it anywhere in your `$PATH`. The configuration file is located in `~/.config/termusic/config.toml` (or on macOS, `~/Library/Application Support/termusic/config.toml`).
 However, as this is a minimalistic program, you don't need to edit the configuration file and almost everything can be set from the app.
 
 ## TODO


### PR DESCRIPTION
Just noting that the config.toml is in the Application Support dir on macOS.