### PR TITLE
Change actions used in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,26 +28,16 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
   test_macos:
     name: Test Mac
@@ -74,26 +64,16 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo  check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
 
   test-win:
@@ -118,23 +98,13 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Install developer package dependencies
@@ -63,11 +61,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
       - name: Install developer package dependencies
@@ -112,11 +108,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
       - name: Install dependencies
         run: choco install protoc
@@ -144,6 +138,3 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,21 +83,25 @@ jobs:
         if: matrix.build == 'x86_64-windows'
         run: choco install protoc 
       
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: test
-          if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos || matrix.build == 'x86_64-windows'
-          args: --release --locked --target ${{ matrix.target }}
+      - name: Run cargo test (cargo)
+        if: (matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos || matrix.build == 'x86_64-windows') && !matrix.cross
+        run: cargo test --release --locked --target ${{ matrix.target }}
 
-      - name: Build release binary
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: --features cover --release --locked --target ${{ matrix.target }}
-          # args: --release --locked --target ${{ matrix.target }}
+      - name: Build release binary (cargo)
+        if: !matrix.cross
+        run: cargo build --features cover --release --locked --target ${{ matrix.target }}
+
+      - name: Install cross (cross)
+        if: matrix.cross
+        run: cargo install cross
+
+      - name: Run cargo test (cross)
+        if: (matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos || matrix.build == 'x86_64-windows') && matrix.cross
+        run: cargo test --release --locked --target ${{ matrix.target }}
+
+      - name: Build release binary (cross)
+        if: matrix.cross
+        run: cargo build --features cover --release --locked --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,10 @@ jobs:
           submodules: true
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Install developer package dependencies
         if: matrix.build == 'x86_64-linux'
@@ -234,4 +232,3 @@ jobs:
         #     bin.install "<bin-name>"
         #   end
         # end
-


### PR DESCRIPTION
This PR changes the actions used in the workflows to non-deprecated versions

NOTE: please wait until the CI is finished with this one, so that we know there are no problems with the actions

another NOTE: the release run will have to be tested separately because it does not run for a CI (and i am unsure of the changes i have done for `actions-rs/cargo`)

PS: the cross/cargo steps could likely be combined by changing the matrix value to set which to use (instead of `cross: true` use `command: cross` and `cross: false` `command: cargo`), but for now i have gone with that