### PR TITLE
Add a Currently Playing Symbol

### DIFF
--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -129,6 +129,7 @@ pub struct StyleColorSymbol {
     pub lyric_background: ColorTermusic,
     pub lyric_border: ColorTermusic,
     pub alacritty_theme: Alacritty,
+    pub currently_playing_track_symbol: String,
 }
 
 impl Default for StyleColorSymbol {
@@ -151,6 +152,7 @@ impl Default for StyleColorSymbol {
             lyric_background: ColorTermusic::Reset,
             lyric_border: ColorTermusic::Blue,
             alacritty_theme: Alacritty::default(),
+            currently_playing_track_symbol: "►".to_string(),
         }
     }
 }

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -161,6 +161,8 @@ pub enum ConfigEditorMsg {
     PlayerUseDiscordBlurUp,
     PlayerPortBlurDown,
     PlayerPortBlurUp,
+    CurrentlyPlayingTrackSymbolBlurDown,
+    CurrentlyPlayingTrackSymbolBlurUp,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -534,6 +536,7 @@ pub enum IdConfigEditor {
     PlaylistLabel,
     PlaylistRandomAlbum,
     PlaylistRandomTrack,
+    CurrentlyPlayingTrackSymbol,
     PodcastDir,
     PodcastMaxRetries,
     PodcastSimulDownload,

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -499,7 +499,7 @@ impl Playlist {
     }
 
     #[must_use]
-    pub fn get_current_track_index(&mut self) -> usize {
+    pub fn get_current_track_index(&self) -> usize {
         self.current_track_index
     }
 

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -870,6 +870,9 @@ impl ConfigInputHighlight {
             IdConfigEditor::PlaylistHighlightSymbol => {
                 &config.style_color_symbol.playlist_highlight_symbol
             }
+            IdConfigEditor::CurrentlyPlayingTrackSymbol => {
+                &config.style_color_symbol.currently_playing_track_symbol
+            }
             _ => todo!("Unhandled IdConfigEditor Variant: {:#?}", id),
         };
         Self {
@@ -1019,6 +1022,9 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
                 IdConfigEditor::PlaylistHighlightSymbol => Some(Msg::ConfigEditor(
                     ConfigEditorMsg::PlaylistHighlightSymbolBlurDown,
                 )),
+                IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
+                    ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown,
+                )),
                 _ => Some(Msg::None),
             },
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => match self.id {
@@ -1027,6 +1033,9 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
                 )),
                 IdConfigEditor::PlaylistHighlightSymbol => Some(Msg::ConfigEditor(
                     ConfigEditorMsg::PlaylistHighlightSymbolBlurUp,
+                )),
+                IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
+                    ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp,
                 )),
                 _ => Some(Msg::None),
             },
