### PR TITLE
Support some more souvlaki media commands

### DIFF
--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -168,9 +168,23 @@ impl GeneralPlayer {
                 // TODO: handle "Seek"
                 info!("Unimplemented Event: OpenUri");
             }
-            MediaControlEvent::SeekBy(_direction, _duration) => {
-                // TODO: handle "SeekBy"
-                info!("Unimplemented Event: SeekBy");
+            MediaControlEvent::SeekBy(direction, duration) => {
+                let as_secs = duration.as_secs();
+
+                // mpris seeking is in micro-seconds (not milliseconds or seconds)
+                if as_secs == 0 {
+                    warn!("can only seek in seconds, got less than 0 seconds");
+                    return;
+                }
+
+                let offset = match direction {
+                    souvlaki::SeekDirection::Forward => as_secs as i64,
+                    souvlaki::SeekDirection::Backward => -(as_secs as i64),
+                };
+
+                // make use of "PlayerTrait" impl on "GeneralPlayer"
+                // ignore result
+                let _ = self.seek(offset);
             }
             // MediaControlEvent::SetVolume(_volume) => {
             //     // TODO: handle "SetVolume"

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -144,13 +144,15 @@ impl GeneralPlayer {
             MediaControlEvent::Play => {
                 self.play();
             }
-            MediaControlEvent::Seek(_direction) => {
-                // TODO: handle "Seek"
-                info!("Unimplemented Event: Seek");
-                // match direction {
-                //     SeekDirection::Forward => activity.player.seek(5).ok(),
-                //     SeekDirection::Backward => activity.player.seek(-5).ok(),
-                // }
+            // The "Seek" even seems to currently only be used for windows, mpris uses "SeekBy"
+            MediaControlEvent::Seek(direction) => {
+                let cmd = match direction {
+                    souvlaki::SeekDirection::Forward => PlayerCmd::SeekForward,
+                    souvlaki::SeekDirection::Backward => PlayerCmd::SeekBackward,
+                };
+
+                // ignore error if sending failed
+                self.cmd_tx.lock().send(cmd).ok();
             }
             MediaControlEvent::SetPosition(_position) => {
                 // let _position = position. / 1000;

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -154,10 +154,8 @@ impl GeneralPlayer {
                 // ignore error if sending failed
                 self.cmd_tx.lock().send(cmd).ok();
             }
-            MediaControlEvent::SetPosition(_position) => {
-                // let _position = position. / 1000;
-                // TODO: handle "SetPosition"
-                info!("Unimplemented Event: SetPosition");
+            MediaControlEvent::SetPosition(position) => {
+                self.seek_to(position.0);
             }
             MediaControlEvent::OpenUri(_uri) => {
                 // let wait = async {
@@ -169,7 +167,8 @@ impl GeneralPlayer {
                 info!("Unimplemented Event: OpenUri");
             }
             MediaControlEvent::SeekBy(direction, duration) => {
-                let as_secs = duration.as_secs();
+                #[allow(clippy::cast_possible_wrap)]
+                let as_secs = duration.as_secs().min(i64::MAX as u64) as i64;
 
                 // mpris seeking is in micro-seconds (not milliseconds or seconds)
                 if as_secs == 0 {
@@ -178,8 +177,8 @@ impl GeneralPlayer {
                 }
 
                 let offset = match direction {
-                    souvlaki::SeekDirection::Forward => as_secs as i64,
-                    souvlaki::SeekDirection::Backward => -(as_secs as i64),
+                    souvlaki::SeekDirection::Forward => as_secs,
+                    souvlaki::SeekDirection::Backward => -as_secs,
                 };
 
                 // make use of "PlayerTrait" impl on "GeneralPlayer"

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -175,8 +175,8 @@ impl GeneralPlayer {
             //     info!("Unimplemented Event: SetVolume");
             // }
             MediaControlEvent::Quit => {
-                // TODO: handle "Quit"
-                info!("Unimplemented Event: Quit");
+                // ignore error if sending failed
+                self.cmd_tx.lock().send(PlayerCmd::Quit).ok();
             }
             MediaControlEvent::Stop => {
                 // TODO: handle "Stop"

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -84,6 +84,7 @@ async fn actual_main() -> Result<()> {
                             }
                         }
                         PlayerCmd::Quit => {
+                            info!("PlayerCmd::Quit received");
                             player.player_save_last_position();
                             if let Err(e) = player.playlist.save() {
                                 error!("error when saving playlist: {e}");


### PR DESCRIPTION
This PR adds some more commands to be supported from `souvlaki`(`mpris.rs`):
- `Seek(direction)`: seek a undetermined amount in a direction (only used in windows, according to source-code), making use of the `seek_relative` function (amount specified by config)
- `SeekBy(direction, duration)`: seek a specified amount in a direction (used by [mpris `Seek`](https://specifications.freedesktop.org/mpris-spec/2.2/Player_Interface.html#Method:Seek), in microseconds)
- `Quit`: quit the player
- `SetPosition(duration)`: seek to a specific point in the track

This PR also adds a log message on `PlayerCmd::Quit` to indicate why the server exited