### PR TITLE
fix: fix debug builds by spawning a blocking tokio thread

### DIFF
--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -61,7 +61,7 @@ impl UI {
     /// Instantiates a new Ui
     pub async fn new(config: &Settings) -> Result<Self> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let mut model = Model::new(config, cmd_tx);
+        let mut model = Model::new(config, cmd_tx).await;
         model.init_config();
         let playback = Playback::new(config.player_port).await?;
         Ok(Self {

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -123,7 +123,7 @@ pub enum ViuerSupported {
 }
 
 impl Model {
-    pub fn new(config: &Settings, cmd_tx: UnboundedSender<PlayerCmd>) -> Self {
+    pub async fn new(config: &Settings, cmd_tx: UnboundedSender<PlayerCmd>) -> Self {
         let path = Self::get_full_path_from_config(config);
         let tree = Tree::new(Self::library_dir_tree(&path, config.max_depth_cli));
 
@@ -176,7 +176,9 @@ impl Model {
             tageditor_song: None,
             time_pos: 0,
             lyric_line: String::new(),
-            youtube_options: YoutubeOptions::default(),
+            youtube_options: tokio::task::spawn_blocking(YoutubeOptions::default)
+                .await
+                .expect("Failed to initialize YoutubeOptions in a blocking task due to a panic"),
             #[cfg(feature = "cover")]
             ueberzug_instance,
             songtag_options: vec![],


### PR DESCRIPTION
This PR uses some changes from #151, so that debug builds are even possible to be run and not crash (without extra new features like in the mentioned PR)