### PR TITLE
fix(tui::config_editor::general): fix panic if "music_dir" is empty

### DIFF
--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -47,7 +47,10 @@ impl MusicDir {
             music_dir.push_str(m.as_str());
             music_dir.push(';');
         }
-        let _drop = music_dir.remove(music_dir.len() - 1);
+        // remove the last ";"
+        if !music_dir.is_empty() {
+            music_dir.remove(music_dir.len() - 1);
+        }
         Self {
             component: Input::default()
                 .borders(


### PR DESCRIPTION
fixes #161

This PR fixes #161, i am not totally sure on why this is necessary in the first place, but adding a guard if it should be empty.
not using `saturating_sub` because it seems like it will panic if the string is empty:
`cannot remove a char from the end of a string`