### PR TITLE
Bump dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.21"
 clap = { version="4", features = ["derive"] }
 # cpal = "0.13"
 thiserror = "1.0.2"
-dirs = "4.0"
+dirs = "5.0"
 discord-rich-presence = { version="0.2",optional = true}
 figment = { version="0.10", features = ["toml"]}
 glib = { version="0.17", optional = true }
@@ -42,10 +42,10 @@ md5 = "0.7"
 num-bigint = "0.4"
 pathdiff = { version = "0.2", features = ["camino"] }
 pinyin = "0.9"
-quick-xml = "0.27"
+quick-xml = "0.28"
 rand = "0.8"
 regex = "^1.5.5"
-rusqlite = { version = "0.28", features = ["bundled"]}
+rusqlite = { version = "0.29", features = ["bundled"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "3"


### PR DESCRIPTION
`dirs 4.0` -> `5.0` - Non-breaking change
`quick-xml 0.27` -> `0.28` -  Non-breaking change, dependency bumps 
`rusqlite 0.28` -> `0.29` - Removable of deprecated APIs, changes to minimal SQLite API version