### PR TITLE
CI test mentioned MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config protobuf-compiler
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev gstreamer-player-1
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo check
@@ -63,7 +63,7 @@ jobs:
             brew update
             brew install protobuf
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo  check
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: choco install protoc
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   test_linux:
     name: Test Linux
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable, 1.67]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -18,7 +22,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - name: Install developer package dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Test Suites
 on:
   pull_request:
   push:
-    branches:
-      - master
   schedule:
     - cron: '00 01 * * *'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["terminal", "tui","music","youtube","podcast"]
 categories = ["command-line-interface","command-line-utilities", "multimedia::audio"]
 readme = "./README.md"
 version = "0.7.11"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+rust-version = "1.67"
 
 [workspace.dependencies]
 termusic-lib= {path = "lib/" ,version = "0.7.11"}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true 
 keywords.workspace = true 
 categories.workspace = true 
+rust-version.workspace = true
 
 
 [lib]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true 
 keywords.workspace = true 
 categories.workspace = true 
+rust-version.workspace = true
 
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 homepage.workspace = true 
 keywords.workspace = true 
 categories.workspace = true 
+rust-version.workspace = true
 
 [[bin]]
 name = "termusic-server"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 keywords.workspace = true 
 categories.workspace = true 
 readme.workspace = true 
+rust-version.workspace = true
 
 
 [[bin]]


### PR DESCRIPTION
This PR adds a entry to test the mentioned MSRV in the CI (for now only linux), in addition also does:
- remove `rust-toolchain.toml`, because it only sets `stable`, which is not useful and would require workarounds for CI
- update rust-cache github action
- add `rust-version` field in `Cargo.toml`s
- run `build` action on all branches, not just master (useful for feature work or CI testing, etc)

*MSRV is based on the one mentioned in the README