### PR TITLE
style(playback::mpris): fix clippy

### DIFF
--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -69,7 +69,6 @@ impl Mpris {
                 album: Some(track.album().unwrap_or("")),
                 cover_url: cover_art.as_deref(),
                 duration: Some(track.duration()),
-                ..MediaMetadata::default()
             })
             .ok();
     }


### PR DESCRIPTION
This PR fixes clippy warning added by merging #179 and #180 and so failing all tests