### PR TITLE
Multiple small changes

### DIFF
--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -358,21 +358,38 @@ pub enum PCMsg {
     SearchError(String),
 }
 
+/// Playlist Library View messages
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PLMsg {
     NextSong,
     PrevSong,
+    /// Change focus to the next view
     PlaylistTableBlurDown,
+    /// Change focus to the previous view
     PlaylistTableBlurUp,
+    /// Add a directory / file to the playlist
     Add(String),
+    /// Remove INDEX from playlist
     Delete(usize),
+    /// Clear the Playlist
     DeleteAll,
+    /// Select the next mode in the list
+    ///
+    /// see `termusicplayback::playlist::Loop` for all modes
     LoopModeCycle,
+    /// Play a specific index
     PlaySelected(usize),
+    /// Shuffle the current items in the playlist
     Shuffle,
+    /// Swap a entry at INDEX with +1 (down)
     SwapDown(usize),
+    /// Swap a entry at INDEX with -1 (up)
     SwapUp(usize),
+    /// Start choosing random albums to be added to the playlist
+    // TODO: the shortform "CmusLQueue" should also be explained
     CmusLQueue,
+    /// Start choosing random tracks to be added to the playlist
+    // TODO: the shortform "CmusTQueue" should also be explained
     CmusTQueue,
 }
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -154,7 +154,7 @@ impl GeneralPlayer {
             backend,
             playlist,
             config: config.clone(),
-            mpris: mpris::Mpris::default(),
+            mpris: mpris::Mpris::new(cmd_tx.clone()),
             discord: discord::Rpc::default(),
             db: DataBase::new(config),
             db_podcast,

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -1,12 +1,17 @@
 use base64::Engine;
+use parking_lot::Mutex;
 use termusiclib::track::Track;
+use tokio::sync::mpsc::UnboundedSender;
 // use crate::souvlaki::{
 //     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig,
 // };
-use crate::GeneralPlayer;
+use crate::{GeneralPlayer, PlayerCmd};
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 // use std::str::FromStr;
-use std::sync::mpsc::{self, Receiver};
+use std::sync::{
+    mpsc::{self, Receiver},
+    Arc,
+};
 // use std::sync::{mpsc, Arc, Mutex};
 // use std::thread::{self, JoinHandle};
 
@@ -14,8 +19,8 @@ pub struct Mpris {
     controls: MediaControls,
     pub rx: Receiver<MediaControlEvent>,
 }
-impl Default for Mpris {
-    fn default() -> Self {
+impl Mpris {
+    pub fn new(cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
         // #[cfg(not(target_os = "windows"))]
         let hwnd = None;
 
@@ -40,6 +45,9 @@ impl Default for Mpris {
         controls
             .attach(move |event: MediaControlEvent| {
                 tx.send(event).ok();
+                // immediately process any mpris commands, current update is inside PlayerCmd::Tick
+                // TODO: this should likely be refactored
+                cmd_tx.lock().send(PlayerCmd::Tick).ok();
             })
             .ok();
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -118,8 +118,7 @@ impl Playlist {
     /// # Panics
     /// panics when error loading podcasts from db
     pub fn load() -> Result<(usize, Vec<Track>)> {
-        let mut path = get_app_config_path()?;
-        path.push("playlist.log");
+        let path = get_playlist_path()?;
 
         let file = if let Ok(f) = File::open(path.as_path()) {
             f
@@ -189,8 +188,7 @@ impl Playlist {
     /// # Errors
     /// Errors could happen when writing files
     pub fn save(&mut self) -> Result<()> {
-        let mut path = get_app_config_path()?;
-        path.push("playlist.log");
+        let path = get_playlist_path()?;
 
         let file = File::create(path.as_path())?;
         let mut writer = BufWriter::new(file);
@@ -537,4 +535,13 @@ impl Playlist {
     pub fn set_next_track_duration(&mut self, d: Duration) {
         self.next_track_duration = d;
     }
+}
+
+const PLAYLIST_SAVE_FILENAME: &str = "playlist.log";
+
+fn get_playlist_path() -> Result<PathBuf> {
+    let mut path = get_app_config_path()?;
+    path.push(PLAYLIST_SAVE_FILENAME);
+
+    Ok(path)
 }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -109,6 +109,10 @@ impl Playlist {
         self.need_proceed_to_next = false;
     }
 
+    /// Load the playlist from the file
+    ///
+    /// Path in `$config$/playlist.log`
+    ///
     /// # Errors
     /// errors could happen when reading file
     /// # Panics
@@ -178,6 +182,10 @@ impl Playlist {
         Ok(())
     }
 
+    /// Save the current playlist and playing index to the playlist log
+    ///
+    /// Path in `$config$/playlist.log`
+    ///
     /// # Errors
     /// Errors could happen when writing files
     pub fn save(&mut self) -> Result<()> {
@@ -210,6 +218,7 @@ impl Playlist {
         }
         self.current_track_index = self.get_next_track_index();
     }
+
     fn get_next_track_index(&self) -> usize {
         let mut next_track_index = self.current_track_index;
         match self.loop_mode {
@@ -336,6 +345,12 @@ impl Playlist {
         self.status
     }
 
+    /// Cycle through the loop modes and return the new mode
+    ///
+    /// order:
+    /// [Random](Loop::Random) -> [Playlist](Loop::Playlist)
+    /// [Playlist](Loop::Playlist) -> [Single](Loop::Single)
+    /// [Single](Loop::Single) -> [Random](Loop::Random)
     pub fn cycle_loop_mode(&mut self) -> Loop {
         match self.loop_mode {
             Loop::Random => {
@@ -351,7 +366,10 @@ impl Playlist {
         self.loop_mode
     }
 
-    // export to M3U
+    /// Export the current playlist to a `.m3u` playlist file
+    ///
+    /// might be confused with [save](Self::save)
+    ///
     /// # Errors
     /// Error could happen when writing file to local disk.
     pub fn save_m3u(&self, filename: &str) -> Result<()> {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -379,7 +379,9 @@ impl Player {
                             if !is_radio {
                                 if let Some(d) = total_duration {
                                     let progress = position as f64 / d.as_secs_f64();
-                                    if progress >= 0.5 && (d.as_secs() - position as u64) < 2 {
+                                    if progress >= 0.5
+                                        && d.as_secs().saturating_sub(position as u64) < 2
+                                    {
                                         if let Err(e) =
                                             cmd_tx_inside.lock().send(PlayerCmd::AboutToFinish)
                                         {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -122,7 +122,7 @@ impl Player {
                 sink.set_speed(speed_inside as f32 / 10.0);
                 sink.set_volume(<f32 as From<u16>>::from(volume_inside) / 100.0);
                 loop {
-                    if let Ok(cmd) = command_rx.try_recv() {
+                    if let Ok(cmd) = command_rx.recv_timeout(Duration::from_micros(100)) {
                         match cmd {
                             // PlayerInternalCmd::PlayPod(stream, gapless, duration) => {
                             //     let mss = MediaSourceStream::new(

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -111,7 +111,7 @@ impl Player {
         let mut volume_inside = volume;
         let mut speed_inside = speed;
         let mut is_radio = false;
-        std::thread::spawn(move || {
+        std::thread::Builder::new().name("playback player loop".into()).spawn(move || {
             let mut total_duration: Option<Duration> = None;
             let (_stream, handle) = OutputStream::try_default().unwrap();
             let mut sink =
@@ -427,7 +427,7 @@ impl Player {
                 }
                 std::thread::sleep(std::time::Duration::from_millis(20));
             }
-        });
+        }).expect("failed to spawn thread");
 
         this
     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -60,7 +60,7 @@ async fn actual_main() -> Result<()> {
         loop {
             {
                 let mut cmd_rx = cmd_rx.lock();
-                if let Ok(cmd) = cmd_rx.try_recv() {
+                if let Some(cmd) = cmd_rx.blocking_recv() {
                     #[allow(unreachable_patterns)]
                     match cmd {
                         PlayerCmd::AboutToFinish => {
@@ -259,7 +259,6 @@ async fn actual_main() -> Result<()> {
                     }
                 }
             }
-            std::thread::sleep(std::time::Duration::from_millis(10));
         }
     });
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -102,6 +102,10 @@ async fn actual_main() -> Result<()> {
             server_args.push("--log-to-file");
         }
 
+        if args.log_options.file_color_log {
+            server_args.push("--log-filecolor");
+        }
+
         let proc = utils::spawn_process(&termusic_server_prog, false, false, &server_args)
             .unwrap_or_else(|_| panic!("Could not find {} binary", termusic_server_prog.display()));
 


### PR DESCRIPTION
This PR has some many minor (possible unrelated) changes, which i found while trying to do something else, changes include:
- fix possible panic on track end (could not 100% reproduce this, but changing to use `saturated_sub` fixed it)
- pass on argument `--log-filecolor` to the started server (like `--log-to-file`)
- add some doc-comments to better get to know what is for what and what parameters are expected (there are still some TODO's, like `Cmus*Queue`)
- add names to spawned threads to better differentiate if a thread crashes or while using gdb
- refactor `playback::playlist::load` to not use a intermediate vector
- refactor `playback::playlist` to use a common way to get the `playlist.log` file path (reducing chance of changing one place but not others, also DRY)
- block on channel `recv`s if nothing else is done in the loops (reduces cpu usage and should make command be processed immediately)
- fire `PlayerCmd::Tick` when a mpris command is received to immediately process it (otherwise pressing the button / command again will not actually do anything)
- fix a error log message which was copy-paste (`AboutToFinish`)