### PR TITLE
fix(tui): add panic hook to reset the screen before printing panic

### DIFF
--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -230,6 +230,13 @@ impl Model {
 
     /// Initialize terminal
     pub fn init_terminal(&mut self) {
+        let original_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic| {
+            let mut terminal_clone = TerminalBridge::new().expect("Could not initialize terminal");
+            let _drop = terminal_clone.disable_raw_mode();
+            let _drop = terminal_clone.leave_alternate_screen();
+            original_hook(panic);
+        }));
         let _drop = self.terminal.enable_raw_mode();
         let _drop = self.terminal.enter_alternate_screen();
         let _drop = self.terminal.clear_screen();


### PR DESCRIPTION
This PR adds a panic hook to reset the screen before printing the panic message

this is likely not ideal because TerminalBridge cannot be cloned, but works

re #161