### PR TITLE
chore(Cargo.toml): change workspace resolve to use v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "lib",
     "playback",


### PR DESCRIPTION
This PR fixes the following cargo warning, because the crates themself use edition 2021 (from what i could tell):

```txt
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```