### PR TITLE
style: fix format (cargo fmt)

### DIFF
--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -69,7 +69,7 @@ impl Symphonia {
         )?;
 
         let Some(track) = probed.format.default_track() else {
-            return Ok(None)
+            return Ok(None);
         };
 
         let mut decoder = symphonia::default::get_codecs().make(

--- a/playback/src/rusty_backend/stream.rs
+++ b/playback/src/rusty_backend/stream.rs
@@ -68,7 +68,7 @@ impl OutputStream {
         default_stream.or_else(|original_err| {
             // default device didn't work, try other ones
             let Ok(mut devices) = cpal::default_host().output_devices() else {
-               return Err(original_err);
+                return Err(original_err);
             };
 
             devices

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -109,7 +109,7 @@ impl Model {
             return Ok(());
         }
         let Some(track) = self.playlist.current_track().cloned() else {
-            return Ok(())
+            return Ok(());
         };
 
         match track.media_type {


### PR DESCRIPTION
This PR applies `cargo fmt`, because the current tests are failing because of it