### PR TITLE
Refactor to use and store `Duration` instead of `i64`

### DIFF
--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -68,10 +68,13 @@ const EOL: &str = "\n";
 
 impl Lyric {
     // GetText will fetch lyric by time in seconds
-    pub fn get_text(&self, mut time: i64) -> Option<String> {
+    pub fn get_text(&self, time: Duration) -> Option<String> {
         if self.unsynced_captions.is_empty() {
             return None;
         };
+
+        #[allow(clippy::cast_possible_wrap)]
+        let mut time = time.as_secs() as i64;
 
         // here we want to show lyric 2 second earlier
         let mut adjusted_time = time * 1000 + 2000;

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -126,11 +126,13 @@ impl Lyric {
         Some(index)
     }
 
-    pub fn adjust_offset(&mut self, time: i64, offset: i64) {
+    pub fn adjust_offset(&mut self, time: Duration, offset: i64) {
+        #[allow(clippy::cast_possible_wrap)]
+        let time = time.as_secs() as i64;
         if let Some(index) = self.get_index(time) {
             // when time stamp is less than 10 seconds or index is before the first line, we adjust
             // the offset.
-            if (index == 0) | (time < 11) {
+            if (index == 0) || (time < 11) {
                 self.offset -= offset;
             } else {
                 // fine tuning each line after 10 seconds

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -53,13 +53,18 @@ lazy_static! {
 
 #[derive(Clone, Debug)]
 pub struct Lyric {
-    pub offset: i64, // positive means delay lyric
+    /// Offset in milliseconds
+    ///
+    /// positive means delay lyric
+    pub offset: i64,
     pub lang_extension: Option<String>,
-    pub unsynced_captions: Vec<UnsyncedCaption>, // USLT captions
+    /// USLT captions
+    pub unsynced_captions: Vec<UnsyncedCaption>,
 }
 
 #[derive(Clone, Debug)]
 pub struct UnsyncedCaption {
+    /// Timestamp in milliseconds
     time_stamp: i64,
     text: String,
 }

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -269,7 +269,7 @@ impl Track {
         }
     }
 
-    pub fn adjust_lyric_delay(&mut self, time_pos: i64, offset: i64) -> Result<()> {
+    pub fn adjust_lyric_delay(&mut self, time_pos: Duration, offset: i64) -> Result<()> {
         if let Some(lyric) = self.parsed_lyric.as_mut() {
             lyric.adjust_offset(time_pos, offset);
             let text = lyric.as_lrc_text();

--- a/playback/proto/player.proto
+++ b/playback/proto/player.proto
@@ -27,10 +27,14 @@ message TogglePauseResponse {
 message SkipNextRequest {}
 message SkipNextResponse{}
 
+message PlayerTime {
+  uint32 position = 1;
+  uint32 total_duration = 2;
+}
+
 message GetProgressRequest {}
 message GetProgressResponse{
-  uint32 position = 1;
-  uint32 duration = 2;
+  PlayerTime progress = 1;
   uint32 current_track_index = 3;
   uint32 status = 4;
   int32 volume = 5;

--- a/playback/proto/player.proto
+++ b/playback/proto/player.proto
@@ -11,8 +11,8 @@ service MusicPlayer {
   rpc SpeedUp (SpeedUpRequest) returns (SpeedReply);
   rpc SpeedDown (SpeedDownRequest) returns (SpeedReply);
   rpc ToggleGapless (ToggleGaplessRequest) returns (ToggleGaplessReply);
-  rpc SeekForward (SeekForwardRequest) returns (SeekReply);
-  rpc SeekBackward (SeekBackwardRequest) returns (SeekReply);
+  rpc SeekForward (SeekForwardRequest) returns (PlayerTime);
+  rpc SeekBackward (SeekBackwardRequest) returns (PlayerTime);
   rpc ReloadConfig (ReloadConfigRequest) returns (EmptyReply);
   rpc ReloadPlaylist (ReloadPlaylistRequest) returns (EmptyReply);
   rpc PlaySelected (PlaySelectedRequest) returns (EmptyReply);
@@ -63,10 +63,11 @@ message ToggleGaplessReply {
 
 message SeekForwardRequest {}
 message SeekBackwardRequest {}
-message SeekReply {
-  uint32 position = 1;
-  uint32 duration = 2;
-}
+// old usage for the Seek*Request, but completely covered by PlayerTime
+// message SeekReply {
+//   uint32 position = 1;
+//   uint32 duration = 2;
+// }
 
 message ReloadConfigRequest {}
 message ReloadPlaylistRequest {}

--- a/playback/proto/player.proto
+++ b/playback/proto/player.proto
@@ -29,7 +29,7 @@ message SkipNextResponse{}
 
 message PlayerTime {
   Duration position = 1;
-  optional Duration total_duration = 2;
+  Duration total_duration = 2;
 }
 
 message GetProgressRequest {}

--- a/playback/proto/player.proto
+++ b/playback/proto/player.proto
@@ -28,8 +28,8 @@ message SkipNextRequest {}
 message SkipNextResponse{}
 
 message PlayerTime {
-  uint32 position = 1;
-  uint32 total_duration = 2;
+  Duration position = 1;
+  optional Duration total_duration = 2;
 }
 
 message GetProgressRequest {}
@@ -74,3 +74,9 @@ message EmptyReply {}
 
 message PlaySelectedRequest {}
 message SkipPreviousRequest {}
+
+// using a custom Duration that matches rust's definition, as rust's may not fit into google's well-known Duration
+message Duration {
+  uint64 secs = 1;
+  uint32 nanos = 2;
+}

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -128,7 +128,11 @@ impl Rpc {
     }
 
     pub fn resume(&mut self, time_pos: PlayerTimeUnit) {
-        self.tx.send(RpcCommand::Resume(time_pos)).ok();
+        // ignore clippy here, this should not be a problem, maybe rich presence will support duration in the future
+        #[allow(clippy::cast_possible_wrap)]
+        self.tx
+            .send(RpcCommand::Resume(time_pos.as_secs() as i64))
+            .ok();
     }
 }
 

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -1,6 +1,7 @@
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use termusiclib::track::Track;
 const APP_ID: &str = "968407067889131520";
+use crate::PlayerTimeUnit;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -126,7 +127,7 @@ impl Rpc {
         self.tx.send(RpcCommand::Pause).ok();
     }
 
-    pub fn resume(&mut self, time_pos: i64) {
+    pub fn resume(&mut self, time_pos: PlayerTimeUnit) {
         self.tx.send(RpcCommand::Resume(time_pos)).ok();
     }
 }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -468,14 +468,14 @@ impl PlayerTrait for GStreamerBackend {
 
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    fn get_progress(&self) -> Result<PlayerProgress> {
+    fn get_progress(&self) -> PlayerProgress {
         let time_pos = self.get_position().seconds() as i64;
         let duration = self.get_duration().seconds() as i64;
         *self.position.lock() = time_pos;
-        Ok(PlayerProgress {
+        PlayerProgress {
             position: time_pos,
             total_duration: Some(duration),
-        })
+        }
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use super::{PlayerCmd, PlayerProgress, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -490,7 +490,7 @@ impl PlayerTrait for GStreamerBackend {
         self.skip_one();
     }
 
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, i64> {
+    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
         self.position.lock()
     }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -467,11 +467,9 @@ impl PlayerTrait for GStreamerBackend {
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
     fn get_progress(&self) -> PlayerProgress {
-        let time_pos = self.get_position().seconds() as i64;
-        let duration = self.get_duration().seconds() as i64;
         PlayerProgress {
-            position: time_pos,
-            total_duration: Some(duration),
+            position: self.get_position().into(),
+            total_duration: Some(self.get_duration().into()),
         }
     }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -488,10 +488,6 @@ impl PlayerTrait for GStreamerBackend {
 
     fn skip_one(&mut self) {
         self.skip_one();
-    }
-
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
-        self.position.lock()
     }
 
     fn enqueue_next(&mut self, file: &str) {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use super::{PlayerCmd, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -467,11 +467,14 @@ impl PlayerTrait for GStreamerBackend {
 
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    fn get_progress(&self) -> Result<(i64, i64)> {
+    fn get_progress(&self) -> Result<PlayerProgress> {
         let time_pos = self.get_position().seconds() as i64;
         let duration = self.get_duration().seconds() as i64;
         *self.position.lock() = time_pos;
-        Ok((time_pos, duration))
+        Ok(PlayerProgress {
+            position: time_pos,
+            total_duration: duration,
+        })
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -60,7 +60,6 @@ pub struct GStreamerBackend {
     speed: i32,
     pub gapless: bool,
     pub message_tx: Sender<PlayerCmd>,
-    pub position: Arc<Mutex<i64>>,
     pub radio_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }
@@ -236,7 +235,6 @@ impl GStreamerBackend {
             speed,
             gapless,
             message_tx,
-            position: Arc::new(Mutex::new(0_i64)),
             radio_title,
             _bus_watch_guard: bus_watch,
         };
@@ -471,7 +469,6 @@ impl PlayerTrait for GStreamerBackend {
     fn get_progress(&self) -> PlayerProgress {
         let time_pos = self.get_position().seconds() as i64;
         let duration = self.get_duration().seconds() as i64;
-        *self.position.lock() = time_pos;
         PlayerProgress {
             position: time_pos,
             total_duration: Some(duration),

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -275,6 +275,7 @@ impl GStreamerBackend {
         }
     }
 
+    // TODO: this should likely return a Option, instead of using pos as fallback
     fn get_duration(&self) -> ClockTime {
         match self.playbin.query_duration::<ClockTime>() {
             Some(pos) => pos,
@@ -473,7 +474,7 @@ impl PlayerTrait for GStreamerBackend {
         *self.position.lock() = time_pos;
         Ok(PlayerProgress {
             position: time_pos,
-            total_duration: duration,
+            total_duration: Some(duration),
         })
     }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -31,6 +31,22 @@
 #[allow(clippy::pedantic)]
 pub mod player {
     tonic::include_proto!("player");
+
+    // implement transform function for easy use
+    impl From<Duration> for std::time::Duration {
+        fn from(value: Duration) -> Self {
+            std::time::Duration::new(value.secs, value.nanos)
+        }
+    }
+
+    impl From<std::time::Duration> for Duration {
+        fn from(value: std::time::Duration) -> Self {
+            Self {
+                secs: value.as_secs(),
+                nanos: value.subsec_nanos(),
+            }
+        }
+    }
 }
 
 #[cfg(feature = "gst")]

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -605,7 +605,7 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player_mut().stop();
     }
 
-    fn get_progress(&self) -> Result<PlayerProgress> {
+    fn get_progress(&self) -> PlayerProgress {
         self.get_player().get_progress()
     }
 
@@ -663,10 +663,8 @@ pub trait PlayerTrait {
     fn seek(&mut self, secs: i64) -> Result<()>;
     // TODO: sync return types between "seek" and "seek_to"?
     fn seek_to(&mut self, last_pos: Duration);
-    /// # Errors
-    ///
-    /// Depending on different backend, there could be different errors during get progress.
-    fn get_progress(&self) -> Result<PlayerProgress>;
+    /// Get current track time position
+    fn get_progress(&self) -> PlayerProgress;
     fn set_speed(&mut self, speed: i32);
     fn speed_up(&mut self);
     fn speed_down(&mut self);

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -653,6 +653,24 @@ pub struct PlayerProgress {
     pub total_duration: Option<PlayerTimeUnit>,
 }
 
+impl From<crate::player::PlayerTime> for PlayerProgress {
+    fn from(value: crate::player::PlayerTime) -> Self {
+        Self {
+            position: value.position.unwrap_or_default().into(),
+            total_duration: value.total_duration.map(std::convert::Into::into),
+        }
+    }
+}
+
+impl From<PlayerProgress> for crate::player::PlayerTime {
+    fn from(value: PlayerProgress) -> Self {
+        Self {
+            position: Some(value.position.into()),
+            total_duration: value.total_duration.map(std::convert::Into::into),
+        }
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
 pub trait PlayerTrait {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -625,10 +625,6 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player().position()
     }
 
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
-        self.get_player().position_lock()
-    }
-
     fn enqueue_next(&mut self, file: &str) {
         self.get_player_mut().enqueue_next(file);
     }
@@ -673,9 +669,11 @@ pub trait PlayerTrait {
     fn gapless(&self) -> bool;
     fn set_gapless(&mut self, to: bool);
     fn skip_one(&mut self);
+    /// Quickly access the position.
+    ///
+    /// This should ALWAYS match up with [`PlayerTrait::get_progress`]'s `.position`!
     fn position(&self) -> PlayerTimeUnit {
-        *self.position_lock()
+        self.get_progress().position
     }
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit>;
     fn enqueue_next(&mut self, file: &str);
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -457,12 +457,10 @@ impl GeneralPlayer {
                     // let time_pos = self.player.position.lock().unwrap();
                     let time_pos = self.get_player().position();
                     match track.media_type {
-                        Some(MediaType::Music) => self
-                            .db
-                            .set_last_position(track, Duration::from_secs(time_pos as u64)),
-                        Some(MediaType::Podcast) => self
-                            .db_podcast
-                            .set_last_position(track, Duration::from_secs(time_pos as u64)),
+                        Some(MediaType::Music) => self.db.set_last_position(track, time_pos),
+                        Some(MediaType::Podcast) => {
+                            self.db_podcast.set_last_position(track, time_pos);
+                        }
                         Some(MediaType::LiveRadio) | None => {}
                     }
                 }
@@ -475,12 +473,10 @@ impl GeneralPlayer {
                         // let time_pos = self.player.position.lock().unwrap();
                         let time_pos = self.get_player().position();
                         match track.media_type {
-                            Some(MediaType::Music) => self
-                                .db
-                                .set_last_position(track, Duration::from_secs(time_pos as u64)),
-                            Some(MediaType::Podcast) => self
-                                .db_podcast
-                                .set_last_position(track, Duration::from_secs(time_pos as u64)),
+                            Some(MediaType::Music) => self.db.set_last_position(track, time_pos),
+                            Some(MediaType::Podcast) => {
+                                self.db_podcast.set_last_position(track, time_pos);
+                            }
                             Some(MediaType::LiveRadio) | None => {}
                         }
                     }
@@ -631,9 +627,8 @@ impl PlayerTrait for GeneralPlayer {
 }
 
 /// The primitive in which time (current position / total duration) will be stored as
-pub type PlayerTimeUnit = i64;
+pub type PlayerTimeUnit = Duration;
 
-// TODO: change the values to be duration
 /// Struct to keep both values with a name, as tuples cannot have named fields
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PlayerProgress {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -605,7 +605,7 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player_mut().stop();
     }
 
-    fn get_progress(&self) -> Result<(i64, i64)> {
+    fn get_progress(&self) -> Result<PlayerProgress> {
         self.get_player().get_progress()
     }
 
@@ -634,6 +634,15 @@ impl PlayerTrait for GeneralPlayer {
     }
 }
 
+// TODO: change the values to be duration
+/// Struct to keep both values with a name, as tuples cannot have named fields
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PlayerProgress {
+    pub position: i64,
+    // TODO: change this to be optional
+    pub total_duration: i64,
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
 pub trait PlayerTrait {
@@ -654,7 +663,7 @@ pub trait PlayerTrait {
     /// # Errors
     ///
     /// Depending on different backend, there could be different errors during get progress.
-    fn get_progress(&self) -> Result<(i64, i64)>;
+    fn get_progress(&self) -> Result<PlayerProgress>;
     fn set_speed(&mut self, speed: i32);
     fn speed_up(&mut self);
     fn speed_down(&mut self);

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -621,11 +621,11 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player_mut().skip_one();
     }
 
-    fn position(&self) -> i64 {
+    fn position(&self) -> PlayerTimeUnit {
         self.get_player().position()
     }
 
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, i64> {
+    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
         self.get_player().position_lock()
     }
 
@@ -634,13 +634,16 @@ impl PlayerTrait for GeneralPlayer {
     }
 }
 
+/// The primitive in which time (current position / total duration) will be stored as
+pub type PlayerTimeUnit = i64;
+
 // TODO: change the values to be duration
 /// Struct to keep both values with a name, as tuples cannot have named fields
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PlayerProgress {
-    pub position: i64,
+    pub position: PlayerTimeUnit,
     /// Total duration of the currently playing track, if there is a known total duration
-    pub total_duration: Option<i64>,
+    pub total_duration: Option<PlayerTimeUnit>,
 }
 
 #[allow(clippy::module_name_repetitions)]
@@ -672,9 +675,9 @@ pub trait PlayerTrait {
     fn gapless(&self) -> bool;
     fn set_gapless(&mut self, to: bool);
     fn skip_one(&mut self);
-    fn position(&self) -> i64 {
+    fn position(&self) -> PlayerTimeUnit {
         *self.position_lock()
     }
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, i64>;
+    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit>;
     fn enqueue_next(&mut self, file: &str);
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -639,8 +639,8 @@ impl PlayerTrait for GeneralPlayer {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PlayerProgress {
     pub position: i64,
-    // TODO: change this to be optional
-    pub total_duration: i64,
+    /// Total duration of the currently playing track, if there is a known total duration
+    pub total_duration: Option<i64>,
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -220,7 +220,7 @@ impl GeneralPlayer {
         }
 
         self.mpris.update_progress(
-            self.get_progress().ok().map_or(0, |v| v.0),
+            self.get_progress().ok().map_or(0, |v| v.position),
             self.playlist.status(),
         );
     }

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -219,9 +219,7 @@ impl GeneralPlayer {
             self.mpris.controls.set_volume(vol).ok();
         }
 
-        self.mpris.update_progress(
-            self.get_progress().ok().map_or(0, |v| v.position),
-            self.playlist.status(),
-        );
+        self.mpris
+            .update_progress(self.get_progress().position, self.playlist.status());
     }
 }

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -4,7 +4,7 @@ use termusiclib::track::Track;
 //     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig,
 // };
 
-use crate::{GeneralPlayer, PlayerCmd, PlayerTrait, Status};
+use crate::{GeneralPlayer, PlayerCmd, PlayerTimeUnit, PlayerTrait, Status};
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 // use std::str::FromStr;
 use std::sync::mpsc::{self, Receiver};
@@ -100,7 +100,7 @@ impl Mpris {
     }
 
     /// Update Track position / progress, requires `playlist_status` because [`MediaControls`] only allows `set_playback`, not `set_position` or `get_playback`
-    pub fn update_progress(&mut self, position: i64, playlist_status: Status) {
+    pub fn update_progress(&mut self, position: PlayerTimeUnit, playlist_status: Status) {
         // safe cast because of "max(0)"
         #[allow(clippy::cast_sign_loss)]
         let position = Duration::from_secs(position.max(0) as u64);

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -8,7 +8,6 @@ use crate::{GeneralPlayer, PlayerCmd, PlayerTimeUnit, PlayerTrait, Status};
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 // use std::str::FromStr;
 use std::sync::mpsc::{self, Receiver};
-use std::time::Duration;
 // use std::sync::{mpsc, Arc, Mutex};
 // use std::thread::{self, JoinHandle};
 
@@ -101,9 +100,6 @@ impl Mpris {
 
     /// Update Track position / progress, requires `playlist_status` because [`MediaControls`] only allows `set_playback`, not `set_position` or `get_playback`
     pub fn update_progress(&mut self, position: PlayerTimeUnit, playlist_status: Status) {
-        // safe cast because of "max(0)"
-        #[allow(clippy::cast_sign_loss)]
-        let position = Duration::from_secs(position.max(0) as u64);
         match playlist_status {
             Status::Running => self
                 .controls

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -46,6 +46,7 @@ pub struct MpvBackend {
     pub gapless: bool,
     command_tx: Sender<PlayerInternalCmd>,
     pub position: Arc<Mutex<i64>>,
+    // TODO: this should likely be a Option
     pub duration: Arc<Mutex<i64>>,
     pub media_title: Arc<Mutex<String>>,
     // cmd_tx: crate::PlayerCmdSender,
@@ -357,7 +358,7 @@ impl PlayerTrait for MpvBackend {
     fn get_progress(&self) -> Result<PlayerProgress> {
         Ok(PlayerProgress {
             position: *self.position.lock(),
-            total_duration: *self.duration.lock(),
+            total_duration: Some(*self.duration.lock()),
         })
     }
 

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -23,7 +23,7 @@
  */
 mod libmpv;
 
-use super::{PlayerCmd, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -354,8 +354,11 @@ impl PlayerTrait for MpvBackend {
         self.command_tx.send(PlayerInternalCmd::Stop).ok();
     }
 
-    fn get_progress(&self) -> Result<(i64, i64)> {
-        Ok((*self.position.lock(), *self.duration.lock()))
+    fn get_progress(&self) -> Result<PlayerProgress> {
+        Ok(PlayerProgress {
+            position: *self.position.lock(),
+            total_duration: *self.duration.lock(),
+        })
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -355,11 +355,11 @@ impl PlayerTrait for MpvBackend {
         self.command_tx.send(PlayerInternalCmd::Stop).ok();
     }
 
-    fn get_progress(&self) -> Result<PlayerProgress> {
-        Ok(PlayerProgress {
+    fn get_progress(&self) -> PlayerProgress {
+        PlayerProgress {
             position: *self.position.lock(),
             total_duration: Some(*self.duration.lock()),
-        })
+        }
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -23,7 +23,7 @@
  */
 mod libmpv;
 
-use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -372,10 +372,6 @@ impl PlayerTrait for MpvBackend {
 
     fn skip_one(&mut self) {
         self.skip_one();
-    }
-
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
-        self.position.lock()
     }
 
     fn enqueue_next(&mut self, file: &str) {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -45,9 +45,9 @@ pub struct MpvBackend {
     speed: i32,
     pub gapless: bool,
     command_tx: Sender<PlayerInternalCmd>,
-    pub position: Arc<Mutex<i64>>,
+    pub position: Arc<Mutex<Duration>>,
     // TODO: this should likely be a Option
-    pub duration: Arc<Mutex<i64>>,
+    pub duration: Arc<Mutex<Duration>>,
     pub media_title: Arc<Mutex<String>>,
     // cmd_tx: crate::PlayerCmdSender,
 }
@@ -74,8 +74,8 @@ impl MpvBackend {
         let volume = config.player_volume;
         let speed = config.player_speed;
         let gapless = config.player_gapless;
-        let position = Arc::new(Mutex::new(0_i64));
-        let duration = Arc::new(Mutex::new(0_i64));
+        let position = Arc::new(Mutex::new(Duration::default()));
+        let duration = Arc::new(Mutex::new(Duration::default()));
         let media_title = Arc::new(Mutex::new(String::new()));
         let position_inside = position.clone();
         let duration_inside = duration.clone();
@@ -106,10 +106,10 @@ impl MpvBackend {
                     .disable_deprecated_events()
                     .expect("failed to disable deprecated events.");
                 ev_ctx
-                    .observe_property("duration", Format::Int64, 0)
+                    .observe_property("duration", Format::Double, 0)
                     .expect("failed to watch duration");
                 ev_ctx
-                    .observe_property("time-pos", Format::Int64, 1)
+                    .observe_property("time-pos", Format::Double, 1)
                     .expect("failed to watch time_pos");
                 ev_ctx
                     .observe_property("media-title", Format::String, 2)
@@ -133,18 +133,24 @@ impl MpvBackend {
                                 reply_userdata: _,
                             }) => match name {
                                 "duration" => {
-                                    if let PropertyData::Int64(c) = change {
-                                        *duration_inside.lock() = c;
+                                    if let PropertyData::Double(dur) = change {
+                                        // using "dur.max" because mpv *may* return a negative number
+                                        *duration_inside.lock() =
+                                            Duration::from_secs_f64(dur.max(0.0));
                                     }
                                 }
                                 "time-pos" => {
-                                    if let PropertyData::Int64(time_pos) = change {
+                                    if let PropertyData::Double(time_pos) = change {
+                                        // using "dur.max" because mpv *may* return a negative number
+                                        let time_pos = Duration::from_secs_f64(time_pos.max(0.0));
                                         *position_inside.lock() = time_pos;
 
                                         // About to finish signal is a simulation of gstreamer, and used for gapless
                                         let dur = duration_inside.lock();
-                                        let progress = time_pos as f64 / *dur as f64;
-                                        if progress >= 0.5 && (*dur - time_pos) < 2 {
+                                        let progress = time_pos.as_secs_f64() / dur.as_secs_f64();
+                                        if progress >= 0.5
+                                            && (*dur - time_pos) < Duration::from_secs(2)
+                                        {
                                             if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
                                                 error!("command AboutToFinish sent failed: {e}");
                                             }
@@ -177,7 +183,7 @@ impl MpvBackend {
                         match cmd {
                             // PlayerCmd::Eos => message_tx.send(PlayerMsg::Eos).unwrap(),
                             PlayerInternalCmd::Play(new) => {
-                                *duration_inside.lock() = 0;
+                                *duration_inside.lock() = Duration::default();
                                 mpv.command("loadfile", &[&format!("\"{new}\""), "replace"])
                                     .ok();
                                 // .expect("Error loading file");
@@ -356,9 +362,11 @@ impl PlayerTrait for MpvBackend {
     }
 
     fn get_progress(&self) -> PlayerProgress {
+        // ignore clippy for now here, should be refactored soon
+        #[allow(clippy::cast_possible_wrap)]
         PlayerProgress {
-            position: *self.position.lock(),
-            total_duration: Some(*self.duration.lock()),
+            position: self.position.lock().as_secs() as i64,
+            total_duration: Some(self.duration.lock().as_secs() as i64),
         }
     }
 

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -23,7 +23,7 @@
  */
 mod libmpv;
 
-use super::{PlayerCmd, PlayerProgress, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -374,7 +374,7 @@ impl PlayerTrait for MpvBackend {
         self.skip_one();
     }
 
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, i64> {
+    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
         self.position.lock()
     }
 

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -362,11 +362,9 @@ impl PlayerTrait for MpvBackend {
     }
 
     fn get_progress(&self) -> PlayerProgress {
-        // ignore clippy for now here, should be refactored soon
-        #[allow(clippy::cast_possible_wrap)]
         PlayerProgress {
-            position: self.position.lock().as_secs() as i64,
-            total_duration: Some(self.duration.lock().as_secs() as i64),
+            position: *self.position.lock(),
+            total_duration: Some(*self.duration.lock()),
         }
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -302,14 +302,14 @@ impl PlayerTrait for RustyBackend {
 
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    fn get_progress(&self) -> Result<PlayerProgress> {
+    fn get_progress(&self) -> PlayerProgress {
         let time_pos = self.position.lock();
         let duration = self.total_duration.lock();
         let d_i64 = duration.map(|v| v.as_secs() as i64);
-        Ok(PlayerProgress {
+        PlayerProgress {
             position: *time_pos,
             total_duration: d_i64,
-        })
+        }
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -303,12 +303,9 @@ impl PlayerTrait for RustyBackend {
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
     fn get_progress(&self) -> PlayerProgress {
-        let time_pos = self.position.lock();
-        let duration = self.total_duration.lock();
-        let d_i64 = duration.map(|v| v.as_secs() as i64);
         PlayerProgress {
-            position: time_pos.as_secs() as i64,
-            total_duration: d_i64,
+            position: *self.position.lock(),
+            total_duration: *self.total_duration.lock(),
         }
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -22,7 +22,7 @@ pub use stream::OutputStream;
 
 use self::decoder::buffered_source::BufferedSource;
 
-use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use std::path::Path;
 use std::sync::mpsc::RecvTimeoutError;
@@ -322,10 +322,6 @@ impl PlayerTrait for RustyBackend {
 
     fn skip_one(&mut self) {
         self.skip_one();
-    }
-
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
-        self.position.lock()
     }
 
     fn enqueue_next(&mut self, file: &str) {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -22,7 +22,7 @@ pub use stream::OutputStream;
 
 use self::decoder::buffered_source::BufferedSource;
 
-use super::{PlayerCmd, PlayerProgress, PlayerTrait};
+use super::{PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait};
 use anyhow::Result;
 use std::path::Path;
 use std::sync::mpsc::RecvTimeoutError;
@@ -324,7 +324,7 @@ impl PlayerTrait for RustyBackend {
         self.skip_one();
     }
 
-    fn position_lock(&self) -> parking_lot::MutexGuard<'_, i64> {
+    fn position_lock(&self) -> parking_lot::MutexGuard<'_, PlayerTimeUnit> {
         self.position.lock()
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -305,8 +305,7 @@ impl PlayerTrait for RustyBackend {
     fn get_progress(&self) -> Result<PlayerProgress> {
         let time_pos = self.position.lock();
         let duration = self.total_duration.lock();
-        // TODO: this should likely be changed to return Option instead of 0
-        let d_i64 = duration.unwrap_or_default().as_secs() as i64;
+        let d_i64 = duration.map(|v| v.as_secs() as i64);
         Ok(PlayerProgress {
             position: *time_pos,
             total_duration: d_i64,

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -22,8 +22,7 @@ pub use stream::OutputStream;
 
 use self::decoder::buffered_source::BufferedSource;
 
-use super::PlayerCmd;
-use super::PlayerTrait;
+use super::{PlayerCmd, PlayerProgress, PlayerTrait};
 use anyhow::Result;
 use std::path::Path;
 use std::sync::mpsc::RecvTimeoutError;
@@ -303,12 +302,15 @@ impl PlayerTrait for RustyBackend {
 
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    fn get_progress(&self) -> Result<(i64, i64)> {
+    fn get_progress(&self) -> Result<PlayerProgress> {
         let time_pos = self.position.lock();
         let duration = self.total_duration.lock();
         // TODO: this should likely be changed to return Option instead of 0
         let d_i64 = duration.unwrap_or_default().as_secs() as i64;
-        Ok((*time_pos, d_i64))
+        Ok(PlayerProgress {
+            position: *time_pos,
+            total_duration: d_i64,
+        })
     }
 
     fn gapless(&self) -> bool {

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -106,8 +106,7 @@ impl Sink {
             .skippable()
             .stoppable()
             .periodic_access(Duration::from_millis(500), move |src| {
-                let position = src.elapsed().as_secs() as i64;
-                tx.send(PlayerInternalCmd::Progress(position)).ok();
+                tx.send(PlayerInternalCmd::Progress(src.elapsed())).ok();
             })
             .periodic_access(Duration::from_millis(5), move |src| {
                 let src = src.inner_mut();

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -18,7 +18,7 @@ use crate::PlayerStats;
 #[derive(Debug)]
 pub struct MusicPlayerService {
     cmd_tx: PlayerCmdSender,
-    pub player_stats: Arc<Mutex<PlayerStats>>,
+    pub(crate) player_stats: Arc<Mutex<PlayerStats>>,
 }
 
 impl MusicPlayerService {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -133,13 +133,13 @@ async fn actual_main() -> Result<()> {
                     player.seek_relative(false);
                     let mut p_tick = progress_tick.lock();
                     let pprogress = player.get_progress();
-                    p_tick.position = pprogress.position as u32;
+                    p_tick.position = pprogress.position.as_secs() as u32;
                 }
                 PlayerCmd::SeekForward => {
                     player.seek_relative(true);
                     let mut p_tick = progress_tick.lock();
                     let pprogress = player.get_progress();
-                    p_tick.position = pprogress.position as u32;
+                    p_tick.position = pprogress.position.as_secs() as u32;
                 }
                 PlayerCmd::SkipNext => {
                     info!("skip to next track.");
@@ -184,8 +184,8 @@ async fn actual_main() -> Result<()> {
                     }
                     let pprogress = player.get_progress();
                     // TODO: this is all kinds of wrong, refactor to store Duration directly in p_tick
-                    p_tick.position = pprogress.position as u32;
-                    p_tick.duration = pprogress.total_duration.unwrap_or_default() as u32;
+                    p_tick.position = pprogress.position.as_secs() as u32;
+                    p_tick.duration = pprogress.total_duration.unwrap_or_default().as_secs() as u32;
                     if player.current_track_updated {
                         p_tick.current_track_index =
                             player.playlist.get_current_track_index() as u32;
@@ -214,7 +214,7 @@ async fn actual_main() -> Result<()> {
                                 Backend::GStreamer(ref mut backend) => {
                                     // p_tick.duration = player.backend.get_buffer_duration();
                                     // error!("buffer duration: {}", p_tick.duration);
-                                    p_tick.duration = pprogress.position as u32 + 20;
+                                    p_tick.duration = pprogress.position.as_secs() as u32 + 20;
                                     p_tick.radio_title = backend.radio_title.lock().clone();
                                     // error!("radio title: {}", p_tick.radio_title);
                                 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -56,10 +56,7 @@ impl PlayerStats {
     pub fn as_getprogress_response(&self) -> GetProgressResponse {
         GetProgressResponse {
             // TODO: refactor proto definition to use duration
-            progress: Some(PlayerTime {
-                position: Some(self.progress.position.into()),
-                total_duration: self.progress.total_duration.map(|v| v.into()),
-            }),
+            progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: self.status,
             volume: self.volume,
@@ -68,6 +65,10 @@ impl PlayerStats {
             current_track_updated: self.current_track_updated,
             radio_title: self.radio_title.clone(),
         }
+    }
+
+    pub fn as_playertime(&self) -> PlayerTime {
+        self.progress.into()
     }
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -132,15 +132,15 @@ async fn actual_main() -> Result<()> {
                 PlayerCmd::SeekBackward => {
                     player.seek_relative(false);
                     let mut p_tick = progress_tick.lock();
-                    if let Ok((position, _duration)) = player.get_progress() {
-                        p_tick.position = position as u32;
+                    if let Ok(pprogress) = player.get_progress() {
+                        p_tick.position = pprogress.position as u32;
                     }
                 }
                 PlayerCmd::SeekForward => {
                     player.seek_relative(true);
                     let mut p_tick = progress_tick.lock();
-                    if let Ok((position, _duration)) = player.get_progress() {
-                        p_tick.position = position as u32;
+                    if let Ok(pprogress) = player.get_progress() {
+                        p_tick.position = pprogress.position as u32;
                     }
                 }
                 PlayerCmd::SkipNext => {
@@ -184,9 +184,9 @@ async fn actual_main() -> Result<()> {
                         player.start_play();
                         continue;
                     }
-                    if let Ok((position, duration)) = player.get_progress() {
-                        p_tick.position = position as u32;
-                        p_tick.duration = duration as u32;
+                    if let Ok(pprogress) = player.get_progress() {
+                        p_tick.position = pprogress.position as u32;
+                        p_tick.duration = pprogress.total_duration as u32;
                         if player.current_track_updated {
                             p_tick.current_track_index =
                                 player.playlist.get_current_track_index() as u32;
@@ -215,7 +215,7 @@ async fn actual_main() -> Result<()> {
                                     Backend::GStreamer(ref mut backend) => {
                                         // p_tick.duration = player.backend.get_buffer_duration();
                                         // error!("buffer duration: {}", p_tick.duration);
-                                        p_tick.duration = position as u32 + 20;
+                                        p_tick.duration = pprogress.position as u32 + 20;
                                         p_tick.radio_title = backend.radio_title.lock().clone();
                                         // error!("radio title: {}", p_tick.radio_title);
                                     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -57,8 +57,8 @@ impl PlayerStats {
         GetProgressResponse {
             // TODO: refactor proto definition to use duration
             progress: Some(PlayerTime {
-                position: self.progress.position.as_secs() as u32,
-                total_duration: self.progress.total_duration.unwrap_or_default().as_secs() as u32,
+                position: Some(self.progress.position.into()),
+                total_duration: self.progress.total_duration.map(|v| v.into()),
             }),
             current_track_index: self.current_track_index,
             status: self.status,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -185,8 +185,9 @@ async fn actual_main() -> Result<()> {
                         continue;
                     }
                     if let Ok(pprogress) = player.get_progress() {
+                        // TODO: this is all kinds of wrong, refactor to store Duration directly in p_tick
                         p_tick.position = pprogress.position as u32;
-                        p_tick.duration = pprogress.total_duration as u32;
+                        p_tick.duration = pprogress.total_duration.unwrap_or_default() as u32;
                         if player.current_track_updated {
                             p_tick.current_track_index =
                                 player.playlist.get_current_track_index() as u32;

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -11,7 +11,7 @@ use music_player_service::MusicPlayerService;
 use termusiclib::config::Settings;
 use termusiclib::track::MediaType;
 use termusicplayback::player::music_player_server::MusicPlayerServer;
-use termusicplayback::player::GetProgressResponse;
+use termusicplayback::player::{GetProgressResponse, PlayerTime};
 use termusicplayback::{
     Backend, GeneralPlayer, PlayerCmd, PlayerCmdSender, PlayerProgress, PlayerTrait, Status,
 };
@@ -56,8 +56,10 @@ impl PlayerStats {
     pub fn as_getprogress_response(&self) -> GetProgressResponse {
         GetProgressResponse {
             // TODO: refactor proto definition to use duration
-            position: self.progress.position.as_secs() as u32,
-            duration: self.progress.total_duration.unwrap_or_default().as_secs() as u32,
+            progress: Some(PlayerTime {
+                position: self.progress.position.as_secs() as u32,
+                total_duration: self.progress.total_duration.unwrap_or_default().as_secs() as u32,
+            }),
             current_track_index: self.current_track_index,
             status: self.status,
             volume: self.volume,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -3,6 +3,7 @@ mod logger;
 mod music_player_service;
 
 use std::path::Path;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -10,7 +11,10 @@ use music_player_service::MusicPlayerService;
 use termusiclib::config::Settings;
 use termusiclib::track::MediaType;
 use termusicplayback::player::music_player_server::MusicPlayerServer;
-use termusicplayback::{Backend, GeneralPlayer, PlayerCmd, PlayerCmdSender, PlayerTrait, Status};
+use termusicplayback::player::GetProgressResponse;
+use termusicplayback::{
+    Backend, GeneralPlayer, PlayerCmd, PlayerCmdSender, PlayerProgress, PlayerTrait, Status,
+};
 use tonic::transport::server::TcpIncoming;
 use tonic::transport::Server;
 
@@ -18,6 +22,52 @@ use tonic::transport::Server;
 extern crate log;
 
 pub const MAX_DEPTH: usize = 4;
+
+/// Stats for the music player responses
+#[derive(Debug, Clone, PartialEq)]
+struct PlayerStats {
+    pub progress: PlayerProgress,
+    pub current_track_index: u32,
+    pub status: u32,
+    pub volume: i32,
+    pub speed: i32,
+    pub gapless: bool,
+    pub current_track_updated: bool,
+    pub radio_title: String,
+}
+
+impl PlayerStats {
+    pub fn new() -> Self {
+        Self {
+            progress: PlayerProgress {
+                position: Duration::default(),
+                total_duration: None,
+            },
+            current_track_index: 0,
+            status: 1,
+            volume: 0,
+            speed: 10,
+            gapless: true,
+            current_track_updated: false,
+            radio_title: String::new(),
+        }
+    }
+
+    pub fn as_getprogress_response(&self) -> GetProgressResponse {
+        GetProgressResponse {
+            // TODO: refactor proto definition to use duration
+            position: self.progress.position.as_secs() as u32,
+            duration: self.progress.total_duration.unwrap_or_default().as_secs() as u32,
+            current_track_index: self.current_track_index,
+            status: self.status,
+            volume: self.volume,
+            speed: self.speed,
+            gapless: self.gapless,
+            current_track_updated: self.current_track_updated,
+            radio_title: self.radio_title.clone(),
+        }
+    }
+}
 
 fn main() -> Result<()> {
     // print error to the log and then throw it
@@ -39,7 +89,7 @@ async fn actual_main() -> Result<()> {
 
     let music_player_service: MusicPlayerService = MusicPlayerService::new(cmd_tx.clone());
     let mut config = get_config(&args)?;
-    let progress_tick = music_player_service.progress.clone();
+    let playerstats = music_player_service.player_stats.clone();
 
     let cmd_tx_ctrlc = cmd_tx.clone();
     let cmd_tx_ticker = cmd_tx.clone();
@@ -131,15 +181,13 @@ async fn actual_main() -> Result<()> {
                 }
                 PlayerCmd::SeekBackward => {
                     player.seek_relative(false);
-                    let mut p_tick = progress_tick.lock();
-                    let pprogress = player.get_progress();
-                    p_tick.position = pprogress.position.as_secs() as u32;
+                    let mut p_tick = playerstats.lock();
+                    p_tick.progress = player.get_progress();
                 }
                 PlayerCmd::SeekForward => {
                     player.seek_relative(true);
-                    let mut p_tick = progress_tick.lock();
-                    let pprogress = player.get_progress();
-                    p_tick.position = pprogress.position.as_secs() as u32;
+                    let mut p_tick = playerstats.lock();
+                    p_tick.progress = player.get_progress();
                 }
                 PlayerCmd::SkipNext => {
                     info!("skip to next track.");
@@ -150,7 +198,7 @@ async fn actual_main() -> Result<()> {
                     player.speed_down();
                     info!("after speed down: {}", player.speed());
                     config.player_speed = player.speed();
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.speed = config.player_speed;
                 }
 
@@ -158,7 +206,7 @@ async fn actual_main() -> Result<()> {
                     player.speed_up();
                     info!("after speed up: {}", player.speed());
                     config.player_speed = player.speed();
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.speed = config.player_speed;
                 }
                 PlayerCmd::Tick => {
@@ -166,7 +214,7 @@ async fn actual_main() -> Result<()> {
                     if config.player_use_mpris {
                         player.update_mpris();
                     }
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.status = player.playlist.status().as_u32();
                     // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
                     if player.playlist.status() == Status::Stopped {
@@ -183,9 +231,7 @@ async fn actual_main() -> Result<()> {
                         continue;
                     }
                     let pprogress = player.get_progress();
-                    // TODO: this is all kinds of wrong, refactor to store Duration directly in p_tick
-                    p_tick.position = pprogress.position.as_secs() as u32;
-                    p_tick.duration = pprogress.total_duration.unwrap_or_default().as_secs() as u32;
+                    p_tick.progress = pprogress;
                     if player.current_track_updated {
                         p_tick.current_track_index =
                             player.playlist.get_current_track_index() as u32;
@@ -203,18 +249,20 @@ async fn actual_main() -> Result<()> {
                                 #[cfg(feature = "rusty")]
                                 Backend::Rusty(ref mut backend) => {
                                     p_tick.radio_title = backend.radio_title.lock().clone();
-                                    p_tick.duration = ((*backend.radio_downloaded.lock() as f32
-                                        * 44100.0
-                                        / 1000000.0
-                                        / 1024.0)
-                                        * (backend.speed() as f32 / 10.0))
-                                        as u32;
+                                    p_tick.progress.total_duration = Some(Duration::from_secs(
+                                        ((*backend.radio_downloaded.lock() as f32 * 44100.0
+                                            / 1000000.0
+                                            / 1024.0)
+                                            * (backend.speed() as f32 / 10.0))
+                                            as u64,
+                                    ));
                                 }
                                 #[cfg(feature = "gst")]
                                 Backend::GStreamer(ref mut backend) => {
                                     // p_tick.duration = player.backend.get_buffer_duration();
                                     // error!("buffer duration: {}", p_tick.duration);
-                                    p_tick.duration = pprogress.position.as_secs() as u32 + 20;
+                                    p_tick.progress.total_duration =
+                                        Some(pprogress.position + Duration::from_secs(20));
                                     p_tick.radio_title = backend.radio_title.lock().clone();
                                     // error!("radio title: {}", p_tick.radio_title);
                                 }
@@ -224,13 +272,13 @@ async fn actual_main() -> Result<()> {
                 }
                 PlayerCmd::ToggleGapless => {
                     config.player_gapless = player.toggle_gapless();
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.gapless = config.player_gapless;
                 }
                 PlayerCmd::TogglePause => {
                     info!("player toggled pause");
                     player.toggle_pause();
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.status = player.playlist.status().as_u32();
                 }
                 PlayerCmd::VolumeDown => {
@@ -238,7 +286,7 @@ async fn actual_main() -> Result<()> {
                     player.volume_down();
                     config.player_volume = player.volume();
                     info!("after volumedown: {}", player.volume());
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.volume = config.player_volume;
                 }
                 PlayerCmd::VolumeUp => {
@@ -246,7 +294,7 @@ async fn actual_main() -> Result<()> {
                     player.volume_up();
                     config.player_volume = player.volume();
                     info!("after volumeup: {}", player.volume());
-                    let mut p_tick = progress_tick.lock();
+                    let mut p_tick = playerstats.lock();
                     p_tick.volume = config.player_volume;
                 }
                 PlayerCmd::Pause => {

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -333,8 +333,7 @@ impl Model {
     }
     pub fn lyric_adjust_delay(&mut self, offset: i64) {
         if let Some(track) = self.playlist.current_track_as_mut() {
-            #[allow(clippy::cast_possible_wrap)]
-            if let Err(e) = track.adjust_lyric_delay(self.time_pos.as_secs() as i64, offset) {
+            if let Err(e) = track.adjust_lyric_delay(self.time_pos, offset) {
                 self.mount_error_popup(format!("adjust lyric delay error: {e}"));
             };
         }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -333,7 +333,8 @@ impl Model {
     }
     pub fn lyric_adjust_delay(&mut self, offset: i64) {
         if let Some(track) = self.playlist.current_track_as_mut() {
-            if let Err(e) = track.adjust_lyric_delay(self.time_pos, offset) {
+            #[allow(clippy::cast_possible_wrap)]
+            if let Err(e) = track.adjust_lyric_delay(self.time_pos.as_secs() as i64, offset) {
                 self.mount_error_popup(format!("adjust lyric delay error: {e}"));
             };
         }

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -116,6 +116,8 @@ impl Model {
         self.force_redraw();
     }
 
+    // TODO: refactor this function to use Duration
+    // TODO: refactor to have "duration" optional
     #[allow(clippy::cast_precision_loss)]
     pub fn progress_update(&mut self, time_pos: i64, duration: i64) {
         // for unsupported file format, don't update progress

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -124,10 +124,10 @@ impl Model {
             return;
         }
 
-        self.time_pos = time_pos.as_secs() as i64;
+        self.time_pos = time_pos;
 
-        let progress = (self.time_pos * 100)
-            .checked_div(total_duration.as_secs() as i64)
+        let progress = (time_pos.as_secs() * 100)
+            .checked_div(total_duration.as_secs())
             .unwrap() as f64;
 
         let new_prog = Self::progress_safeguard(progress);
@@ -155,9 +155,7 @@ impl Model {
                 Attribute::Text,
                 AttrValue::String(format!(
                     "{}    -    {}",
-                    Track::duration_formatted_short(&Duration::from_secs(
-                        self.time_pos.try_into().unwrap_or(0)
-                    )),
+                    Track::duration_formatted_short(&self.time_pos),
                     Track::duration_formatted_short(&total_duration)
                 )),
             )

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -221,9 +221,10 @@ impl UI {
                 }
                 PlayerCmd::GetProgress => {
                     let response = self.playback.get_progress().await?;
+                    let pprogress = response.progress.unwrap_or_default();
                     self.model.progress_update(
-                        i64::from(response.position),
-                        i64::from(response.duration),
+                        i64::from(pprogress.position),
+                        i64::from(pprogress.total_duration),
                     );
                     if response.current_track_updated {
                         self.handle_current_track_index(response.current_track_index as usize);

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -222,9 +222,12 @@ impl UI {
                 PlayerCmd::GetProgress => {
                     let response = self.playback.get_progress().await?;
                     let pprogress = response.progress.unwrap_or_default();
+                    // ignore for now
+                    #[allow(clippy::cast_possible_wrap)]
                     self.model.progress_update(
-                        i64::from(pprogress.position),
-                        i64::from(pprogress.total_duration),
+                        Duration::from(pprogress.position.unwrap_or_default()).as_secs() as i64,
+                        Duration::from(pprogress.total_duration.unwrap_or_default()).as_secs()
+                            as i64,
                     );
                     if response.current_track_updated {
                         self.handle_current_track_index(response.current_track_index as usize);

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -249,15 +249,19 @@ impl UI {
                 PlayerCmd::ReloadConfig => self.playback.reload_config().await?,
                 PlayerCmd::ReloadPlaylist => self.playback.reload_playlist().await?,
                 PlayerCmd::SeekBackward => {
-                    let (position, duration) = self.playback.seek_backward().await?;
-                    self.model
-                        .progress_update(i64::from(position), i64::from(duration));
+                    let pprogress = self.playback.seek_backward().await?;
+                    self.model.progress_update(
+                        pprogress.position.as_secs() as i64,
+                        pprogress.total_duration.unwrap_or_default().as_secs() as i64,
+                    );
                     self.model.force_redraw();
                 }
                 PlayerCmd::SeekForward => {
-                    let (position, duration) = self.playback.seek_forward().await?;
-                    self.model
-                        .progress_update(i64::from(position), i64::from(duration));
+                    let pprogress = self.playback.seek_forward().await?;
+                    self.model.progress_update(
+                        pprogress.position.as_secs() as i64,
+                        pprogress.total_duration.unwrap_or_default().as_secs() as i64,
+                    );
                     self.model.force_redraw();
                 }
                 PlayerCmd::SpeedDown => {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 use sysinfo::System;
 use termusiclib::config::Settings;
 pub use termusiclib::types::*;
-use termusicplayback::{PlayerCmd, Status};
+use termusicplayback::{PlayerCmd, PlayerProgress, Status};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use tuirealm::application::PollStrategy;
 use tuirealm::{Application, Update};
@@ -221,13 +221,10 @@ impl UI {
                 }
                 PlayerCmd::GetProgress => {
                     let response = self.playback.get_progress().await?;
-                    let pprogress = response.progress.unwrap_or_default();
-                    // ignore for now
-                    #[allow(clippy::cast_possible_wrap)]
+                    let pprogress: PlayerProgress = response.progress.unwrap_or_default().into();
                     self.model.progress_update(
-                        Duration::from(pprogress.position.unwrap_or_default()).as_secs() as i64,
-                        Duration::from(pprogress.total_duration.unwrap_or_default()).as_secs()
-                            as i64,
+                        pprogress.position,
+                        pprogress.total_duration.unwrap_or_default(),
                     );
                     if response.current_track_updated {
                         self.handle_current_track_index(response.current_track_index as usize);
@@ -251,16 +248,16 @@ impl UI {
                 PlayerCmd::SeekBackward => {
                     let pprogress = self.playback.seek_backward().await?;
                     self.model.progress_update(
-                        pprogress.position.as_secs() as i64,
-                        pprogress.total_duration.unwrap_or_default().as_secs() as i64,
+                        pprogress.position,
+                        pprogress.total_duration.unwrap_or_default(),
                     );
                     self.model.force_redraw();
                 }
                 PlayerCmd::SeekForward => {
                     let pprogress = self.playback.seek_forward().await?;
                     self.model.progress_update(
-                        pprogress.position.as_secs() as i64,
-                        pprogress.total_duration.unwrap_or_default().as_secs() as i64,
+                        pprogress.position,
+                        pprogress.total_duration.unwrap_or_default(),
                     );
                     self.model.force_redraw();
                 }

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -83,6 +83,7 @@ pub struct Model {
     pub yanked_node_id: Option<String>,
     pub current_song: Option<Track>,
     pub tageditor_song: Option<Track>,
+    // TODO: refactor "time_pos" to be Duration
     pub time_pos: i64,
     pub lyric_line: String,
     youtube_options: YoutubeOptions,

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -83,8 +83,7 @@ pub struct Model {
     pub yanked_node_id: Option<String>,
     pub current_song: Option<Track>,
     pub tageditor_song: Option<Track>,
-    // TODO: refactor "time_pos" to be Duration
-    pub time_pos: i64,
+    pub time_pos: Duration,
     pub lyric_line: String,
     youtube_options: YoutubeOptions,
     #[cfg(feature = "cover")]
@@ -175,7 +174,7 @@ impl Model {
             yanked_node_id: None,
             // current_song: None,
             tageditor_song: None,
-            time_pos: 0,
+            time_pos: Duration::default(),
             lyric_line: String::new(),
 
             // TODO: Consider making YoutubeOptions async and use async reqwest in YoutubeOptions
@@ -274,7 +273,7 @@ impl Model {
     }
 
     pub fn player_update_current_track_after(&mut self) {
-        self.time_pos = 0;
+        self.time_pos = Duration::default();
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(format!("update photo error: {e}"));
         };

--- a/tui/src/ui/playback.rs
+++ b/tui/src/ui/playback.rs
@@ -6,7 +6,7 @@ use termusicplayback::player::{
     SkipNextRequest, SkipPreviousRequest, SpeedDownRequest, SpeedUpRequest, ToggleGaplessRequest,
     TogglePauseRequest, VolumeDownRequest, VolumeUpRequest,
 };
-use termusicplayback::Status;
+use termusicplayback::{PlayerProgress, Status};
 use tonic::transport::Channel;
 
 pub struct Playback {
@@ -90,20 +90,20 @@ impl Playback {
         Ok(response.gapless)
     }
 
-    pub async fn seek_forward(&mut self) -> Result<(u32, u32)> {
+    pub async fn seek_forward(&mut self) -> Result<PlayerProgress> {
         let request = tonic::Request::new(SeekForwardRequest {});
         let response = self.client.seek_forward(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
-        Ok((response.position, response.duration))
+        Ok(response.into())
     }
 
-    pub async fn seek_backward(&mut self) -> Result<(u32, u32)> {
+    pub async fn seek_backward(&mut self) -> Result<PlayerProgress> {
         let request = tonic::Request::new(SeekBackwardRequest {});
         let response = self.client.seek_backward(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
-        Ok((response.position, response.duration))
+        Ok(response.into())
     }
 
     pub async fn reload_config(&mut self) -> Result<()> {


### PR DESCRIPTION
This PR refactors "all" places (`PlayerTrait`, Backends, gRPC, TUI) to use `Duration` instead of `i64` (or even `u32` or `i32`).
There are some tangential things i have done:
- change mpv to listen on `Double`(`f64`)s instead of `Int64`(`i64`) (way more precision than just a second)
- add some doc-comments to `lrc`
- change music-player-service's shared state to be separate from the response (easier to use)

@tramhao please let me know if everything as `Duration` is fine, or should we use something like gst's `u64` which is nano seconds, or mpv's `double`(`f64`) storing(or at least for transfer) seconds?