### PR TITLE
Fix broken merge of #172

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,7 +29,6 @@ serde.workspace = true
 sysinfo.workspace = true
 tokio.workspace = true
 tonic.workspace = true
-# tokio-stream.workspace = true
 clap.workspace = true
 
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Action {
     },
 }
 
-const DEFAULT_LOG_FILE: &str = "/tmp/termusic-server.log";
+const DEFAULT_LOGFILE_FILENAME: &str = "termusic-server.log";
 
 #[derive(Debug, Parser, Clone, PartialEq)]
 pub struct LogOptions {
@@ -76,11 +76,15 @@ pub struct LogOptions {
     pub log_to_file: bool,
 
     /// Set logging file
-    #[arg(long = "log-file", default_value = DEFAULT_LOG_FILE, env = "TMS_LOGFILE")]
+    #[arg(long = "log-file", default_value_os_t = default_logfile_path(), env = "TMS_LOGFILE")]
     pub log_file: PathBuf,
 
     /// Use colored logging for files
     /// Example: live tailing via `tail -f /logfile`
     #[arg(long = "log-filecolor", env = "TMS_LOGFILE_COLOR")]
     pub file_color_log: bool,
+}
+
+fn default_logfile_path() -> PathBuf {
+    std::env::temp_dir().join(DEFAULT_LOGFILE_FILENAME)
 }

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -8,7 +8,7 @@ use crate::cli::Args;
 /// Function for setting up the logger
 /// This function is mainly to keep the code structured and sorted
 #[inline]
-pub fn setup_logger(args: &Args) -> LoggerHandle {
+pub fn setup(args: &Args) -> LoggerHandle {
     // TODO: look into https://github.com/emabee/flexi_logger/issues/142 again
     let handle = {
         let mut logger = Logger::try_with_env_or_str("warn")
@@ -61,7 +61,7 @@ pub fn setup_logger(args: &Args) -> LoggerHandle {
 pub fn log_format(
     w: &mut dyn std::io::Write,
     now: &mut DeferredNow,
-    record: &Record,
+    record: &Record<'_>,
 ) -> Result<(), std::io::Error> {
     write!(
         w,
@@ -82,7 +82,7 @@ pub fn log_format(
 pub fn color_log_format(
     w: &mut dyn std::io::Write,
     now: &mut DeferredNow,
-    record: &Record,
+    record: &Record<'_>,
 ) -> Result<(), std::io::Error> {
     let level = record.level();
     write!(

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -23,7 +23,7 @@ pub const MAX_DEPTH: usize = 4;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = cli::Args::parse();
-    let _ = logger::setup_logger(&args);
+    let _ = logger::setup(&args);
     info!("background thread start");
 
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Action {
     },
 }
 
-const DEFAULT_LOG_FILE: &str = "/tmp/termusic-tui.log";
+const DEFAULT_LOGFILE_FILENAME: &str = "termusic-tui.log";
 
 #[derive(Debug, Parser, Clone, PartialEq)]
 pub struct LogOptions {
@@ -76,11 +76,15 @@ pub struct LogOptions {
     pub log_to_file: bool,
 
     /// Set logging file
-    #[arg(long = "log-file", default_value = DEFAULT_LOG_FILE, env = "TM_LOGFILE")]
+    #[arg(long = "log-file", default_value_os_t = default_logfile_path(), env = "TM_LOGFILE")]
     pub log_file: PathBuf,
 
     /// Use colored logging for files
     /// Example: live tailing via `tail -f /logfile`
     #[arg(long = "log-filecolor", env = "TM_LOGFILE_COLOR")]
     pub file_color_log: bool,
+}
+
+fn default_logfile_path() -> PathBuf {
+    std::env::temp_dir().join(DEFAULT_LOGFILE_FILENAME)
 }


### PR DESCRIPTION
This PR fixes the broken merge done in #172, in more detail:
- fixes that #172 was still based on before the revert of #154, which meant the merge in #172 re-added a dependency which was not defined in the workspace
- #172 was not properly formatted (cargo fmt & cargo clippy)
- #172 still had the out-standing issue that the default logfile path would not work on non-posix systems
