### PR TITLE
Refactor some channel related types in playback

### DIFF
--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
-use tokio::sync::mpsc::UnboundedSender;
 
 /// This trait allows for easy conversion of a path to a URI
 pub trait PathToURI {
@@ -70,7 +69,7 @@ pub struct GStreamerBackend {
 #[allow(clippy::cast_lossless)]
 impl GStreamerBackend {
     #[allow(clippy::too_many_lines)]
-    pub fn new(config: &Settings, cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
+    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
         gst::init().expect("Couldn't initialize Gstreamer");
         let ctx = glib::MainContext::default();
         let _guard = ctx.acquire();

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -82,12 +82,12 @@ impl GStreamerBackend {
                 if let Ok(msg) = message_rx.try_recv() {
                     match msg {
                         PlayerCmd::Eos => {
-                            if let Err(e) = cmd_tx.lock().send(PlayerCmd::Eos) {
+                            if let Err(e) = cmd_tx.send(PlayerCmd::Eos) {
                                 error!("error in sending eos: {e}");
                             }
                         }
                         PlayerCmd::AboutToFinish => {
-                            if let Err(e) = cmd_tx.lock().send(PlayerCmd::AboutToFinish) {
+                            if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
                                 error!("error in sending eos: {e}");
                             }
                         }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -212,7 +212,6 @@ pub struct GeneralPlayer {
     pub discord: discord::Rpc,
     pub db: DataBase,
     pub db_podcast: DBPod,
-    pub cmd_rx: PlayerCmdReciever,
     pub cmd_tx: PlayerCmdSender,
 }
 
@@ -227,7 +226,6 @@ impl GeneralPlayer {
         backend: BackendSelect,
         config: &Settings,
         cmd_tx: PlayerCmdSender,
-        cmd_rx: PlayerCmdReciever,
     ) -> Result<Self> {
         let backend = Backend::new_select(backend, config, Arc::clone(&cmd_tx));
         let playlist = Playlist::new(config).unwrap_or_default();
@@ -252,7 +250,6 @@ impl GeneralPlayer {
             discord: discord::Rpc::default(),
             db: DataBase::new(config),
             db_podcast,
-            cmd_rx,
             cmd_tx,
             current_track_updated: false,
         })
@@ -268,9 +265,8 @@ impl GeneralPlayer {
     pub fn new(
         config: &Settings,
         cmd_tx: PlayerCmdSender,
-        cmd_rx: PlayerCmdReciever,
     ) -> Result<Self> {
-        Self::new_backend(BackendSelect::Default, config, cmd_tx, cmd_rx)
+        Self::new_backend(BackendSelect::Default, config, cmd_tx)
     }
 
     fn get_player(&self) -> &dyn PlayerTrait {

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -44,7 +44,7 @@ impl Mpris {
                 tx.send(event).ok();
                 // immediately process any mpris commands, current update is inside PlayerCmd::Tick
                 // TODO: this should likely be refactored
-                cmd_tx.lock().send(PlayerCmd::Tick).ok();
+                cmd_tx.send(PlayerCmd::Tick).ok();
             })
             .ok();
 
@@ -147,7 +147,7 @@ impl GeneralPlayer {
                 };
 
                 // ignore error if sending failed
-                self.cmd_tx.lock().send(cmd).ok();
+                self.cmd_tx.send(cmd).ok();
             }
             MediaControlEvent::SetPosition(position) => {
                 self.seek_to(position.0);
@@ -195,7 +195,7 @@ impl GeneralPlayer {
             }
             MediaControlEvent::Quit => {
                 // ignore error if sending failed
-                self.cmd_tx.lock().send(PlayerCmd::Quit).ok();
+                self.cmd_tx.send(PlayerCmd::Quit).ok();
             }
             MediaControlEvent::Stop => {
                 // TODO: handle "Stop"

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -1,7 +1,5 @@
 use base64::Engine;
-use parking_lot::Mutex;
 use termusiclib::track::Track;
-use tokio::sync::mpsc::UnboundedSender;
 // use crate::souvlaki::{
 //     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig,
 // };
@@ -9,10 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{GeneralPlayer, PlayerCmd, PlayerTrait, Status};
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 // use std::str::FromStr;
-use std::sync::{
-    mpsc::{self, Receiver},
-    Arc,
-};
+use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
 // use std::sync::{mpsc, Arc, Mutex};
 // use std::thread::{self, JoinHandle};
@@ -22,7 +17,7 @@ pub struct Mpris {
     pub rx: Receiver<MediaControlEvent>,
 }
 impl Mpris {
-    pub fn new(cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
+    pub fn new(cmd_tx: crate::PlayerCmdSender) -> Self {
         // #[cfg(not(target_os = "windows"))]
         let hwnd = None;
 

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -38,7 +38,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::Track;
-use tokio::sync::mpsc::UnboundedSender;
 
 pub struct MpvBackend {
     // player: Mpv,
@@ -49,7 +48,7 @@ pub struct MpvBackend {
     pub position: Arc<Mutex<i64>>,
     pub duration: Arc<Mutex<i64>>,
     pub media_title: Arc<Mutex<String>>,
-    // cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+    // cmd_tx: crate::PlayerCmdSender,
 }
 
 enum PlayerInternalCmd {
@@ -68,7 +67,7 @@ enum PlayerInternalCmd {
 
 impl MpvBackend {
     #[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
-    pub fn new(config: &Settings, cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
+    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
         let (command_tx, command_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
         let volume = config.player_volume;

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -144,9 +144,7 @@ impl MpvBackend {
                                         let dur = duration_inside.lock();
                                         let progress = time_pos as f64 / *dur as f64;
                                         if progress >= 0.5 && (*dur - time_pos) < 2 {
-                                            if let Err(e) =
-                                                cmd_tx.lock().send(PlayerCmd::AboutToFinish)
-                                            {
+                                            if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
                                                 error!("command AboutToFinish sent failed: {e}");
                                             }
                                         }
@@ -234,7 +232,7 @@ impl MpvBackend {
                                 // message_tx.send(PlayerMsg::Progress(secs, duration)).ok();
                             }
                             PlayerInternalCmd::Eos => {
-                                if let Err(e) = cmd_tx.lock().send(PlayerCmd::Eos) {
+                                if let Err(e) = cmd_tx.send(PlayerCmd::Eos) {
                                     error!("error sending eos: {e}");
                                 }
                             }

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -37,7 +37,6 @@ use symphonia::core::io::{MediaSource, MediaSourceStream, MediaSourceStreamOptio
 use termusic_stream::StreamDownload;
 use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
-use tokio::sync::mpsc::UnboundedSender;
 
 static VOLUME_STEP: u16 = 5;
 
@@ -73,7 +72,7 @@ pub struct RustyBackend {
     pub position: Arc<Mutex<i64>>,
     pub radio_title: Arc<Mutex<String>>,
     pub radio_downloaded: Arc<Mutex<u64>>,
-    // cmd_tx_outside: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+    // cmd_tx_outside: crate::PlayerCmdSender,
 }
 
 #[allow(
@@ -84,7 +83,7 @@ pub struct RustyBackend {
 impl RustyBackend {
     #[allow(clippy::similar_names)]
     #[allow(clippy::too_many_lines)]
-    pub fn new(config: &Settings, cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
+    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
         let (picmd_tx, picmd_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
         let picmd_tx_local = picmd_tx.clone();
@@ -408,7 +407,7 @@ fn append_to_sink_queue(
 )]
 fn player_thread(
     total_duration: ArcTotalDuration,
-    pcmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+    pcmd_tx: crate::PlayerCmdSender,
     picmd_tx: Sender<PlayerInternalCmd>,
     picmd_rx: Receiver<PlayerInternalCmd>,
     radio_title: Arc<Mutex<String>>,

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -604,7 +604,7 @@ fn player_thread(
                     if let Some(d) = *total_duration.lock() {
                         let progress = new_position as f64 / d.as_secs_f64();
                         if progress >= 0.5 && d.as_secs().saturating_sub(new_position as u64) < 2 {
-                            if let Err(e) = pcmd_tx.lock().send(PlayerCmd::AboutToFinish) {
+                            if let Err(e) = pcmd_tx.send(PlayerCmd::AboutToFinish) {
                                 error!("command AboutToFinish sent failed: {e}");
                             }
                         }

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -22,7 +22,7 @@ pub struct Sink {
     detached: bool,
     elapsed: Arc<RwLock<Duration>>,
     message_tx: Sender<PlayerInternalCmd>,
-    cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+    cmd_tx: crate::PlayerCmdSender,
 }
 
 struct Controls {
@@ -40,7 +40,7 @@ impl Sink {
     pub fn try_new(
         stream: &OutputStreamHandle,
         tx: Sender<PlayerInternalCmd>,
-        cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+        cmd_tx: crate::PlayerCmdSender,
     ) -> Result<Self, PlayError> {
         let (sink, queue_rx) = Self::new_idle(tx, cmd_tx);
         stream.play_raw(queue_rx)?;
@@ -50,7 +50,7 @@ impl Sink {
     #[inline]
     pub fn new_idle(
         tx: Sender<PlayerInternalCmd>,
-        cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+        cmd_tx: crate::PlayerCmdSender,
     ) -> (Self, queue::SourcesQueueOutput<f32>) {
         // pub fn new_idle() -> (Sink, queue::SourcesQueueOutput<f32>) {
         // let (queue_tx, queue_rx) = queue::queue(true);

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -288,7 +288,7 @@ impl Sink {
                 .name("rusty message_on_end".into())
                 .spawn(move || {
                     let _drop = sleep_until_end.recv();
-                    if let Err(e) = cmd_tx.lock().send(PlayerCmd::Eos) {
+                    if let Err(e) = cmd_tx.send(PlayerCmd::Eos) {
                         error!("Error in message_on_end: {e}");
                     }
                     if let Err(e) = message_tx.send(PlayerInternalCmd::Eos) {

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -39,7 +39,7 @@ impl MusicPlayerService {
 
 impl MusicPlayerService {
     fn command(&self, cmd: &PlayerCmd) {
-        if let Err(e) = self.cmd_tx.lock().send(cmd.clone()) {
+        if let Err(e) = self.cmd_tx.send(cmd.clone()) {
             error!("error {cmd:?}: {e}");
         }
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -9,18 +9,17 @@ use termusicplayback::player::{
     SpeedDownRequest, SpeedReply, SpeedUpRequest, ToggleGaplessReply, ToggleGaplessRequest,
     TogglePauseRequest, TogglePauseResponse, VolumeDownRequest, VolumeReply, VolumeUpRequest,
 };
-use termusicplayback::PlayerCmd;
-use tokio::sync::mpsc::UnboundedSender;
+use termusicplayback::{PlayerCmd, PlayerCmdSender};
 use tonic::{Request, Response, Status};
 
 #[derive(Debug)]
 pub struct MusicPlayerService {
-    cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
+    cmd_tx: PlayerCmdSender,
     pub progress: Arc<Mutex<GetProgressResponse>>,
 }
 
 impl MusicPlayerService {
-    pub fn new(cmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>) -> Self {
+    pub fn new(cmd_tx: PlayerCmdSender) -> Self {
         let progress = GetProgressResponse {
             position: 0,
             duration: 60,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -71,7 +71,6 @@ async fn actual_main() -> Result<()> {
             args.backend.into(),
             &config,
             cmd_tx.clone(),
-            cmd_rx.clone(),
         )?;
         loop {
             {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -7,8 +7,6 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use clap::Parser;
 use music_player_service::MusicPlayerService;
-use parking_lot::Mutex;
-use std::sync::Arc;
 use termusiclib::config::Settings;
 use termusiclib::track::MediaType;
 use termusicplayback::player::music_player_server::MusicPlayerServer;
@@ -38,8 +36,6 @@ async fn actual_main() -> Result<()> {
     info!("background thread start");
 
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
-    let cmd_tx = Arc::new(Mutex::new(cmd_tx));
-    let cmd_rx = Arc::new(Mutex::new(cmd_rx));
 
     let music_player_service: MusicPlayerService = MusicPlayerService::new(cmd_tx.clone());
     let mut config = get_config(&args)?;
@@ -49,7 +45,6 @@ async fn actual_main() -> Result<()> {
 
     ctrlc::set_handler(move || {
         cmd_tx_ctrlc
-            .lock()
             .send(PlayerCmd::Quit)
             .expect("Could not send signal on channel.");
     })
@@ -67,14 +62,11 @@ async fn actual_main() -> Result<()> {
         TcpIncoming::from_listener(tcp_listener, true, None).map_err(|e| anyhow::anyhow!(e))?;
 
     let player_handle = tokio::task::spawn_blocking(move || -> Result<()> {
-        let mut player = GeneralPlayer::new_backend(
-            args.backend.into(),
-            &config,
-            cmd_tx.clone(),
-        )?;
+        let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx.clone())?;
+        // move "cmd_rx" and change to be mutable
+        let mut cmd_rx = cmd_rx;
         loop {
             {
-                let mut cmd_rx = cmd_rx.lock();
                 if let Some(cmd) = cmd_rx.blocking_recv() {
                     #[allow(unreachable_patterns)]
                     match cmd {


### PR DESCRIPTION
This PR expands on a297816754ab4672752f3d67a484bdc61bf32674 (part of #154), which refactors channels for `PlayerCmd`, which includes:
- making a alias for the type, so it is easily used and referenced across many places
- remove `Arc<Mutex<` around the tokio channels, because they themself are `Send + Sync + Clone` (on both receiver and sender)

This PR will very likely conflict with ~~#196~~ and #197