### PR TITLE
fix(lib::utils::spawn_process): return Result

### DIFF
--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -456,7 +456,7 @@ pub fn spawn_process<A: IntoIterator<Item = S> + Clone, S: AsRef<OsStr>>(
     superuser: bool,
     shout_output: bool,
     args: A,
-) -> Child {
+) -> std::io::Result<Child> {
     let mut cmd = if superuser {
         let mut cmd_t = Command::new("sudo");
         cmd_t.arg(prog);
@@ -470,7 +470,7 @@ pub fn spawn_process<A: IntoIterator<Item = S> + Clone, S: AsRef<OsStr>>(
     }
 
     cmd.args(args);
-    cmd.spawn().expect("Error spawning server process.")
+    cmd.spawn()
 }
 
 #[cfg(test)]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
     }
 
     if launch_daemon {
-        let proc = utils::spawn_process(termusic_server_prog, false, false, [""]);
+        let proc = utils::spawn_process(termusic_server_prog, false, false, [""]).expect(&format!("Could not find {} binary", termusic_server_prog));
         pid = proc.id();
         std::thread::sleep(std::time::Duration::from_millis(200));
     }


### PR DESCRIPTION
This PR changes `spawn_process` to return a result so it can be handled by the calling function instead.

Alternatively the expect in the function originally could include what failed to spawn, but this would only indirectly hint at the line which actually is a error (ie the calling function, see error).

I ran into this trying to run binary `termusic` without having `termusic-server` build.

error before this PR:

```txt
thread 'main' panicked at /mnt/projects/rust/termusic/lib/src/utils/mod.rs:473:17:
Error spawning server process.: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

error after this PR:

```txt
thread 'main' panicked at tui/src/main.rs:109:83:
Could not find termusic-server binary: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```