### PR TITLE
Server main file refactor & fixes

### DIFF
--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -228,11 +228,6 @@ impl GeneralPlayer {
         let backend = Backend::new_select(backend, config, cmd_tx.clone());
         let playlist = Playlist::new(config).unwrap_or_default();
 
-        let cmd_tx_tick = cmd_tx.clone();
-        std::thread::spawn(move || loop {
-            cmd_tx_tick.send(PlayerCmd::Tick).ok();
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        });
         let db_path = get_app_config_path().with_context(|| "failed to get podcast db path.")?;
 
         let db_podcast =

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -158,7 +158,7 @@ impl GeneralPlayer {
                 // };
                 // let rt = tokio::runtime::Runtime::new().expect("failed to create runtime");
                 // rt.block_on(wait);
-                // TODO: handle "Seek"
+                // TODO: handle "OpenUri"
                 info!("Unimplemented Event: OpenUri");
             }
             MediaControlEvent::SeekBy(direction, duration) => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -270,7 +270,9 @@ async fn actual_main() -> Result<()> {
         .serve_with_incoming(tcp_stream)
         .await?;
 
-    let _drop = player_handle.await?;
+    // if the underlying task/thread panicked, the error will be "task X panicked" instead of the actual panic (with no workaround?)
+    // see the log or stderr for actual panic
+    player_handle.await??;
 
     Ok(())
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -250,7 +250,7 @@ async fn actual_main() -> Result<()> {
                     info!("after volumeup: {}", player.volume());
                     let mut p_tick = progress_tick.lock();
                     p_tick.volume = config.player_volume;
-                } // _ => {}
+                }
                 PlayerCmd::Pause => {
                     player.pause();
                 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -263,7 +263,7 @@ async fn actual_main() -> Result<()> {
         Ok(())
     });
 
-    ticker_thread(cmd_tx_ticker);
+    ticker_thread(cmd_tx_ticker)?;
 
     tokio::spawn(
         Server::builder()
@@ -279,12 +279,16 @@ async fn actual_main() -> Result<()> {
 }
 
 /// Spawn the thread that periodically sends [`PlayerCmd::Tick`]
-fn ticker_thread(cmd_tx: PlayerCmdSender) {
-    std::thread::spawn(move || {
-        while cmd_tx.send(PlayerCmd::Tick).is_ok() {
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    });
+fn ticker_thread(cmd_tx: PlayerCmdSender) -> Result<()> {
+    std::thread::Builder::new()
+        .name("ticker".into())
+        .spawn(move || {
+            while cmd_tx.send(PlayerCmd::Tick).is_ok() {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
+        })?;
+
+    Ok(())
 }
 
 fn get_config(args: &cli::Args) -> Result<Settings> {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -68,37 +68,113 @@ async fn actual_main() -> Result<()> {
         let mut cmd_rx = cmd_rx;
         // TODO: refactor this to be a while let Some loop
         loop {
-            {
-                if let Some(cmd) = cmd_rx.blocking_recv() {
-                    #[allow(unreachable_patterns)]
-                    match cmd {
-                        PlayerCmd::AboutToFinish => {
-                            info!("about to finish signal received");
-                            if !player.playlist.is_empty()
-                                && !player.playlist.has_next_track()
-                                && player.config.player_gapless
-                            {
-                                player.enqueue_next_from_playlist();
-                            }
+            if let Some(cmd) = cmd_rx.blocking_recv() {
+                #[allow(unreachable_patterns)]
+                match cmd {
+                    PlayerCmd::AboutToFinish => {
+                        info!("about to finish signal received");
+                        if !player.playlist.is_empty()
+                            && !player.playlist.has_next_track()
+                            && player.config.player_gapless
+                        {
+                            player.enqueue_next_from_playlist();
                         }
-                        PlayerCmd::Quit => {
-                            info!("PlayerCmd::Quit received");
-                            player.player_save_last_position();
-                            if let Err(e) = player.playlist.save() {
-                                error!("error when saving playlist: {e}");
-                            };
-                            if let Err(e) = config.save() {
-                                error!("error when saving config: {e}");
-                            };
-                            std::process::exit(0);
+                    }
+                    PlayerCmd::Quit => {
+                        info!("PlayerCmd::Quit received");
+                        player.player_save_last_position();
+                        if let Err(e) = player.playlist.save() {
+                            error!("error when saving playlist: {e}");
+                        };
+                        if let Err(e) = config.save() {
+                            error!("error when saving config: {e}");
+                        };
+                        std::process::exit(0);
+                    }
+                    PlayerCmd::CycleLoop => {
+                        config.player_loop_mode = player.playlist.cycle_loop_mode();
+                    }
+                    PlayerCmd::Eos => {
+                        info!("Eos received");
+                        if player.playlist.is_empty() {
+                            player.stop();
+                            continue;
                         }
-                        PlayerCmd::CycleLoop => {
-                            config.player_loop_mode = player.playlist.cycle_loop_mode();
+                        debug!(
+                            "current track index: {:?}",
+                            player.playlist.get_current_track_index()
+                        );
+                        player.playlist.clear_current_track();
+                        player.start_play();
+                        debug!(
+                            "playing index is: {}",
+                            player.playlist.get_current_track_index()
+                        );
+                    }
+                    PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
+                    PlayerCmd::PlaySelected => {
+                        info!("play selected");
+                        player.player_save_last_position();
+                        player.playlist.proceed_false();
+                        player.next();
+                    }
+                    PlayerCmd::SkipPrevious => {
+                        info!("skip to previous track");
+                        player.player_save_last_position();
+                        player.previous();
+                    }
+                    PlayerCmd::ReloadConfig => {
+                        config.load()?;
+                        info!("config reloaded");
+                        player.config = config.clone();
+                    }
+                    PlayerCmd::ReloadPlaylist => {
+                        player.playlist.reload_tracks().ok();
+                    }
+                    PlayerCmd::SeekBackward => {
+                        player.seek_relative(false);
+                        let mut p_tick = progress_tick.lock();
+                        if let Ok((position, _duration)) = player.get_progress() {
+                            p_tick.position = position as u32;
                         }
-                        PlayerCmd::Eos => {
-                            info!("Eos received");
+                    }
+                    PlayerCmd::SeekForward => {
+                        player.seek_relative(true);
+                        let mut p_tick = progress_tick.lock();
+                        if let Ok((position, _duration)) = player.get_progress() {
+                            p_tick.position = position as u32;
+                        }
+                    }
+                    PlayerCmd::SkipNext => {
+                        info!("skip to next track.");
+                        player.player_save_last_position();
+                        player.next();
+                    }
+                    PlayerCmd::SpeedDown => {
+                        player.speed_down();
+                        info!("after speed down: {}", player.speed());
+                        config.player_speed = player.speed();
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.speed = config.player_speed;
+                    }
+
+                    PlayerCmd::SpeedUp => {
+                        player.speed_up();
+                        info!("after speed up: {}", player.speed());
+                        config.player_speed = player.speed();
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.speed = config.player_speed;
+                    }
+                    PlayerCmd::Tick => {
+                        // info!("tick received");
+                        if config.player_use_mpris {
+                            player.update_mpris();
+                        }
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.status = player.playlist.status().as_u32();
+                        // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
+                        if player.playlist.status() == Status::Stopped {
                             if player.playlist.is_empty() {
-                                player.stop();
                                 continue;
                             }
                             debug!(
@@ -106,164 +182,83 @@ async fn actual_main() -> Result<()> {
                                 player.playlist.get_current_track_index()
                             );
                             player.playlist.clear_current_track();
-                            player.start_play();
-                            debug!(
-                                "playing index is: {}",
-                                player.playlist.get_current_track_index()
-                            );
-                        }
-                        PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
-                        PlayerCmd::PlaySelected => {
-                            info!("play selected");
-                            player.player_save_last_position();
                             player.playlist.proceed_false();
-                            player.next();
+                            player.start_play();
+                            continue;
                         }
-                        PlayerCmd::SkipPrevious => {
-                            info!("skip to previous track");
-                            player.player_save_last_position();
-                            player.previous();
-                        }
-                        PlayerCmd::ReloadConfig => {
-                            config.load()?;
-                            info!("config reloaded");
-                            player.config = config.clone();
-                        }
-                        PlayerCmd::ReloadPlaylist => {
-                            player.playlist.reload_tracks().ok();
-                        }
-                        PlayerCmd::SeekBackward => {
-                            player.seek_relative(false);
-                            let mut p_tick = progress_tick.lock();
-                            if let Ok((position, _duration)) = player.get_progress() {
-                                p_tick.position = position as u32;
+                        if let Ok((position, duration)) = player.get_progress() {
+                            p_tick.position = position as u32;
+                            p_tick.duration = duration as u32;
+                            if player.current_track_updated {
+                                p_tick.current_track_index =
+                                    player.playlist.get_current_track_index() as u32;
+                                p_tick.current_track_updated = player.current_track_updated;
+                                player.current_track_updated = false;
                             }
-                        }
-                        PlayerCmd::SeekForward => {
-                            player.seek_relative(true);
-                            let mut p_tick = progress_tick.lock();
-                            if let Ok((position, _duration)) = player.get_progress() {
-                                p_tick.position = position as u32;
-                            }
-                        }
-                        PlayerCmd::SkipNext => {
-                            info!("skip to next track.");
-                            player.player_save_last_position();
-                            player.next();
-                        }
-                        PlayerCmd::SpeedDown => {
-                            player.speed_down();
-                            info!("after speed down: {}", player.speed());
-                            config.player_speed = player.speed();
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.speed = config.player_speed;
-                        }
-
-                        PlayerCmd::SpeedUp => {
-                            player.speed_up();
-                            info!("after speed up: {}", player.speed());
-                            config.player_speed = player.speed();
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.speed = config.player_speed;
-                        }
-                        PlayerCmd::Tick => {
-                            // info!("tick received");
-                            if config.player_use_mpris {
-                                player.update_mpris();
-                            }
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.status = player.playlist.status().as_u32();
-                            // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
-                            if player.playlist.status() == Status::Stopped {
-                                if player.playlist.is_empty() {
-                                    continue;
-                                }
-                                debug!(
-                                    "current track index: {:?}",
-                                    player.playlist.get_current_track_index()
-                                );
-                                player.playlist.clear_current_track();
-                                player.playlist.proceed_false();
-                                player.start_play();
-                                continue;
-                            }
-                            if let Ok((position, duration)) = player.get_progress() {
-                                p_tick.position = position as u32;
-                                p_tick.duration = duration as u32;
-                                if player.current_track_updated {
-                                    p_tick.current_track_index =
-                                        player.playlist.get_current_track_index() as u32;
-                                    p_tick.current_track_updated = player.current_track_updated;
-                                    player.current_track_updated = false;
-                                }
-                                if let Some(track) = player.playlist.current_track() {
-                                    if let Some(MediaType::LiveRadio) = &track.media_type {
-                                        // TODO: consider changing "radio_title" and "media_title" to be consistent
-                                        match player.backend {
-                                            #[cfg(feature = "mpv")]
-                                            Backend::Mpv(ref mut backend) => {
-                                                p_tick.radio_title =
-                                                    backend.media_title.lock().clone();
-                                            }
-                                            #[cfg(feature = "rusty")]
-                                            Backend::Rusty(ref mut backend) => {
-                                                p_tick.radio_title =
-                                                    backend.radio_title.lock().clone();
-                                                p_tick.duration = ((*backend.radio_downloaded.lock()
-                                                    as f32
-                                                    * 44100.0
-                                                    / 1000000.0
-                                                    / 1024.0)
-                                                    * (backend.speed() as f32 / 10.0))
-                                                    as u32;
-                                            }
-                                            #[cfg(feature = "gst")]
-                                            Backend::GStreamer(ref mut backend) => {
-                                                // p_tick.duration = player.backend.get_buffer_duration();
-                                                // error!("buffer duration: {}", p_tick.duration);
-                                                p_tick.duration = position as u32 + 20;
-                                                p_tick.radio_title =
-                                                    backend.radio_title.lock().clone();
-                                                // error!("radio title: {}", p_tick.radio_title);
-                                            }
+                            if let Some(track) = player.playlist.current_track() {
+                                if let Some(MediaType::LiveRadio) = &track.media_type {
+                                    // TODO: consider changing "radio_title" and "media_title" to be consistent
+                                    match player.backend {
+                                        #[cfg(feature = "mpv")]
+                                        Backend::Mpv(ref mut backend) => {
+                                            p_tick.radio_title = backend.media_title.lock().clone();
+                                        }
+                                        #[cfg(feature = "rusty")]
+                                        Backend::Rusty(ref mut backend) => {
+                                            p_tick.radio_title = backend.radio_title.lock().clone();
+                                            p_tick.duration = ((*backend.radio_downloaded.lock()
+                                                as f32
+                                                * 44100.0
+                                                / 1000000.0
+                                                / 1024.0)
+                                                * (backend.speed() as f32 / 10.0))
+                                                as u32;
+                                        }
+                                        #[cfg(feature = "gst")]
+                                        Backend::GStreamer(ref mut backend) => {
+                                            // p_tick.duration = player.backend.get_buffer_duration();
+                                            // error!("buffer duration: {}", p_tick.duration);
+                                            p_tick.duration = position as u32 + 20;
+                                            p_tick.radio_title = backend.radio_title.lock().clone();
+                                            // error!("radio title: {}", p_tick.radio_title);
                                         }
                                     }
                                 }
                             }
                         }
-                        PlayerCmd::ToggleGapless => {
-                            config.player_gapless = player.toggle_gapless();
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.gapless = config.player_gapless;
-                        }
-                        PlayerCmd::TogglePause => {
-                            info!("player toggled pause");
-                            player.toggle_pause();
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.status = player.playlist.status().as_u32();
-                        }
-                        PlayerCmd::VolumeDown => {
-                            info!("before volumedown: {}", player.volume());
-                            player.volume_down();
-                            config.player_volume = player.volume();
-                            info!("after volumedown: {}", player.volume());
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.volume = config.player_volume;
-                        }
-                        PlayerCmd::VolumeUp => {
-                            info!("before volumeup: {}", player.volume());
-                            player.volume_up();
-                            config.player_volume = player.volume();
-                            info!("after volumeup: {}", player.volume());
-                            let mut p_tick = progress_tick.lock();
-                            p_tick.volume = config.player_volume;
-                        } // _ => {}
-                        PlayerCmd::Pause => {
-                            player.pause();
-                        }
-                        PlayerCmd::Play => {
-                            player.resume();
-                        }
+                    }
+                    PlayerCmd::ToggleGapless => {
+                        config.player_gapless = player.toggle_gapless();
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.gapless = config.player_gapless;
+                    }
+                    PlayerCmd::TogglePause => {
+                        info!("player toggled pause");
+                        player.toggle_pause();
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.status = player.playlist.status().as_u32();
+                    }
+                    PlayerCmd::VolumeDown => {
+                        info!("before volumedown: {}", player.volume());
+                        player.volume_down();
+                        config.player_volume = player.volume();
+                        info!("after volumedown: {}", player.volume());
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.volume = config.player_volume;
+                    }
+                    PlayerCmd::VolumeUp => {
+                        info!("before volumeup: {}", player.volume());
+                        player.volume_up();
+                        config.player_volume = player.volume();
+                        info!("after volumeup: {}", player.volume());
+                        let mut p_tick = progress_tick.lock();
+                        p_tick.volume = config.player_volume;
+                    } // _ => {}
+                    PlayerCmd::Pause => {
+                        player.pause();
+                    }
+                    PlayerCmd::Play => {
+                        player.resume();
                     }
                 }
             }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -66,38 +66,113 @@ async fn actual_main() -> Result<()> {
         let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx.clone())?;
         // move "cmd_rx" and change to be mutable
         let mut cmd_rx = cmd_rx;
-        // TODO: refactor this to be a while let Some loop
-        loop {
-            if let Some(cmd) = cmd_rx.blocking_recv() {
-                #[allow(unreachable_patterns)]
-                match cmd {
-                    PlayerCmd::AboutToFinish => {
-                        info!("about to finish signal received");
-                        if !player.playlist.is_empty()
-                            && !player.playlist.has_next_track()
-                            && player.config.player_gapless
-                        {
-                            player.enqueue_next_from_playlist();
-                        }
+        while let Some(cmd) = cmd_rx.blocking_recv() {
+            #[allow(unreachable_patterns)]
+            match cmd {
+                PlayerCmd::AboutToFinish => {
+                    info!("about to finish signal received");
+                    if !player.playlist.is_empty()
+                        && !player.playlist.has_next_track()
+                        && player.config.player_gapless
+                    {
+                        player.enqueue_next_from_playlist();
                     }
-                    PlayerCmd::Quit => {
-                        info!("PlayerCmd::Quit received");
-                        player.player_save_last_position();
-                        if let Err(e) = player.playlist.save() {
-                            error!("error when saving playlist: {e}");
-                        };
-                        if let Err(e) = config.save() {
-                            error!("error when saving config: {e}");
-                        };
-                        std::process::exit(0);
+                }
+                PlayerCmd::Quit => {
+                    info!("PlayerCmd::Quit received");
+                    player.player_save_last_position();
+                    if let Err(e) = player.playlist.save() {
+                        error!("error when saving playlist: {e}");
+                    };
+                    if let Err(e) = config.save() {
+                        error!("error when saving config: {e}");
+                    };
+                    std::process::exit(0);
+                }
+                PlayerCmd::CycleLoop => {
+                    config.player_loop_mode = player.playlist.cycle_loop_mode();
+                }
+                PlayerCmd::Eos => {
+                    info!("Eos received");
+                    if player.playlist.is_empty() {
+                        player.stop();
+                        continue;
                     }
-                    PlayerCmd::CycleLoop => {
-                        config.player_loop_mode = player.playlist.cycle_loop_mode();
+                    debug!(
+                        "current track index: {:?}",
+                        player.playlist.get_current_track_index()
+                    );
+                    player.playlist.clear_current_track();
+                    player.start_play();
+                    debug!(
+                        "playing index is: {}",
+                        player.playlist.get_current_track_index()
+                    );
+                }
+                PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
+                PlayerCmd::PlaySelected => {
+                    info!("play selected");
+                    player.player_save_last_position();
+                    player.playlist.proceed_false();
+                    player.next();
+                }
+                PlayerCmd::SkipPrevious => {
+                    info!("skip to previous track");
+                    player.player_save_last_position();
+                    player.previous();
+                }
+                PlayerCmd::ReloadConfig => {
+                    config.load()?;
+                    info!("config reloaded");
+                    player.config = config.clone();
+                }
+                PlayerCmd::ReloadPlaylist => {
+                    player.playlist.reload_tracks().ok();
+                }
+                PlayerCmd::SeekBackward => {
+                    player.seek_relative(false);
+                    let mut p_tick = progress_tick.lock();
+                    if let Ok((position, _duration)) = player.get_progress() {
+                        p_tick.position = position as u32;
                     }
-                    PlayerCmd::Eos => {
-                        info!("Eos received");
+                }
+                PlayerCmd::SeekForward => {
+                    player.seek_relative(true);
+                    let mut p_tick = progress_tick.lock();
+                    if let Ok((position, _duration)) = player.get_progress() {
+                        p_tick.position = position as u32;
+                    }
+                }
+                PlayerCmd::SkipNext => {
+                    info!("skip to next track.");
+                    player.player_save_last_position();
+                    player.next();
+                }
+                PlayerCmd::SpeedDown => {
+                    player.speed_down();
+                    info!("after speed down: {}", player.speed());
+                    config.player_speed = player.speed();
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.speed = config.player_speed;
+                }
+
+                PlayerCmd::SpeedUp => {
+                    player.speed_up();
+                    info!("after speed up: {}", player.speed());
+                    config.player_speed = player.speed();
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.speed = config.player_speed;
+                }
+                PlayerCmd::Tick => {
+                    // info!("tick received");
+                    if config.player_use_mpris {
+                        player.update_mpris();
+                    }
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.status = player.playlist.status().as_u32();
+                    // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
+                    if player.playlist.status() == Status::Stopped {
                         if player.playlist.is_empty() {
-                            player.stop();
                             continue;
                         }
                         debug!(
@@ -105,164 +180,87 @@ async fn actual_main() -> Result<()> {
                             player.playlist.get_current_track_index()
                         );
                         player.playlist.clear_current_track();
-                        player.start_play();
-                        debug!(
-                            "playing index is: {}",
-                            player.playlist.get_current_track_index()
-                        );
-                    }
-                    PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
-                    PlayerCmd::PlaySelected => {
-                        info!("play selected");
-                        player.player_save_last_position();
                         player.playlist.proceed_false();
-                        player.next();
+                        player.start_play();
+                        continue;
                     }
-                    PlayerCmd::SkipPrevious => {
-                        info!("skip to previous track");
-                        player.player_save_last_position();
-                        player.previous();
-                    }
-                    PlayerCmd::ReloadConfig => {
-                        config.load()?;
-                        info!("config reloaded");
-                        player.config = config.clone();
-                    }
-                    PlayerCmd::ReloadPlaylist => {
-                        player.playlist.reload_tracks().ok();
-                    }
-                    PlayerCmd::SeekBackward => {
-                        player.seek_relative(false);
-                        let mut p_tick = progress_tick.lock();
-                        if let Ok((position, _duration)) = player.get_progress() {
-                            p_tick.position = position as u32;
+                    if let Ok((position, duration)) = player.get_progress() {
+                        p_tick.position = position as u32;
+                        p_tick.duration = duration as u32;
+                        if player.current_track_updated {
+                            p_tick.current_track_index =
+                                player.playlist.get_current_track_index() as u32;
+                            p_tick.current_track_updated = player.current_track_updated;
+                            player.current_track_updated = false;
                         }
-                    }
-                    PlayerCmd::SeekForward => {
-                        player.seek_relative(true);
-                        let mut p_tick = progress_tick.lock();
-                        if let Ok((position, _duration)) = player.get_progress() {
-                            p_tick.position = position as u32;
-                        }
-                    }
-                    PlayerCmd::SkipNext => {
-                        info!("skip to next track.");
-                        player.player_save_last_position();
-                        player.next();
-                    }
-                    PlayerCmd::SpeedDown => {
-                        player.speed_down();
-                        info!("after speed down: {}", player.speed());
-                        config.player_speed = player.speed();
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.speed = config.player_speed;
-                    }
-
-                    PlayerCmd::SpeedUp => {
-                        player.speed_up();
-                        info!("after speed up: {}", player.speed());
-                        config.player_speed = player.speed();
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.speed = config.player_speed;
-                    }
-                    PlayerCmd::Tick => {
-                        // info!("tick received");
-                        if config.player_use_mpris {
-                            player.update_mpris();
-                        }
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.status = player.playlist.status().as_u32();
-                        // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
-                        if player.playlist.status() == Status::Stopped {
-                            if player.playlist.is_empty() {
-                                continue;
-                            }
-                            debug!(
-                                "current track index: {:?}",
-                                player.playlist.get_current_track_index()
-                            );
-                            player.playlist.clear_current_track();
-                            player.playlist.proceed_false();
-                            player.start_play();
-                            continue;
-                        }
-                        if let Ok((position, duration)) = player.get_progress() {
-                            p_tick.position = position as u32;
-                            p_tick.duration = duration as u32;
-                            if player.current_track_updated {
-                                p_tick.current_track_index =
-                                    player.playlist.get_current_track_index() as u32;
-                                p_tick.current_track_updated = player.current_track_updated;
-                                player.current_track_updated = false;
-                            }
-                            if let Some(track) = player.playlist.current_track() {
-                                if let Some(MediaType::LiveRadio) = &track.media_type {
-                                    // TODO: consider changing "radio_title" and "media_title" to be consistent
-                                    match player.backend {
-                                        #[cfg(feature = "mpv")]
-                                        Backend::Mpv(ref mut backend) => {
-                                            p_tick.radio_title = backend.media_title.lock().clone();
-                                        }
-                                        #[cfg(feature = "rusty")]
-                                        Backend::Rusty(ref mut backend) => {
-                                            p_tick.radio_title = backend.radio_title.lock().clone();
-                                            p_tick.duration = ((*backend.radio_downloaded.lock()
-                                                as f32
-                                                * 44100.0
+                        if let Some(track) = player.playlist.current_track() {
+                            if let Some(MediaType::LiveRadio) = &track.media_type {
+                                // TODO: consider changing "radio_title" and "media_title" to be consistent
+                                match player.backend {
+                                    #[cfg(feature = "mpv")]
+                                    Backend::Mpv(ref mut backend) => {
+                                        p_tick.radio_title = backend.media_title.lock().clone();
+                                    }
+                                    #[cfg(feature = "rusty")]
+                                    Backend::Rusty(ref mut backend) => {
+                                        p_tick.radio_title = backend.radio_title.lock().clone();
+                                        p_tick.duration =
+                                            ((*backend.radio_downloaded.lock() as f32 * 44100.0
                                                 / 1000000.0
                                                 / 1024.0)
                                                 * (backend.speed() as f32 / 10.0))
                                                 as u32;
-                                        }
-                                        #[cfg(feature = "gst")]
-                                        Backend::GStreamer(ref mut backend) => {
-                                            // p_tick.duration = player.backend.get_buffer_duration();
-                                            // error!("buffer duration: {}", p_tick.duration);
-                                            p_tick.duration = position as u32 + 20;
-                                            p_tick.radio_title = backend.radio_title.lock().clone();
-                                            // error!("radio title: {}", p_tick.radio_title);
-                                        }
+                                    }
+                                    #[cfg(feature = "gst")]
+                                    Backend::GStreamer(ref mut backend) => {
+                                        // p_tick.duration = player.backend.get_buffer_duration();
+                                        // error!("buffer duration: {}", p_tick.duration);
+                                        p_tick.duration = position as u32 + 20;
+                                        p_tick.radio_title = backend.radio_title.lock().clone();
+                                        // error!("radio title: {}", p_tick.radio_title);
                                     }
                                 }
                             }
                         }
                     }
-                    PlayerCmd::ToggleGapless => {
-                        config.player_gapless = player.toggle_gapless();
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.gapless = config.player_gapless;
-                    }
-                    PlayerCmd::TogglePause => {
-                        info!("player toggled pause");
-                        player.toggle_pause();
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.status = player.playlist.status().as_u32();
-                    }
-                    PlayerCmd::VolumeDown => {
-                        info!("before volumedown: {}", player.volume());
-                        player.volume_down();
-                        config.player_volume = player.volume();
-                        info!("after volumedown: {}", player.volume());
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.volume = config.player_volume;
-                    }
-                    PlayerCmd::VolumeUp => {
-                        info!("before volumeup: {}", player.volume());
-                        player.volume_up();
-                        config.player_volume = player.volume();
-                        info!("after volumeup: {}", player.volume());
-                        let mut p_tick = progress_tick.lock();
-                        p_tick.volume = config.player_volume;
-                    } // _ => {}
-                    PlayerCmd::Pause => {
-                        player.pause();
-                    }
-                    PlayerCmd::Play => {
-                        player.resume();
-                    }
+                }
+                PlayerCmd::ToggleGapless => {
+                    config.player_gapless = player.toggle_gapless();
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.gapless = config.player_gapless;
+                }
+                PlayerCmd::TogglePause => {
+                    info!("player toggled pause");
+                    player.toggle_pause();
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.status = player.playlist.status().as_u32();
+                }
+                PlayerCmd::VolumeDown => {
+                    info!("before volumedown: {}", player.volume());
+                    player.volume_down();
+                    config.player_volume = player.volume();
+                    info!("after volumedown: {}", player.volume());
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.volume = config.player_volume;
+                }
+                PlayerCmd::VolumeUp => {
+                    info!("before volumeup: {}", player.volume());
+                    player.volume_up();
+                    config.player_volume = player.volume();
+                    info!("after volumeup: {}", player.volume());
+                    let mut p_tick = progress_tick.lock();
+                    p_tick.volume = config.player_volume;
+                } // _ => {}
+                PlayerCmd::Pause => {
+                    player.pause();
+                }
+                PlayerCmd::Play => {
+                    player.resume();
                 }
             }
         }
+
+        Ok(())
     });
 
     ticker_thread(cmd_tx_ticker);

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -265,10 +265,11 @@ async fn actual_main() -> Result<()> {
 
     ticker_thread(cmd_tx_ticker);
 
-    Server::builder()
-        .add_service(MusicPlayerServer::new(music_player_service))
-        .serve_with_incoming(tcp_stream)
-        .await?;
+    tokio::spawn(
+        Server::builder()
+            .add_service(MusicPlayerServer::new(music_player_service))
+            .serve_with_incoming(tcp_stream),
+    );
 
     // if the underlying task/thread panicked, the error will be "task X panicked" instead of the actual panic (with no workaround?)
     // see the log or stderr for actual panic


### PR DESCRIPTION
This PR updates `server/src/server.rs` to be less indented and work better, in more details:
- move ticker thread from `playback` into `server`
- remove much indentation
- change player loop to be `while let Some`, so that it exits on channel close
- change ticker thread to be `while let Some`, so that it exists on channel close
- return result of player task on failure (instead of ignoring)
- change tonic music server to be a task instead (server now actually exits when the player dies)
- add a name to the ticker thread
- fix a comment in mpris