### PR TITLE
Fix all warnings

### DIFF
--- a/lib/src/podcast/db.rs
+++ b/lib/src/podcast/db.rs
@@ -643,6 +643,9 @@ impl Database {
         Ok(last_position)
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn set_last_position(&mut self, track: &Track, last_position: Duration) {
         let query = "UPDATE episodes SET last_position = ?1 WHERE url = ?2";
         let conn = self

--- a/lib/src/podcast/db.rs
+++ b/lib/src/podcast/db.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use std::path::{Path, PathBuf};
 
 use crate::track::Track;
@@ -50,11 +50,11 @@ impl Database {
             let conn = db_conn
                 .conn
                 .as_ref()
-                .expect("Error connecting to database.");
+                .ok_or(anyhow!("Error connecting to database."))?;
 
             // SQLite defaults to foreign key support off
             conn.execute("PRAGMA foreign_keys=ON;", params![])
-                .expect("Could not set database parameters.");
+                .with_context(|| "Could not set database parameters.")?;
 
             // get version number stored in database
             let mut stmt = conn.prepare("SELECT version FROM version WHERE id = 1;")?;
@@ -91,7 +91,10 @@ impl Database {
     /// exist. Panics if database cannot be accessed, or if tables cannot
     /// be created.
     pub fn create(&self) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         // create podcasts table
         conn.execute(
@@ -157,7 +160,10 @@ impl Database {
     /// of the app, this updates the value stored in the database to
     /// match.
     fn update_version(&self, current_version: &Version, update: bool) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         if update {
             conn.execute(
@@ -178,7 +184,8 @@ impl Database {
     /// Inserts a new podcast and list of podcast episodes into the
     /// database.
     pub fn insert_podcast(&self, podcast: &PodcastNoId) -> Result<SyncResult> {
-        let mut conn = Connection::open(&self.path).expect("Error connecting to database.");
+        let mut conn =
+            Connection::open(&self.path).with_context(|| "Error connecting to database.")?;
         let tx = conn.transaction()?;
         // let conn = self.conn.as_ref().expect("Error connecting to database.");
         {
@@ -254,7 +261,10 @@ impl Database {
 
     /// Inserts a filepath to a downloaded episode.
     pub fn insert_file(&self, episode_id: i64, path: &Path) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         let mut stmt = conn.prepare_cached(
             "INSERT INTO files (episode_id, path)
@@ -267,7 +277,10 @@ impl Database {
     /// Removes a file listing for an episode from the database when the
     /// user has chosen to delete the file.
     pub fn remove_file(&self, episode_id: i64) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
         let mut stmt = conn.prepare_cached("DELETE FROM files WHERE episode_id = ?;")?;
         stmt.execute(params![episode_id])?;
         Ok(())
@@ -275,7 +288,10 @@ impl Database {
 
     /// Removes all file listings for the selected episode ids.
     pub fn remove_files(&self, episode_ids: &[i64]) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         // convert list of episode ids into a comma-separated String
         let episode_list: Vec<String> = episode_ids
@@ -291,7 +307,10 @@ impl Database {
 
     /// Removes a podcast, all episodes, and files from the database.
     pub fn remove_podcast(&self, podcast_id: i64) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
         // Note: Because of the foreign key constraints on `episodes`
         // and `files` tables, all associated episodes for this podcast
         // will also be deleted, and all associated file entries for
@@ -306,7 +325,10 @@ impl Database {
     /// are updated, new episodes are inserted).
     pub fn update_podcast(&self, pod_id: i64, podcast: &PodcastNoId) -> Result<SyncResult> {
         {
-            let conn = self.conn.as_ref().expect("Error connecting to database.");
+            let conn = self
+                .conn
+                .as_ref()
+                .ok_or(anyhow!("Error connecting to database."))?;
             let mut stmt = conn.prepare_cached(
                 "UPDATE podcasts SET title = ?, url = ?, description = ?,
             author = ?, explicit = ?, last_checked = ?
@@ -349,7 +371,8 @@ impl Database {
             }
         }
 
-        let mut conn = Connection::open(&self.path).expect("Error connecting to database.");
+        let mut conn =
+            Connection::open(&self.path).with_context(|| "Error connecting to database.")?;
         let tx = conn.transaction()?;
 
         let mut insert_ep = Vec::new();
@@ -455,7 +478,10 @@ impl Database {
 
     /// Updates an episode to mark it as played or unplayed.
     pub fn set_played_status(&self, episode_id: i64, played: bool) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         let mut stmt = conn.prepare_cached("UPDATE episodes SET played = ? WHERE id = ?;")?;
         stmt.execute(params![played, episode_id])?;
@@ -464,7 +490,8 @@ impl Database {
 
     /// Updates an episode to mark it as played or unplayed.
     pub fn set_all_played_status(&self, episode_id_vec: &[i64], played: bool) -> Result<()> {
-        let mut conn = Connection::open(&self.path).expect("Error connecting to database.");
+        let mut conn =
+            Connection::open(&self.path).with_context(|| "Error connecting to database.")?;
         let tx = conn.transaction()?;
 
         for episode_id in episode_id_vec {
@@ -479,7 +506,10 @@ impl Database {
     /// episodes need to stay in the database so that they don't get
     /// re-added when the podcast is synced again.
     pub fn hide_episode(&self, episode_id: i64, hide: bool) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
 
         let mut stmt = conn.prepare_cached("UPDATE episodes SET hidden = ? WHERE id = ?;")?;
         stmt.execute(params![hide, episode_id])?;
@@ -489,7 +519,10 @@ impl Database {
     /// Generates list of all podcasts in database.
     /// TODO: This should probably use a JOIN statement instead.
     pub fn get_podcasts(&self) -> Result<Vec<Podcast>> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
         let mut stmt = conn.prepare_cached("SELECT * FROM podcasts;")?;
         let podcast_iter = stmt.query_map(params![], |row| {
             let pod_id = row.get("id")?;
@@ -531,7 +564,10 @@ impl Database {
 
     /// Generates list of episodes for a given podcast.
     pub fn get_episodes(&self, pod_id: i64, include_hidden: bool) -> Result<Vec<Episode>> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
         let mut stmt = if include_hidden {
             conn.prepare_cached(
                 "SELECT * FROM episodes
@@ -574,7 +610,10 @@ impl Database {
 
     /// Deletes all rows in all tables
     pub fn clear_db(&self) -> Result<()> {
-        let conn = self.conn.as_ref().expect("Error connecting to database.");
+        let conn = self
+            .conn
+            .as_ref()
+            .ok_or(anyhow!("Error connecting to database."))?;
         conn.execute("DELETE FROM files;", params![])?;
         conn.execute("DELETE FROM episodes;", params![])?;
         conn.execute("DELETE FROM podcasts;", params![])?;
@@ -588,7 +627,7 @@ impl Database {
         let conn = self
             .conn
             .as_ref()
-            .expect("conn is not available for get last position.");
+            .ok_or(anyhow!("conn is not available for get last position."))?;
         conn.query_row(
             query,
             params![track.file().unwrap_or("Unknown File").to_string(),],

--- a/lib/src/podcast/mod.rs
+++ b/lib/src/podcast/mod.rs
@@ -288,6 +288,10 @@ impl PodcastFeed {
 }
 
 /// Spawns a new thread to check a feed and retrieve podcast data.
+///
+/// # Panics
+///
+/// if sending commands to `tx_to_main` fails
 pub fn check_feed(
     feed: PodcastFeed,
     max_retries: usize,
@@ -544,6 +548,10 @@ impl Threadpool {
 
     /// Adds a new job to the threadpool, passing closure to first
     /// available worker.
+    ///
+    /// # Panics
+    ///
+    /// if sending commands to the sender fails
     pub fn execute<F>(&self, func: F)
     where
         F: FnOnce() + Send + 'static,
@@ -827,14 +835,21 @@ pub fn download_list(
     for ep in episodes {
         let tx = tx_to_main.clone();
         let dest2 = dest.to_path_buf();
-        threadpool.execute(move || {
-            tx.send(Msg::Podcast(PCMsg::DLStart(ep.clone())))
-                .expect("Thread messaging error when start download");
-            let result = download_file(ep, dest2, max_retries);
-            tx.send(Msg::Podcast(result))
-                .expect("Thread messaging error");
-        });
+        threadpool.execute(move || download_job(&tx, ep, dest2, max_retries));
     }
+}
+
+/// # Panics
+///
+/// if sending command via `tx_to_main` fails
+fn download_job(tx_to_main: &Sender<Msg>, ep: EpData, dest: PathBuf, max_retries: usize) {
+    tx_to_main
+        .send(Msg::Podcast(PCMsg::DLStart(ep.clone())))
+        .expect("Thread messaging error when start download");
+    let result = download_file(ep, dest, max_retries);
+    tx_to_main
+        .send(Msg::Podcast(result))
+        .expect("Thread messaging error");
 }
 
 /// Downloads a file to a local filepath, returning `DownloadMsg` variant

--- a/lib/src/songtag/encrypt.rs
+++ b/lib/src/songtag/encrypt.rs
@@ -150,7 +150,6 @@ impl Crypto {
     pub fn encrypt_id(id: &str) -> String {
         let magic = b"3go8&$8*3*3h0k(2)2";
         let magic_len = magic.len();
-        let id = id;
         let mut song_id = id.to_string().into_bytes();
         id.as_bytes().iter().enumerate().for_each(|(i, sid)| {
             song_id[i] = *sid ^ magic[i % magic_len];

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -288,7 +288,10 @@ impl SongTag {
         ];
 
         let p_full = format!("{p_parent}/{artist}-{title}.mp3");
-        std::fs::remove_file(Path::new(p_full.as_str())).is_err();
+        match std::fs::remove_file(Path::new(p_full.as_str())) {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
+            v => v?,
+        }
 
         let mp3_url = self.url.clone().unwrap_or_else(|| String::from("N/A"));
         if mp3_url.starts_with("Copyright") {

--- a/lib/src/sqlite.rs
+++ b/lib/src/sqlite.rs
@@ -88,6 +88,10 @@ impl std::fmt::Display for SearchCriteria {
 }
 
 impl DataBase {
+    /// # Panics
+    ///
+    /// - if app config path creation fails
+    /// - if any required database operation fails
     pub fn new(config: &Settings) -> Self {
         let mut db_path = get_app_config_path().expect("failed to get app configuration path");
         db_path.push("library.db");
@@ -268,6 +272,9 @@ impl DataBase {
         });
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn get_all_records(&mut self) -> Result<Vec<TrackForDB>> {
         let conn = self
             .conn
@@ -281,6 +288,9 @@ impl DataBase {
         Ok(vec)
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn get_record_by_criteria(
         &mut self,
         str: &str,
@@ -327,6 +337,9 @@ impl DataBase {
         }
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn get_criterias(&mut self, cri: &SearchCriteria) -> Result<Vec<String>> {
         let search_str = format!("SELECT DISTINCT {cri} FROM tracks");
         let conn = self
@@ -347,6 +360,9 @@ impl DataBase {
         Ok(vec)
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn get_last_position(&mut self, track: &Track) -> Result<Duration> {
         let query = "SELECT last_position FROM tracks WHERE name = ?1";
 
@@ -370,6 +386,9 @@ impl DataBase {
         Ok(last_position)
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn set_last_position(&mut self, track: &Track, last_position: Duration) {
         let query = "UPDATE tracks SET last_position = ?1 WHERE name = ?2";
         let conn = self
@@ -387,6 +406,9 @@ impl DataBase {
         // eprintln!("set last position as {}", last_position.as_secs());
     }
 
+    /// # Panics
+    ///
+    /// if the connection is unavailable
     pub fn get_record_by_path(&mut self, str: &str) -> Result<TrackForDB> {
         let search_str = "SELECT * FROM tracks WHERE file = ?";
         let conn = self

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -24,7 +24,7 @@ use crate::podcast::Episode;
  */
 use crate::songtag::lrc::Lyric;
 use crate::utils::get_parent_folder;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use id3::frame::Lyrics;
 use lofty::id3::v2::{Frame, FrameFlags, FrameValue, Id3v2Tag, UnsynchronizedTextFrame};
 use lofty::{
@@ -445,7 +445,7 @@ impl Track {
                                         encoding: TextEncoding::UTF8,
                                         language: l.lang.as_bytes()[0..3]
                                             .try_into()
-                                            .expect("wrong length of language"),
+                                            .with_context(|| "wrong length of language")?,
                                         description: l.description,
                                         content: l.text,
                                     }),

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -295,6 +295,9 @@ impl GeneralPlayer {
             }
         }
     }
+    /// # Panics
+    ///
+    /// if the underlying "seek" returns a error (which current never happens)
     pub fn seek_relative(&mut self, forward: bool) {
         let mut offset = match self.config.player_seek_step {
             SeekStep::Short => -5_i64,
@@ -493,6 +496,7 @@ pub trait PlayerTrait {
     ///
     /// Depending on different backend, there could be different errors during seek.
     fn seek(&mut self, secs: i64) -> Result<()>;
+    // TODO: sync return types between "seek" and "seek_to"?
     fn seek_to(&mut self, last_pos: Duration);
     /// # Errors
     ///

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -164,6 +164,9 @@ impl GeneralPlayer {
         self.backend.gapless
     }
 
+    /// # Panics
+    ///
+    /// panics if the [`tokio::runtime::Runtime`] fails to build
     pub fn start_play(&mut self) {
         if self.playlist.is_stopped() | self.playlist.is_paused() {
             self.playlist.set_status(Status::Running);
@@ -194,8 +197,11 @@ impl GeneralPlayer {
             let wait = async {
                 self.add_and_play(&track).await;
             };
-            let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
-            rt.block_on(wait);
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to create runtime")
+                .block_on(wait);
 
             self.add_and_play_mpris_discord();
             self.player_restore_last_position();

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use pathdiff::diff_utf8_paths;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
@@ -139,7 +139,7 @@ impl Playlist {
         let db_podcast = DBPod::connect(&db_path)?;
         let podcasts = db_podcast
             .get_podcasts()
-            .expect("failed to get podcasts from db.");
+            .with_context(|| "failed to get podcasts from db.")?;
         for line in &lines {
             if let Ok(s) = Track::read_from_path(line, false) {
                 playlist_items.push(s);

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -567,8 +567,7 @@ impl PlayerTrait for Player {
     }
 
     fn seek(&mut self, offset: i64) -> Result<()> {
-        self.command_tx
-            .send(PlayerInternalCmd::SeekRelative(offset))?;
+        self.command(PlayerInternalCmd::SeekRelative(offset));
         Ok(())
     }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let addr = format!("[::]:{}", config.player_port).parse()?;
     let player_handle = tokio::task::spawn_blocking(move || -> Result<()> {
-        let mut player = GeneralPlayer::new(&config, cmd_tx.clone(), cmd_rx.clone());
+        let mut player = GeneralPlayer::new(&config, cmd_tx.clone(), cmd_rx.clone())?;
         loop {
             {
                 let mut cmd_rx = cmd_rx.lock();

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     let config = get_config(&args)?;
 
     if let Some(action) = args.action {
-        execute_action(action, config);
+        execute_action(action, &config);
 
         return Ok(());
     }
@@ -143,7 +143,7 @@ fn get_path(dir: &str) -> Option<String> {
     music_dir
 }
 
-fn execute_action(action: cli::Action, config: Settings) {
+fn execute_action(action: cli::Action, config: &Settings) {
     match action {
         cli::Action::Import { file } => {
             println!("need to import from file {file}");
@@ -152,7 +152,7 @@ fn execute_action(action: cli::Action, config: Settings) {
             let db_path = utils::get_app_config_path();
 
             if let (Some(path_str), Ok(db_path)) = (path_str, db_path) {
-                if let Err(e) = podcast::import_from_opml(db_path.as_path(), &config, &path_str) {
+                if let Err(e) = podcast::import_from_opml(db_path.as_path(), config, &path_str) {
                     eprintln!("Error when import file {file}: {e}");
                 }
             }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -53,7 +53,9 @@ async fn main() -> Result<()> {
     let config = get_config(&args)?;
 
     if let Some(action) = args.action {
-        return execute_action(action, config);
+        execute_action(action, config);
+
+        return Ok(());
     }
 
     // launch the daemon if it isn't already
@@ -141,7 +143,7 @@ fn get_path(dir: &str) -> Option<String> {
     music_dir
 }
 
-fn execute_action(action: cli::Action, config: Settings) -> Result<()> {
+fn execute_action(action: cli::Action, config: Settings) {
     match action {
         cli::Action::Import { file } => {
             println!("need to import from file {file}");
@@ -166,8 +168,6 @@ fn execute_action(action: cli::Action, config: Settings) -> Result<()> {
             }
         }
     };
-
-    Ok(())
 }
 
 fn get_path_export(dir: &str) -> String {


### PR DESCRIPTION
This PR fixes all rustc and clippy warnings, some by refactoring. in more detail:
- mostly appease clippy by converting `.expect`s to return results instead where possible
- add `# Panics` (and `# Errors`) headers where clippy wants them
- refactor some functions to return results
- outsource podcast `download_list` job to its own function (because it does not actually panic, but the job being sent does)
- in `GeneralPlayer::start_player` use a single-threaded runtime instead, because it will block the current thread anyway (so less overhead)
- add a todo to the `PlayerTrait` to sync the return types of `seek` and `seek_to` (because why would they return different hings?)
- change `playback::rusty_backend::Player::seek` to use `self.command` like surrounding functions
- remove return type from `tui::main::execute_action` (because of clippy warning)