### PR TITLE
Logging improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,9 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ termusic-lib= {path = "lib/" ,version = "0.7.11"}
 termusic-playback= {path = "playback/",version = "0.7.11"}
 termusic-stream= {path = "stream/",version = "0.7.11"}
 ahash = "^0.8"
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 async-trait = "0.1"
 base64 = "0.21"
 bytes = "1"

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -20,8 +20,18 @@ extern crate log;
 
 pub const MAX_DEPTH: usize = 4;
 
+fn main() -> Result<()> {
+    // print error to the log and then throw it
+    if let Err(err) = actual_main() {
+        error!("Error: {:?}", err);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn actual_main() -> Result<()> {
     let args = cli::Args::parse();
     let _ = logger::setup(&args);
     info!("background thread start");

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -46,9 +46,19 @@ extern crate log;
 
 pub const MAX_DEPTH: usize = 4;
 
+fn main() -> Result<()> {
+    // print error to the log and then throw it
+    if let Err(err) = actual_main() {
+        error!("Error: {:?}", err);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 /// Handles CLI args, potentially starts termusic-server, then runs UI loop
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn actual_main() -> Result<()> {
     let args = cli::Args::parse();
     let mut logger_handle = logger::setup(&args);
     let config = get_config(&args)?;

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -76,6 +76,19 @@ impl UI {
     /// Main loop for Ui thread
     pub async fn run(&mut self) -> Result<()> {
         self.model.init_terminal();
+
+        let res = self.run_inner().await;
+
+        // reset terminal in any case
+        self.model.finalize_terminal();
+
+        res
+    }
+
+    /// Main Loop function
+    ///
+    /// This function does NOT handle initializing and finializing the terminal
+    async fn run_inner(&mut self) -> Result<()> {
         // Main loop
         let mut progress_interval = 0;
         while !self.model.quit {
@@ -135,7 +148,6 @@ impl UI {
             }
         }
 
-        self.model.finalize_terminal();
         Ok(())
     }
 


### PR DESCRIPTION
This PR does a bunch of logging improvements that i have noticed, in more detail:
- reset terminal regardless what the main-loop result is
- add panic hooks in loggers to print panics to logs
- print `main` Result::Err(ors) to the log
- enable anyhow `backtrace` to get a full trace of where a error originates if `RUST_BACKTRACE` is set to a truthy value (`1` or `true`)