### PR TITLE
fix(tui): try to find the daemon binary adjacent to the current exe

### DIFF
--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -452,7 +452,7 @@ impl StringUtils for String {
 
 /// Spawn a detached process
 pub fn spawn_process<A: IntoIterator<Item = S> + Clone, S: AsRef<OsStr>>(
-    prog: &str,
+    prog: &Path,
     superuser: bool,
     shout_output: bool,
     args: A,

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
     }
 
     // launch the daemon if it isn't already
-    let termusic_server_prog = "termusic-server";
+    let mut termusic_server_prog = std::path::PathBuf::from("termusic-server");
 
     let mut system = System::new();
     system.refresh_all();
@@ -105,8 +105,18 @@ async fn main() -> Result<()> {
         }
     }
 
+    // try to find the server binary adjacent to the currently executing binary path
+    let potential_server_exe = {
+        let mut exe = std::env::current_exe()?;
+        exe.pop();
+        exe.join(&termusic_server_prog)
+    };
+    if potential_server_exe.exists() {
+        termusic_server_prog = potential_server_exe;
+    }
+
     if launch_daemon {
-        let proc = utils::spawn_process(termusic_server_prog, false, false, [""]);
+        let proc = utils::spawn_process(&termusic_server_prog, false, false, [""]);
         pid = proc.id();
         std::thread::sleep(std::time::Duration::from_millis(200));
     }


### PR DESCRIPTION
This PR changes the TUI daemon spawning process to try to look for the binary adjacent to the currently executing exe, which will allow running `cargo run --bin=termusic` and not cause a issue like `No such file or directory`.

This check could likely be improved to also check for permissions before being used, but for now i know this is working for the simple case of running it when not installed (or in PATH)