### PR TITLE
Gst updates

### DIFF
--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -374,7 +374,15 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn is_paused(&self) -> bool {
-        self.playbin.current_state() == gst::State::Paused
+        match self.playbin.current_state() {
+            gst::State::Playing => false,
+            gst::State::Paused => true,
+            state => {
+                debug!("Bad GStreamer state {:#?}", state);
+                // fallback to saying it is paused, even in other states
+                true
+            }
+        }
     }
 
     #[allow(clippy::cast_sign_loss)]

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -362,14 +362,12 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn pause(&mut self) {
-        // self.player.pause();
         self.playbin
             .set_state(gst::State::Paused)
             .expect("set gst state paused error");
     }
 
     fn resume(&mut self) {
-        // self.player.play();
         self.playbin
             .set_state(gst::State::Playing)
             .expect("set gst state playing error in resume");

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -61,7 +61,6 @@ pub struct GStreamerBackend {
     pub gapless: bool,
     pub message_tx: Sender<PlayerCmd>,
     pub position: Arc<Mutex<i64>>,
-    pub duration: Arc<Mutex<i64>>,
     pub radio_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }
@@ -121,8 +120,6 @@ impl GStreamerBackend {
             .build()
             .unwrap();
         playbin.set_property_from_value("flags", &flags);
-
-        let duration = Arc::new(Mutex::new(0_i64));
 
         // Asynchronous channel to communicate with main() with
         // let (main_tx, main_rx) = MainContext::channel(glib::Priority::default());
@@ -234,7 +231,6 @@ impl GStreamerBackend {
             gapless,
             message_tx,
             position: Arc::new(Mutex::new(0_i64)),
-            duration,
             radio_title,
             _bus_watch_guard: bus_watch,
         };
@@ -472,7 +468,6 @@ impl PlayerTrait for GStreamerBackend {
         let time_pos = self.get_position().seconds() as i64;
         let duration = self.get_duration().seconds() as i64;
         *self.position.lock() = time_pos;
-        *self.duration.lock() = duration;
         Ok((time_pos, duration))
     }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -356,7 +356,7 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn set_volume(&mut self, mut volume: i32) {
-        volume = volume.clamp(0, 100);
+        volume = volume.max(0);
         self.volume = volume;
         self.set_volume_inside(f64::from(volume) / 100.0);
     }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -260,14 +260,6 @@ impl GStreamerBackend {
             None
         });
 
-        // glib::source::timeout_add(
-        //     std::time::Duration::from_millis(1000),
-        //     glib::clone!(@strong this => move || {
-        //         this.get_progress().ok();
-        //     glib::ControlFlow::Continue
-        //     }),
-        // );
-
         this
     }
     pub fn skip_one(&mut self) {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -170,6 +170,9 @@ impl GStreamerBackend {
                         // let msg = buffering.message();
                         // info!("message is: {msg:?}");
                     }
+                    gst::MessageView::Warning(warning) => {
+                        info!("GStreamer Warning: {}", warning.error());
+                    }
                     // gst::MessageView::DurationChanged(dur) => {
                     // }
                     // Left for debug

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -242,21 +242,10 @@ impl GStreamerBackend {
         this.set_volume(volume);
         this.set_speed(speed);
 
-        // Switch to next song when reaching end of current track
-        // let tx = main_tx;
-        // this.playbin.connect(
-        //     "about-to-finish",
-        //     false,
-        //     glib::clone!(@strong this => move |_args| {
-        //        tx.send(PlayerMsg::AboutToFinish).unwrap();
-        //        None
-        //     }),
-        // );
-
+        // Send a signal to enqueue the next media before the current finished
         this.playbin.connect("about-to-finish", false, move |_| {
-            info!("about to finish generated!");
+            debug!("Sending playbin AboutToFinish");
             main_tx.send_blocking(PlayerCmd::AboutToFinish).unwrap();
-            info!("about to finish sent by playbin!");
             None
         });
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -141,7 +141,7 @@ impl GStreamerBackend {
                         .expect("Unable to send message to main()"),
                     gst::MessageView::StreamStart(_) => {}
                     gst::MessageView::Error(e) =>
-                        glib::g_debug!("song", "{}", e.error()),
+                        error!("GStreamer Error: {}", e.error()),
                     gst::MessageView::Tag(tag) => {
                         if let Some(title) = tag.tags().get::<gst::tags::Title>() {
                             info!("  Title: {}", title.get());

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -55,7 +55,6 @@ impl PathToURI for Path {
 
 pub struct GStreamerBackend {
     playbin: Element,
-    paused: bool,
     volume: i32,
     speed: i32,
     pub gapless: bool,
@@ -213,7 +212,6 @@ impl GStreamerBackend {
 
         let mut this = Self {
             playbin,
-            paused: false,
             volume,
             speed,
             gapless,
@@ -364,7 +362,6 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn pause(&mut self) {
-        self.paused = true;
         // self.player.pause();
         self.playbin
             .set_state(gst::State::Paused)
@@ -372,7 +369,6 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn resume(&mut self) {
-        self.paused = false;
         // self.player.play();
         self.playbin
             .set_state(gst::State::Playing)

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -122,9 +122,8 @@ impl GStreamerBackend {
         playbin.set_property_from_value("flags", &flags);
 
         // Asynchronous channel to communicate with main() with
-        // let (main_tx, main_rx) = MainContext::channel(glib::Priority::default());
         let (main_tx, main_rx) = async_channel::bounded(3);
-        // Handle messages from GSTreamer bus
+        // Handle messages from GStreamer bus
 
         let radio_title = Arc::new(Mutex::new(String::new()));
         let radio_title_internal = radio_title.clone();
@@ -157,7 +156,6 @@ impl GStreamerBackend {
                         // let (mode,_, _, left) = buffering.buffering_stats();
                         // info!("mode is: {mode:?}, and left is: {left}");
                         let percent = buffering.percent();
-                        // info!("Buffering ({}%)\r", percent);
                         if percent < 100 {
                             let _ = main_tx.send_blocking(PlayerCmd::Pause);
                         } else {
@@ -170,8 +168,6 @@ impl GStreamerBackend {
                     gst::MessageView::Warning(warning) => {
                         info!("GStreamer Warning: {}", warning.error());
                     }
-                    // gst::MessageView::DurationChanged(dur) => {
-                    // }
                     // Left for debug
                     // msg => {
                     //     info!("msg: {msg:?}");
@@ -210,14 +206,6 @@ impl GStreamerBackend {
                 // self_.do_action(action);
             }
         });
-
-        // glib::spawn_future(glib::clone!(@strong mainloop => async move{
-        //     while let Ok(msg) = main_rx.recv().await {
-        //         info!("{:?} received!!",msg);
-        //         tx.send(msg).ok();
-        //         // glib::ControlFlow::Continue;
-        //     }
-        // }));
 
         let volume = config.player_volume;
         let speed = config.player_speed;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -345,13 +345,6 @@ impl GeneralPlayer {
         self.playlist.set_next_track(Some(&track));
         if let Some(file) = track.file() {
             self.get_player_mut().enqueue_next(file);
-            #[cfg(all(feature = "gst", not(feature = "mpv")))]
-            #[allow(irrefutable_let_patterns)]
-            if let Backend::GStreamer(_) = self.backend {
-                // why exactly is this done for gst but not other backends?
-                self.playlist.set_next_track(None);
-                // self.playlist.handle_current_track();
-            }
 
             info!("Next track enqueued: {:#?}", file);
         }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -346,7 +346,8 @@ impl GeneralPlayer {
         if let Some(file) = track.file() {
             self.get_player_mut().enqueue_next(file);
             #[cfg(all(feature = "gst", not(feature = "mpv")))]
-            {
+            #[allow(irrefutable_let_patterns)]
+            if let Backend::GStreamer(_) = self.backend {
                 // why exactly is this done for gst but not other backends?
                 self.playlist.set_next_track(None);
                 // self.playlist.handle_current_track();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -65,6 +65,7 @@ async fn actual_main() -> Result<()> {
         let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx.clone())?;
         // move "cmd_rx" and change to be mutable
         let mut cmd_rx = cmd_rx;
+        // TODO: refactor this to be a while let Some loop
         loop {
             {
                 if let Some(cmd) = cmd_rx.blocking_recv() {


### PR DESCRIPTION
This PR does a variety of thing to the `gst_backend`, most notably: fixing #192 and applying https://github.com/tramhao/termusic/commit/f4ed6659baaad449ad1b40c58760db65dbcb2d21#commitcomment-138909846, in more detail:

- apply https://github.com/tramhao/termusic/commit/f4ed6659baaad449ad1b40c58760db65dbcb2d21#commitcomment-138909846 so that gst events actually get send again
- replace glib warnings / errors with rust log ones
- remove only written-to (and otherwise unused) property `duration`
- remove only written-to (and otherwise unused) property `paused`
- clean-up some commented-out code
- allow volume above 100 (because gst allows it) (currently gets clamped somewhere else on set, but reads higher values from config just fine)
- change `is_paused` to check against specific states and log unusual states
- have EOS events in "gapless" mode (thereby fixing #192)

current downside to the implementation of the fix for #192 is that if you hold down `n`(skip one), then the key-repeats will get buffered (unlike in rusty; via unbounded channel) and gst-backend may decide to just stop playing anything (no crash, no further investigation for now); note that this buffering behavior also exists without this pr