### PR TITLE
feat(playback::mpris): add duration metadata

### DIFF
--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -58,6 +58,7 @@ impl Mpris {
                 title: Some(track.title().unwrap_or("Unknown Title")),
                 artist: Some(track.artist().unwrap_or("Unknown Artist")),
                 album: Some(track.album().unwrap_or("")),
+                duration: Some(track.duration()),
                 ..MediaMetadata::default()
             })
             .ok();


### PR DESCRIPTION
This PR adds mpris duration metadata

tested & working in KDE Plasma Wayland 5.27.9 (uses the same method MPV does)