### PR TITLE
feat(playback::mpris): display coverart if available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,6 +3569,7 @@ version = "0.7.11"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.2",
  "cpal",
  "discord-rich-presence",
  "glib",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -41,6 +41,7 @@ tonic.workspace = true
 prost.workspace = true
 async-trait.workspace = true
 parking_lot.workspace = true
+base64.workspace = true
 
 [features]
 # default = []

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use termusiclib::track::Track;
 // use crate::souvlaki::{
 //     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig,
@@ -53,11 +54,20 @@ impl Mpris {
         self.controls
             .set_playback(MediaPlayback::Playing { progress: None })
             .ok();
+
+        let cover_art = track.picture().map(|picture| {
+            format!(
+                "data:image/jpeg;base64,{}",
+                base64::engine::general_purpose::STANDARD_NO_PAD.encode(picture.data())
+            )
+        });
+
         self.controls
             .set_metadata(MediaMetadata {
                 title: Some(track.title().unwrap_or("Unknown Title")),
                 artist: Some(track.artist().unwrap_or("Unknown Artist")),
                 album: Some(track.album().unwrap_or("")),
+                cover_url: cover_art.as_deref(),
                 ..MediaMetadata::default()
             })
             .ok();


### PR DESCRIPTION
fixes #178

This PR adds the `mpris:artUrl` metadata and so displays cover-art in mpris

tested & working in KDE Plasma Wayland 5.27.9 (uses the same method MPV does)