### PR TITLE
Rusty decoder buffered files

### DIFF
--- a/playback/src/rusty_backend/decoder/buffered_source.rs
+++ b/playback/src/rusty_backend/decoder/buffered_source.rs
@@ -21,7 +21,8 @@ pub struct BufferedSource {
 }
 
 impl BufferedSource {
-    pub fn new(file: File) -> Self {
+    /// Create a new Buffered-Source with a given custom size
+    pub fn new(file: File, size: usize) -> Self {
         let mut is_seekable = false;
         let mut byte_len = None;
 
@@ -33,13 +34,18 @@ impl BufferedSource {
             byte_len = Some(metadata.len());
         }
 
-        let inner = BufReader::with_capacity(BUF_SIZE, file);
+        let inner = BufReader::with_capacity(size, file);
 
         BufferedSource {
             inner,
             is_seekable,
             byte_len,
         }
+    }
+
+    /// Create a new Buffered-Source with default [`BUF_SIZE`]
+    pub fn new_default_size(file: File) -> Self {
+        Self::new(file, BUF_SIZE)
     }
 }
 

--- a/playback/src/rusty_backend/decoder/buffered_source.rs
+++ b/playback/src/rusty_backend/decoder/buffered_source.rs
@@ -1,0 +1,86 @@
+use std::fs::File;
+use std::io::{BufReader, Read, Result, Seek, SeekFrom};
+
+use symphonia::core::io::MediaSource;
+
+/// Buffer capacity in bytes
+///
+/// 1024 * 1024 * 4 = 4 MiB
+///
+/// [`BufReader`] default size is 8 Kib
+const BUF_SIZE: usize = 1024 * 1024 * 4;
+
+/// A [`MediaSource`] for [`File`] but using a [`BufReader`] (Buffered file source)
+pub struct BufferedSource {
+    /// The inner reader
+    inner: BufReader<File>,
+    /// Cache the [`MediaSource::is_seekable`] call
+    is_seekable: bool,
+    /// Cache the [`MediaSource::byte_len`] call
+    byte_len: Option<u64>,
+}
+
+impl BufferedSource {
+    pub fn new(file: File) -> Self {
+        let mut is_seekable = false;
+        let mut byte_len = None;
+
+        if let Ok(metadata) = file.metadata() {
+            // If the file's metadata is available, and the file is a regular file (i.e., not a FIFO,
+            // etc.), then the MediaSource will be seekable. Otherwise assume it is not. Note that
+            // metadata() follows symlinks.
+            is_seekable = metadata.is_file();
+            byte_len = Some(metadata.len());
+        }
+
+        let inner = BufReader::with_capacity(BUF_SIZE, file);
+
+        BufferedSource {
+            inner,
+            is_seekable,
+            byte_len,
+        }
+    }
+}
+
+impl MediaSource for BufferedSource {
+    fn is_seekable(&self) -> bool {
+        self.is_seekable
+    }
+
+    fn byte_len(&self) -> Option<u64> {
+        self.byte_len
+    }
+}
+
+impl Read for BufferedSource {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl Seek for BufferedSource {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        // normal seek always flushes the buffer
+        // use relative seek for common cases
+        if let SeekFrom::Current(v) = pos {
+            self.inner.seek_relative(v)?;
+            return self.inner.stream_position();
+        }
+        if let SeekFrom::Start(v) = pos {
+            let old_pos = self.inner.stream_position()?;
+            if v >= old_pos {
+                // seek forward
+                self.inner.seek_relative((v - old_pos) as i64)?;
+            } else {
+                // seek backward
+                self.inner.seek_relative(-((old_pos - v) as i64))?;
+            }
+
+            return self.inner.stream_position();
+        }
+
+        // fallback
+        self.inner.seek(pos)
+    }
+}

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -1,3 +1,5 @@
+pub mod buffered_source;
+
 use super::Source;
 use std::{fmt, time::Duration};
 use symphonia::{

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -20,6 +20,8 @@ pub use sink::Sink;
 pub use source::Source;
 pub use stream::OutputStream;
 
+use self::decoder::buffered_source::BufferedSource;
+
 use super::PlayerCmd;
 use super::PlayerTrait;
 use anyhow::Result;
@@ -459,7 +461,7 @@ fn player_thread(
                     if let Some(file_path) = track.file() {
                         match File::open(Path::new(file_path)) {
                             Ok(file) => append_to_sink(
-                                Box::new(file),
+                                Box::new(BufferedSource::new(file)),
                                 file_path,
                                 &sink,
                                 gapless,
@@ -545,7 +547,7 @@ fn player_thread(
                 match File::open(Path::new(&url)) {
                     Ok(file) => {
                         append_to_sink_queue(
-                            Box::new(file),
+                            Box::new(BufferedSource::new(file)),
                             &url,
                             &sink,
                             gapless,

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -461,7 +461,7 @@ fn player_thread(
                     if let Some(file_path) = track.file() {
                         match File::open(Path::new(file_path)) {
                             Ok(file) => append_to_sink(
-                                Box::new(BufferedSource::new(file)),
+                                Box::new(BufferedSource::new_default_size(file)),
                                 file_path,
                                 &sink,
                                 gapless,
@@ -547,7 +547,7 @@ fn player_thread(
                 match File::open(Path::new(&url)) {
                     Ok(file) => {
                         append_to_sink_queue(
-                            Box::new(BufferedSource::new(file)),
+                            Box::new(BufferedSource::new_default_size(file)),
                             &url,
                             &sink,
                             gapless,


### PR DESCRIPTION
~~This PR is based on #205, do not merge this current PR first~~

This PR buffers all source files using a 4MiB `BufReader`, which is lower if the file-size is lower (to not waste memory); also in the future the capacity could be configurable.

re #191

also see https://github.com/pdeljanov/Symphonia/discussions/260

~~WIP: because of the based-on PR and because i wanted a reply first from https://github.com/pdeljanov/Symphonia/discussions/260~~