### PR TITLE
fix(playback::mpris): use correct mime-type of picture

### DIFF
--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -57,7 +57,8 @@ impl Mpris {
 
         let cover_art = track.picture().map(|picture| {
             format!(
-                "data:image/jpeg;base64,{}",
+                "data:{};base64,{}",
+                picture.mime_type().as_str(),
                 base64::engine::general_purpose::STANDARD_NO_PAD.encode(picture.data())
             )
         });


### PR DESCRIPTION
This is a fixup to #179, at the time i didnt notice that the `Picture` type had a `mime_type` associated with it and assume it is always a jpeg, this PR fixes it

(tested on the same system as #179, i dont have any png or gif songs, but jpeg still works)