@@ -1083,6 +1092,29 @@ impl ConfigPlaylistHighlightSymbol {
 }
 
 impl Component<Msg, NoUserEvent> for ConfigPlaylistHighlightSymbol {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigCurrentlyPlayingTrackSymbol {
+    component: ConfigInputHighlight,
+}
+
+impl ConfigCurrentlyPlayingTrackSymbol {
+    pub fn new(config: &Settings) -> Self {
+        Self {
+            component: ConfigInputHighlight::new(
+                " Current Track Symbol ",
+                IdConfigEditor::CurrentlyPlayingTrackSymbol,
+                config,
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigCurrentlyPlayingTrackSymbol {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -862,11 +862,15 @@ pub struct ConfigInputHighlight {
 
 impl ConfigInputHighlight {
     pub fn new(name: &str, id: IdConfigEditor, config: &Settings) -> Self {
+        // TODO: this should likely not be here, because it is a runtime error if it is unhandled
         let highlight_str = match id {
             IdConfigEditor::LibraryHighlightSymbol => {
                 &config.style_color_symbol.library_highlight_symbol
             }
-            _ => &config.style_color_symbol.playlist_highlight_symbol,
+            IdConfigEditor::PlaylistHighlightSymbol => {
+                &config.style_color_symbol.playlist_highlight_symbol
+            }
+            _ => todo!("Unhandled IdConfigEditor Variant: {:#?}", id),
         };
         Self {
             component: Input::default()

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -225,12 +225,20 @@ impl Model {
                     .ok();
             }
             ConfigEditorMsg::PlaylistHighlightBlurDown
-            | ConfigEditorMsg::ProgressForegroundBlurUp => {
+            | ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol))
                     .ok();
             }
             ConfigEditorMsg::PlaylistHighlightSymbolBlurDown
+            | ConfigEditorMsg::ProgressForegroundBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(
+                        IdConfigEditor::CurrentlyPlayingTrackSymbol,
+                    ))
+                    .ok();
+            }
+            ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown
             | ConfigEditorMsg::ProgressBackgroundBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::ProgressForeground))
@@ -291,6 +299,10 @@ impl Model {
                     }
                     IdConfigEditor::PlaylistHighlightSymbol => {
                         self.ce_style_color_symbol.playlist_highlight_symbol = symbol.to_string();
+                    }
+                    IdConfigEditor::CurrentlyPlayingTrackSymbol => {
+                        self.ce_style_color_symbol.currently_playing_track_symbol =
+                            symbol.to_string();
                     }
                     _ => {}
                 };

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,17 +1,17 @@
 use crate::ui::components::{
-    AlbumPhotoAlign, CEHeader, CEThemeSelectTable, ConfigDatabaseAddAll, ConfigGlobalConfig,
-    ConfigGlobalDown, ConfigGlobalGotoBottom, ConfigGlobalGotoTop, ConfigGlobalHelp,
-    ConfigGlobalLayoutDatabase, ConfigGlobalLayoutPodcast, ConfigGlobalLayoutTreeview,
-    ConfigGlobalLeft, ConfigGlobalLyricAdjustBackward, ConfigGlobalLyricAdjustForward,
-    ConfigGlobalLyricCycle, ConfigGlobalPlayerNext, ConfigGlobalPlayerPrevious,
-    ConfigGlobalPlayerSeekBackward, ConfigGlobalPlayerSeekForward, ConfigGlobalPlayerSpeedDown,
-    ConfigGlobalPlayerSpeedUp, ConfigGlobalPlayerToggleGapless, ConfigGlobalPlayerTogglePause,
-    ConfigGlobalQuit, ConfigGlobalRight, ConfigGlobalSavePlaylist, ConfigGlobalUp,
-    ConfigGlobalVolumeDown, ConfigGlobalVolumeUp, ConfigGlobalXywhHide, ConfigGlobalXywhMoveDown,
-    ConfigGlobalXywhMoveLeft, ConfigGlobalXywhMoveRight, ConfigGlobalXywhMoveUp,
-    ConfigGlobalXywhZoomIn, ConfigGlobalXywhZoomOut, ConfigLibraryAddRoot, ConfigLibraryBackground,
-    ConfigLibraryBorder, ConfigLibraryDelete, ConfigLibraryForeground, ConfigLibraryHighlight,
-    ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
+    AlbumPhotoAlign, CEHeader, CEThemeSelectTable, ConfigCurrentlyPlayingTrackSymbol,
+    ConfigDatabaseAddAll, ConfigGlobalConfig, ConfigGlobalDown, ConfigGlobalGotoBottom,
+    ConfigGlobalGotoTop, ConfigGlobalHelp, ConfigGlobalLayoutDatabase, ConfigGlobalLayoutPodcast,
+    ConfigGlobalLayoutTreeview, ConfigGlobalLeft, ConfigGlobalLyricAdjustBackward,
+    ConfigGlobalLyricAdjustForward, ConfigGlobalLyricCycle, ConfigGlobalPlayerNext,
+    ConfigGlobalPlayerPrevious, ConfigGlobalPlayerSeekBackward, ConfigGlobalPlayerSeekForward,
+    ConfigGlobalPlayerSpeedDown, ConfigGlobalPlayerSpeedUp, ConfigGlobalPlayerToggleGapless,
+    ConfigGlobalPlayerTogglePause, ConfigGlobalQuit, ConfigGlobalRight, ConfigGlobalSavePlaylist,
+    ConfigGlobalUp, ConfigGlobalVolumeDown, ConfigGlobalVolumeUp, ConfigGlobalXywhHide,
+    ConfigGlobalXywhMoveDown, ConfigGlobalXywhMoveLeft, ConfigGlobalXywhMoveRight,
+    ConfigGlobalXywhMoveUp, ConfigGlobalXywhZoomIn, ConfigGlobalXywhZoomOut, ConfigLibraryAddRoot,
+    ConfigLibraryBackground, ConfigLibraryBorder, ConfigLibraryDelete, ConfigLibraryForeground,
+    ConfigLibraryHighlight, ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
     ConfigLibraryRemoveRoot, ConfigLibrarySearch, ConfigLibrarySearchYoutube,
     ConfigLibrarySwitchRoot, ConfigLibraryTagEditor, ConfigLibraryTitle, ConfigLibraryYank,
     ConfigLyricBackground, ConfigLyricBorder, ConfigLyricForeground, ConfigLyricTitle,
@@ -404,6 +404,7 @@ impl Model {
                             Constraint::Length(select_playlist_border_len),
                             Constraint::Length(select_playlist_highlight_len),
                             Constraint::Length(3),
+                            Constraint::Length(3),
                             Constraint::Min(3),
                         ]
                         .as_ref(),
@@ -511,6 +512,11 @@ impl Model {
                     &Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol),
                     f,
                     chunks_playlist[5],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::CurrentlyPlayingTrackSymbol),
+                    f,
+                    chunks_playlist[6],
                 );
                 self.app.view(
                     &Id::ConfigEditor(IdConfigEditor::ProgressLabel),
@@ -1915,6 +1921,15 @@ impl Model {
             )
             .is_ok());
 
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::CurrentlyPlayingTrackSymbol),
+                Box::new(ConfigCurrentlyPlayingTrackSymbol::new(config)),
+                vec![]
+            )
+            .is_ok());
+
         // Key 1: Global keys
 
         assert!(self
@@ -2625,6 +2640,12 @@ impl Model {
         assert!(self
             .app
             .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol))
+            .is_ok());
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(
+                IdConfigEditor::CurrentlyPlayingTrackSymbol
+            ))
             .is_ok());
 
         // umount keys global

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -833,7 +833,7 @@ impl Model {
 
     // show a popup for playing song
     pub fn update_playing_song(&mut self) {
-        if let Some(track) = self.playlist.current_track().cloned() {
+        if let Some(track) = self.playlist.current_track() {
             if self.layout == TermusicLayout::Podcast {
                 let title = track.title().unwrap_or("Unknown Episode");
                 self.update_show_message_timeout("Current Playing", title, None);

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -841,6 +841,10 @@ impl Model {
             }
             let name = track.name().unwrap_or("Unknown Song");
             self.update_show_message_timeout("Current Playing", name, None);
+
+            // TODO: is there a better way to update only a single / 2 columns (prev/next) instead of re-doing the whole playist; OR a way to decide at draw-time?
+            // sync playlist to update any dynamic parts added to the columns (like current playing symbol)
+            self.playlist_sync();
         }
     }
 


### PR DESCRIPTION
This PR adds a symbol to the currently playing track in the playlist:
![currently_playing_symbol](https://github.com/tramhao/termusic/assets/10911626/20a2da21-e1b7-44e9-a1b8-4e824c2b7b46)

This PR builds on the original commit of 5b2b5cf24d6c6ba9d4ce6e6d5e9ed7e61aef51d8 (part of #154), but enhances it so that it is actually configurable (like the other symbols)

Note: i am personally not happy with:
- the way it gets added and needs a full playlist re-sync to remove it from one title and add it onto another (instead of operating on the table directly)
- the way it looks / where the symbol is placed; it looks like it is part of the track name, but i didnt / dont know how to put it somewhere like the highlight symbol (cursor)

as for the location the config where this field is placed, it is right under `Playlist Highlight Symbol` (in the playlist column), because i didnt know a better place to put it

fixes #150