### PR TITLE
Slight refactoring of seeking

### DIFF
--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -420,8 +420,8 @@ impl PlayerTrait for GStreamerBackend {
 
     #[allow(clippy::cast_sign_loss)]
     #[allow(clippy::cast_possible_wrap)]
-    fn seek_to(&mut self, last_pos: Duration) {
-        let seek_pos = last_pos.as_secs() as i64;
+    fn seek_to(&mut self, position: Duration) {
+        let seek_pos = position.as_secs() as i64;
         // let duration = self.get_duration().seconds() as i64;
 
         let seek_pos_clock = ClockTime::from_seconds(seek_pos as u64);

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -418,13 +418,10 @@ impl PlayerTrait for GStreamerBackend {
         Ok(())
     }
 
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_possible_wrap)]
     fn seek_to(&mut self, position: Duration) {
-        let seek_pos = position.as_secs() as i64;
-        // let duration = self.get_duration().seconds() as i64;
-
-        let seek_pos_clock = ClockTime::from_seconds(seek_pos as u64);
+        // expect should be fine here, as this function does not allow erroring and any duration more than u64::MAX is unlikely
+        let seek_pos_clock =
+            ClockTime::try_from(position).expect("Duration(u128) did not fit into ClockTime(u64)");
         self.set_volume_inside(0.0);
         while self
             .playbin

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -590,8 +590,8 @@ impl PlayerTrait for GeneralPlayer {
     fn seek(&mut self, secs: i64) -> Result<()> {
         self.get_player_mut().seek(secs)
     }
-    fn seek_to(&mut self, last_pos: Duration) {
-        self.get_player_mut().seek_to(last_pos);
+    fn seek_to(&mut self, position: Duration) {
+        self.get_player_mut().seek_to(position);
     }
 
     fn set_speed(&mut self, speed: i32) {
@@ -682,12 +682,15 @@ pub trait PlayerTrait {
     fn pause(&mut self);
     fn resume(&mut self);
     fn is_paused(&self) -> bool;
+    /// Seek relatively to the current time
+    ///
     /// # Errors
     ///
     /// Depending on different backend, there could be different errors during seek.
     fn seek(&mut self, secs: i64) -> Result<()>;
     // TODO: sync return types between "seek" and "seek_to"?
-    fn seek_to(&mut self, last_pos: Duration);
+    /// Seek to a absolute position
+    fn seek_to(&mut self, position: Duration);
     /// Get current track time position
     fn get_progress(&self) -> PlayerProgress;
     fn set_speed(&mut self, speed: i32);

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -60,7 +60,7 @@ enum PlayerInternalCmd {
     QueueNext(String),
     Resume,
     Seek(i64),
-    SeekAbsolute(i64),
+    SeekAbsolute(Duration),
     Speed(i32),
     Stop,
     Volume(i64),
@@ -226,10 +226,10 @@ impl MpvBackend {
                                 //     .send(PlayerMsg::Progress(time_pos_seek, duration_seek))
                                 //     .ok();
                             }
-                            PlayerInternalCmd::SeekAbsolute(secs) => {
+                            PlayerInternalCmd::SeekAbsolute(position) => {
                                 mpv.pause().ok();
                                 while mpv
-                                    .command("seek", &[&format!("\"{secs}\""), "absolute"])
+                                    .command("seek", &[&format_duration(position), "absolute"])
                                     .is_err()
                                 {
                                     // This is because we need to wait until the file is fully loaded.
@@ -282,6 +282,16 @@ impl MpvBackend {
     }
 }
 
+/// Format a duration in "SS.mm" format
+///
+/// Note that mpv supports "HH:MM:SS.mmmm" format, but only the second and millisecond part is used
+fn format_duration(dur: Duration) -> String {
+    let secs = dur.as_secs();
+    let milli = dur.subsec_millis();
+
+    format!("{secs}.{milli}")
+}
+
 #[async_trait]
 impl PlayerTrait for MpvBackend {
     async fn add_and_play(&mut self, current_item: &Track) {
@@ -328,7 +338,7 @@ impl PlayerTrait for MpvBackend {
     #[allow(clippy::cast_possible_wrap)]
     fn seek_to(&mut self, position: Duration) {
         self.command_tx
-            .send(PlayerInternalCmd::SeekAbsolute(position.as_secs() as i64))
+            .send(PlayerInternalCmd::SeekAbsolute(position))
             .ok();
     }
     fn speed(&self) -> i32 {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -326,9 +326,9 @@ impl PlayerTrait for MpvBackend {
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn seek_to(&mut self, last_pos: Duration) {
+    fn seek_to(&mut self, position: Duration) {
         self.command_tx
-            .send(PlayerInternalCmd::SeekAbsolute(last_pos.as_secs() as i64))
+            .send(PlayerInternalCmd::SeekAbsolute(position.as_secs() as i64))
             .ok();
     }
     fn speed(&self) -> i32 {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -267,8 +267,8 @@ impl PlayerTrait for RustyBackend {
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn seek_to(&mut self, time: Duration) {
-        let time_i64 = time.as_secs() as i64;
+    fn seek_to(&mut self, position: Duration) {
+        let time_i64 = position.as_secs() as i64;
         self.command(PlayerInternalCmd::Seek(time_i64));
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -55,7 +55,7 @@ pub enum PlayerInternalCmd {
     Progress(Duration),
     QueueNext(String, bool),
     Resume,
-    Seek(i64),
+    SeekAbsolute(i64),
     SeekRelative(i64),
     Skip,
     Speed(i32),
@@ -269,7 +269,7 @@ impl PlayerTrait for RustyBackend {
     #[allow(clippy::cast_possible_wrap)]
     fn seek_to(&mut self, position: Duration) {
         let time_i64 = position.as_secs() as i64;
-        self.command(PlayerInternalCmd::Seek(time_i64));
+        self.command(PlayerInternalCmd::SeekAbsolute(time_i64));
     }
 
     fn speed_up(&mut self) {
@@ -609,7 +609,7 @@ fn player_thread(
                     }
                 }
             }
-            PlayerInternalCmd::Seek(d_i64) => {
+            PlayerInternalCmd::SeekAbsolute(d_i64) => {
                 sink.seek(Duration::from_secs(d_i64 as u64));
             }
             PlayerInternalCmd::MessageOnEnd => {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -55,7 +55,7 @@ pub enum PlayerInternalCmd {
     Progress(Duration),
     QueueNext(String, bool),
     Resume,
-    SeekAbsolute(i64),
+    SeekAbsolute(Duration),
     SeekRelative(i64),
     Skip,
     Speed(i32),
@@ -268,8 +268,7 @@ impl PlayerTrait for RustyBackend {
 
     #[allow(clippy::cast_possible_wrap)]
     fn seek_to(&mut self, position: Duration) {
-        let time_i64 = position.as_secs() as i64;
-        self.command(PlayerInternalCmd::SeekAbsolute(time_i64));
+        self.command(PlayerInternalCmd::SeekAbsolute(position));
     }
 
     fn speed_up(&mut self) {
@@ -609,8 +608,8 @@ fn player_thread(
                     }
                 }
             }
-            PlayerInternalCmd::SeekAbsolute(d_i64) => {
-                sink.seek(Duration::from_secs(d_i64 as u64));
+            PlayerInternalCmd::SeekAbsolute(position) => {
+                sink.seek(position);
             }
             PlayerInternalCmd::MessageOnEnd => {
                 sink.message_on_end();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -55,7 +55,6 @@ impl PlayerStats {
 
     pub fn as_getprogress_response(&self) -> GetProgressResponse {
         GetProgressResponse {
-            // TODO: refactor proto definition to use duration
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: self.status,


### PR DESCRIPTION
This PR touches the definition of seeking slightly, in more details:
- remove a TODO which was added (and also done) in #216 (which i forgot to remove)
- add doc-comments to seek definition
- change (and consistentize) `seek_to` parameter name
- allow `seek_to` to be more precise in all backends (rusty, mpv, gst)
- rusty backend: rename a event to be more obvious what it is