### PR TITLE
Refactor rusty_backend queue duration

### DIFF
--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -41,6 +41,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 static VOLUME_STEP: u16 = 5;
 
+pub type TotalDuration = Duration;
+pub type ArcTotalDuration = Arc<Mutex<TotalDuration>>;
+
 // #[allow(clippy::module_name_repetitions)]
 #[allow(unused)]
 #[derive(Clone, Debug)]
@@ -61,7 +64,7 @@ pub enum PlayerInternalCmd {
     Volume(i64),
 }
 pub struct RustyBackend {
-    pub total_duration: Arc<Mutex<Duration>>,
+    pub total_duration: ArcTotalDuration,
     volume: u16,
     speed: i32,
     pub gapless: bool,
@@ -351,7 +354,7 @@ fn append_to_sink(
     sink: &Sink,
     gapless: bool,
     total_duration: &mut Option<Duration>,
-    total_duration_local: &Arc<Mutex<Duration>>,
+    total_duration_local: &ArcTotalDuration,
 ) {
     append_to_sink_inner(media_source, trace, sink, gapless, |decoder| {
         std::mem::swap(total_duration, &mut decoder.total_duration());
@@ -381,7 +384,7 @@ fn append_to_sink_no_duration(
     clippy::too_many_arguments
 )]
 fn player_thread(
-    total_duration: Arc<Mutex<Duration>>,
+    total_duration: ArcTotalDuration,
     pcmd_tx: Arc<Mutex<UnboundedSender<PlayerCmd>>>,
     picmd_tx: Sender<PlayerInternalCmd>,
     picmd_rx: Receiver<PlayerInternalCmd>,

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -283,11 +283,15 @@ impl Sink {
     pub fn message_on_end(&self) {
         if let Some(sleep_until_end) = self.sleep_until_end.lock().take() {
             let cmd_tx = self.cmd_tx.clone();
+            let message_tx = self.message_tx.clone();
             std::thread::Builder::new()
                 .name("rusty message_on_end".into())
                 .spawn(move || {
                     let _drop = sleep_until_end.recv();
                     if let Err(e) = cmd_tx.lock().send(PlayerCmd::Eos) {
+                        error!("Error in message_on_end: {e}");
+                    }
+                    if let Err(e) = message_tx.send(PlayerInternalCmd::Eos) {
                         error!("Error in message_on_end: {e}");
                     }
                 })


### PR DESCRIPTION
This PR fixes the issue(s) added by #196 and #197, while also cleaning up some of the total_duration duplication, in more detail:
- move to use `type` for total_duration(s) instead of having to write it out every time
- refactor to not have duplicate `total_duration` (once arc-mutex and once as a thread local)
- add a new player-internal command `Eos` (same as `PlayerCmd::Eos`)
- store enqueued duration as a thread variable, and set it as current_duration on EOS

Notes on the current implementation: the current QueueNext implementation on storing durations only works for 1 enqueued after the currently playing and will break if there should be more enqueued into the sink.

also i dont quite like how it is stored as such a variable instead of being stored / gotten from the media-stream / source, but it is better than before #196.

fixes #207