### PR TITLE
Refactor `PlayerTrait`'s volume

### DIFF
--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -290,7 +290,7 @@ pub struct Settings {
     pub max_depth_cli: usize,
     pub player_port: u16,
     pub player_loop_mode: Loop,
-    pub player_volume: i32,
+    pub player_volume: u16,
     pub player_speed: i32,
     pub player_gapless: bool,
     pub podcast_simultanious_download: usize,

--- a/playback/proto/player.proto
+++ b/playback/proto/player.proto
@@ -37,7 +37,8 @@ message GetProgressResponse{
   PlayerTime progress = 1;
   uint32 current_track_index = 3;
   uint32 status = 4;
-  int32 volume = 5;
+  // actually a u16, but protobuf does not support types lower than 32 bits
+  uint32 volume = 5;
   int32 speed = 6;
   bool gapless = 7;
   bool current_track_updated = 8;
@@ -47,7 +48,8 @@ message GetProgressResponse{
 message VolumeUpRequest {}
 message VolumeDownRequest {}
 message VolumeReply {
-  int32 volume = 1;
+  // actually a u16, but protobuf does not support types lower than 32 bits
+  uint32 volume = 1;
 }
 message CycleLoopRequest {}
 message CycleLoopReply {}

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -239,7 +239,7 @@ impl GStreamerBackend {
             _bus_watch_guard: bus_watch,
         };
 
-        this.set_volume(i32::from(volume));
+        this.set_volume(volume);
         this.set_speed(speed);
 
         // Send a signal to enqueue the next media before the current finished
@@ -354,21 +354,20 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn volume_up(&mut self) {
-        self.set_volume(i32::from(self.volume.saturating_add(5)));
+        self.set_volume(self.volume.saturating_add(5));
     }
 
     fn volume_down(&mut self) {
-        self.set_volume(i32::from(self.volume.saturating_sub(5)));
+        self.set_volume(self.volume.saturating_sub(5));
     }
 
-    fn volume(&self) -> i32 {
-        self.volume.into()
+    fn volume(&self) -> u16 {
+        self.volume
     }
 
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn set_volume(&mut self, volume: i32) {
-        let volume = volume.max(0).min(100);
-        self.volume = volume as u16;
+    fn set_volume(&mut self, volume: u16) {
+        let volume = volume.min(100);
+        self.volume = volume;
         self.set_volume_inside(f64::from(volume) / 100.0);
     }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -31,7 +31,6 @@ use gst::{event::Seek, Element, SeekFlags, SeekType};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use parking_lot::Mutex;
-use std::cmp;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::Sender;
@@ -354,21 +353,19 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn volume_up(&mut self) {
-        self.volume = cmp::min(self.volume + 5, 100);
-        self.set_volume_inside(f64::from(self.volume) / 100.0);
+        self.set_volume(self.volume + 5);
     }
 
     fn volume_down(&mut self) {
-        self.volume = cmp::max(self.volume - 5, 0);
-        self.set_volume_inside(f64::from(self.volume) / 100.0);
+        self.set_volume(self.volume - 5);
     }
 
     fn volume(&self) -> i32 {
         self.volume
     }
 
-    fn set_volume(&mut self, mut volume: i32) {
-        volume = volume.max(0);
+    fn set_volume(&mut self, volume: i32) {
+        let volume = volume.max(0).min(100);
         self.volume = volume;
         self.set_volume_inside(f64::from(volume) / 100.0);
     }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -224,8 +224,7 @@ impl GStreamerBackend {
             }
         });
 
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        let volume = config.player_volume.max(0).min(u16::MAX.into()) as u16;
+        let volume = config.player_volume;
         let speed = config.player_speed;
         let gapless = config.player_gapless;
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -564,7 +564,7 @@ impl PlayerTrait for GeneralPlayer {
     async fn add_and_play(&mut self, current_track: &Track) {
         self.get_player_mut().add_and_play(current_track).await;
     }
-    fn volume(&self) -> i32 {
+    fn volume(&self) -> u16 {
         self.get_player().volume()
     }
     fn volume_up(&mut self) {
@@ -573,7 +573,7 @@ impl PlayerTrait for GeneralPlayer {
     fn volume_down(&mut self) {
         self.get_player_mut().volume_down();
     }
-    fn set_volume(&mut self, volume: i32) {
+    fn set_volume(&mut self, volume: u16) {
         self.get_player_mut().set_volume(volume);
     }
     fn pause(&mut self) {
@@ -675,10 +675,10 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
 #[async_trait]
 pub trait PlayerTrait {
     async fn add_and_play(&mut self, current_track: &Track);
-    fn volume(&self) -> i32;
+    fn volume(&self) -> u16;
     fn volume_up(&mut self);
     fn volume_down(&mut self);
-    fn set_volume(&mut self, volume: i32);
+    fn set_volume(&mut self, volume: u16);
     fn pause(&mut self);
     fn resume(&mut self);
     fn is_paused(&self) -> bool;

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -185,8 +185,8 @@ impl GeneralPlayer {
                 }
                 // convert a 0.0 to 1.0 range to 0 to 100, because that is what termusic uses for volume
                 // default float to int casting will truncate values to the decimal point
-                #[allow(clippy::cast_possible_truncation)]
-                let uvol = (volume.clamp(0.0, 1.0) * 100.0) as i32;
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let uvol = (volume.clamp(0.0, 1.0) * 100.0) as u16;
                 self.set_volume(uvol);
             }
             MediaControlEvent::Quit => {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -71,8 +71,7 @@ impl MpvBackend {
     pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
         let (command_tx, command_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
-        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        let volume = config.player_volume.max(0).min(u16::MAX.into()) as u16;
+        let volume = config.player_volume;
         let speed = config.player_speed;
         let gapless = config.player_gapless;
         let position = Arc::new(Mutex::new(Duration::default()));

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -289,20 +289,20 @@ impl PlayerTrait for MpvBackend {
         self.queue_and_play(current_item);
     }
 
-    fn volume(&self) -> i32 {
-        self.volume.into()
+    fn volume(&self) -> u16 {
+        self.volume
     }
 
     fn volume_up(&mut self) {
-        self.set_volume(i32::from(self.volume.saturating_add(5)));
+        self.set_volume(self.volume.saturating_add(5));
     }
 
     fn volume_down(&mut self) {
-        self.set_volume(i32::from(self.volume.saturating_sub(5)));
+        self.set_volume(self.volume.saturating_sub(5));
     }
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn set_volume(&mut self, volume: i32) {
-        self.volume = volume.max(0).min(100) as u16;
+
+    fn set_volume(&mut self, volume: u16) {
+        self.volume = volume.min(100);
         self.command_tx
             .send(PlayerInternalCmd::Volume(self.volume))
             .ok();

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -293,13 +293,11 @@ impl PlayerTrait for MpvBackend {
     }
 
     fn volume_up(&mut self) {
-        self.volume = cmp::min(self.volume + 5, 100);
-        self.set_volume(self.volume);
+        self.set_volume(self.volume.saturating_add(5));
     }
 
     fn volume_down(&mut self) {
-        self.volume = cmp::max(self.volume - 5, 0);
-        self.set_volume(self.volume);
+        self.set_volume(self.volume.saturating_sub(5));
     }
     fn set_volume(&mut self, volume: i32) {
         self.volume = volume.clamp(0, 100);

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -63,7 +63,7 @@ enum PlayerInternalCmd {
     SeekAbsolute(i64),
     Speed(i32),
     Stop,
-    Volume(i64),
+    Volume(u16),
 }
 
 impl MpvBackend {
@@ -196,7 +196,7 @@ impl MpvBackend {
                                 // .expect("Error loading file");
                             }
                             PlayerInternalCmd::Volume(volume) => {
-                                mpv.set_property("volume", volume).ok();
+                                mpv.set_property("volume", i64::from(volume)).ok();
                                 // .expect("Error increase volume");
                             }
                             PlayerInternalCmd::Pause => {
@@ -304,7 +304,7 @@ impl PlayerTrait for MpvBackend {
     fn set_volume(&mut self, volume: i32) {
         self.volume = volume.max(0).min(100) as u16;
         self.command_tx
-            .send(PlayerInternalCmd::Volume(i64::from(self.volume)))
+            .send(PlayerInternalCmd::Volume(self.volume))
             .ok();
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -89,9 +89,7 @@ impl RustyBackend {
         let (picmd_tx, picmd_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
         let picmd_tx_local = picmd_tx.clone();
-        let volume = Arc::new(AtomicU16::from(
-            config.player_volume.max(0).min(u16::MAX.into()) as u16,
-        ));
+        let volume = Arc::new(AtomicU16::from(config.player_volume));
         let volume_local = volume.clone();
         let speed = config.player_speed;
         let gapless = config.player_gapless;

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -248,11 +248,9 @@ impl PlayerTrait for RustyBackend {
         clippy::cast_lossless
     )]
     fn set_volume(&mut self, volume: i32) {
-        self.volume
-            .store(volume.clamp(0, 100) as u16, Ordering::SeqCst);
-        self.command(PlayerInternalCmd::Volume(
-            self.volume.load(Ordering::SeqCst),
-        ));
+        let volume = volume.max(0).min(100) as u16;
+        self.volume.store(volume, Ordering::SeqCst);
+        self.command(PlayerInternalCmd::Volume(volume));
     }
 
     fn pause(&mut self) {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -427,7 +427,7 @@ fn player_thread(
     let (_stream, handle) = OutputStream::try_default().unwrap();
     let mut sink = Sink::try_new(&handle, picmd_tx.clone(), pcmd_tx.clone()).unwrap();
     sink.set_speed(speed_inside as f32 / 10.0);
-    sink.set_volume(<f32 as From<_>>::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
+    sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
     loop {
         let cmd = match picmd_rx.recv_timeout(Duration::from_micros(100)) {
             Ok(v) => v,
@@ -584,12 +584,10 @@ fn player_thread(
             PlayerInternalCmd::Stop => {
                 sink = Sink::try_new(&handle, picmd_tx.clone(), pcmd_tx.clone()).unwrap();
                 sink.set_speed(speed_inside as f32 / 10.0);
-                sink.set_volume(
-                    <f32 as From<_>>::from(volume_inside.load(Ordering::Relaxed)) / 100.0,
-                );
+                sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
             }
             PlayerInternalCmd::Volume(volume) => {
-                sink.set_volume(volume as f32 / 100.0);
+                sink.set_volume(f32::from(volume) / 100.0);
                 volume_inside.store(volume, Ordering::SeqCst);
             }
             PlayerInternalCmd::Skip => {
@@ -647,9 +645,7 @@ fn player_thread(
                 if paused {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     sink.pause();
-                    sink.set_volume(
-                        <f32 as From<_>>::from(volume_inside.load(Ordering::Relaxed)) / 100.0,
-                    );
+                    sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
                 }
             }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -229,16 +229,16 @@ impl PlayerTrait for RustyBackend {
     }
 
     fn volume(&self) -> i32 {
-        self.volume.load(Ordering::Relaxed).into()
+        self.volume.load(Ordering::SeqCst).into()
     }
 
     fn volume_up(&mut self) {
-        let volume = i32::from(self.volume.load(Ordering::Relaxed)) + i32::from(VOLUME_STEP);
+        let volume = i32::from(self.volume.load(Ordering::SeqCst)) + i32::from(VOLUME_STEP);
         self.set_volume(volume);
     }
 
     fn volume_down(&mut self) {
-        let volume = i32::from(self.volume.load(Ordering::Relaxed)) - i32::from(VOLUME_STEP);
+        let volume = i32::from(self.volume.load(Ordering::SeqCst)) - i32::from(VOLUME_STEP);
         self.set_volume(volume);
     }
 
@@ -427,7 +427,7 @@ fn player_thread(
     let (_stream, handle) = OutputStream::try_default().unwrap();
     let mut sink = Sink::try_new(&handle, picmd_tx.clone(), pcmd_tx.clone()).unwrap();
     sink.set_speed(speed_inside as f32 / 10.0);
-    sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
+    sink.set_volume(f32::from(volume_inside.load(Ordering::SeqCst)) / 100.0);
     loop {
         let cmd = match picmd_rx.recv_timeout(Duration::from_micros(100)) {
             Ok(v) => v,
@@ -584,7 +584,7 @@ fn player_thread(
             PlayerInternalCmd::Stop => {
                 sink = Sink::try_new(&handle, picmd_tx.clone(), pcmd_tx.clone()).unwrap();
                 sink.set_speed(speed_inside as f32 / 10.0);
-                sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
+                sink.set_volume(f32::from(volume_inside.load(Ordering::SeqCst)) / 100.0);
             }
             PlayerInternalCmd::Volume(volume) => {
                 sink.set_volume(f32::from(volume) / 100.0);
@@ -645,7 +645,7 @@ fn player_thread(
                 if paused {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     sink.pause();
-                    sink.set_volume(f32::from(volume_inside.load(Ordering::Relaxed)) / 100.0);
+                    sink.set_volume(f32::from(volume_inside.load(Ordering::SeqCst)) / 100.0);
                 }
             }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -233,19 +233,22 @@ impl PlayerTrait for RustyBackend {
     }
 
     fn volume_up(&mut self) {
-        let volume = i32::from(self.volume.load(Ordering::SeqCst)) + i32::from(VOLUME_STEP);
-        self.set_volume(volume);
+        let volume = self
+            .volume
+            .load(Ordering::SeqCst)
+            .saturating_add(VOLUME_STEP);
+        self.set_volume(i32::from(volume));
     }
 
     fn volume_down(&mut self) {
-        let volume = i32::from(self.volume.load(Ordering::SeqCst)) - i32::from(VOLUME_STEP);
-        self.set_volume(volume);
+        let volume = self
+            .volume
+            .load(Ordering::SeqCst)
+            .saturating_sub(VOLUME_STEP);
+        self.set_volume(i32::from(volume));
     }
 
-    #[allow(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-    )]
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn set_volume(&mut self, volume: i32) {
         let volume = volume.max(0).min(100) as u16;
         self.volume.store(volume, Ordering::SeqCst);

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -245,7 +245,6 @@ impl PlayerTrait for RustyBackend {
     #[allow(
         clippy::cast_sign_loss,
         clippy::cast_possible_truncation,
-        clippy::cast_lossless
     )]
     fn set_volume(&mut self, volume: i32) {
         let volume = volume.max(0).min(100) as u16;

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -228,8 +228,8 @@ impl PlayerTrait for RustyBackend {
         self.play(current_track).await;
     }
 
-    fn volume(&self) -> i32 {
-        self.volume.load(Ordering::SeqCst).into()
+    fn volume(&self) -> u16 {
+        self.volume.load(Ordering::SeqCst)
     }
 
     fn volume_up(&mut self) {
@@ -237,7 +237,7 @@ impl PlayerTrait for RustyBackend {
             .volume
             .load(Ordering::SeqCst)
             .saturating_add(VOLUME_STEP);
-        self.set_volume(i32::from(volume));
+        self.set_volume(volume);
     }
 
     fn volume_down(&mut self) {
@@ -245,12 +245,11 @@ impl PlayerTrait for RustyBackend {
             .volume
             .load(Ordering::SeqCst)
             .saturating_sub(VOLUME_STEP);
-        self.set_volume(i32::from(volume));
+        self.set_volume(volume);
     }
 
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-    fn set_volume(&mut self, volume: i32) {
-        let volume = volume.max(0).min(100) as u16;
+    fn set_volume(&mut self, volume: u16) {
+        let volume = volume.min(100);
         self.volume.store(volume, Ordering::SeqCst);
         self.command(PlayerInternalCmd::Volume(volume));
     }

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -62,7 +62,7 @@ pub enum PlayerInternalCmd {
     Speed(i32),
     Stop,
     TogglePause,
-    Volume(i64),
+    Volume(u16),
     Eos,
 }
 pub struct RustyBackend {
@@ -251,7 +251,7 @@ impl PlayerTrait for RustyBackend {
         self.volume
             .store(volume.clamp(0, 100) as u16, Ordering::SeqCst);
         self.command(PlayerInternalCmd::Volume(
-            self.volume.load(Ordering::SeqCst).into(),
+            self.volume.load(Ordering::SeqCst),
         ));
     }
 
@@ -590,7 +590,7 @@ fn player_thread(
             }
             PlayerInternalCmd::Volume(volume) => {
                 sink.set_volume(volume as f32 / 100.0);
-                volume_inside.store(volume as u16, Ordering::SeqCst);
+                volume_inside.store(volume, Ordering::SeqCst);
             }
             PlayerInternalCmd::Skip => {
                 sink.skip_one();

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -199,7 +199,9 @@ impl MusicPlayer for MusicPlayerService {
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
-        let reply = VolumeReply { volume: r.volume };
+        let reply = VolumeReply {
+            volume: i32::from(r.volume),
+        };
 
         Ok(Response::new(reply))
     }
@@ -212,7 +214,9 @@ impl MusicPlayer for MusicPlayerService {
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
-        let reply = VolumeReply { volume: r.volume };
+        let reply = VolumeReply {
+            volume: i32::from(r.volume),
+        };
 
         Ok(Response::new(reply))
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -200,7 +200,7 @@ impl MusicPlayer for MusicPlayerService {
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
         let reply = VolumeReply {
-            volume: i32::from(r.volume),
+            volume: u32::from(r.volume),
         };
 
         Ok(Response::new(reply))
@@ -215,7 +215,7 @@ impl MusicPlayer for MusicPlayerService {
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
         let reply = VolumeReply {
-            volume: i32::from(r.volume),
+            volume: u32::from(r.volume),
         };
 
         Ok(Response::new(reply))

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -288,7 +288,7 @@ async fn actual_main() -> Result<()> {
                     info!("before volumedown: {}", player.volume());
                     player.volume_down();
                     let new_volume = player.volume();
-                    config.player_volume = i32::from(new_volume);
+                    config.player_volume = new_volume;
                     info!("after volumedown: {}", player.volume());
                     let mut p_tick = playerstats.lock();
                     p_tick.volume = new_volume;
@@ -297,7 +297,7 @@ async fn actual_main() -> Result<()> {
                     info!("before volumeup: {}", player.volume());
                     player.volume_up();
                     let new_volume = player.volume();
-                    config.player_volume = i32::from(new_volume);
+                    config.player_volume = new_volume;
                     info!("after volumeup: {}", player.volume());
                     let mut p_tick = playerstats.lock();
                     p_tick.volume = new_volume;

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -59,7 +59,7 @@ impl PlayerStats {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: self.status,
-            volume: i32::from(self.volume),
+            volume: u32::from(self.volume),
             speed: self.speed,
             gapless: self.gapless,
             current_track_updated: self.current_track_updated,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -29,7 +29,7 @@ struct PlayerStats {
     pub progress: PlayerProgress,
     pub current_track_index: u32,
     pub status: u32,
-    pub volume: i32,
+    pub volume: u16,
     pub speed: i32,
     pub gapless: bool,
     pub current_track_updated: bool,
@@ -59,7 +59,7 @@ impl PlayerStats {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: self.status,
-            volume: self.volume,
+            volume: i32::from(self.volume),
             speed: self.speed,
             gapless: self.gapless,
             current_track_updated: self.current_track_updated,
@@ -287,18 +287,20 @@ async fn actual_main() -> Result<()> {
                 PlayerCmd::VolumeDown => {
                     info!("before volumedown: {}", player.volume());
                     player.volume_down();
-                    config.player_volume = i32::from(player.volume());
+                    let new_volume = player.volume();
+                    config.player_volume = i32::from(new_volume);
                     info!("after volumedown: {}", player.volume());
                     let mut p_tick = playerstats.lock();
-                    p_tick.volume = config.player_volume;
+                    p_tick.volume = new_volume;
                 }
                 PlayerCmd::VolumeUp => {
                     info!("before volumeup: {}", player.volume());
                     player.volume_up();
-                    config.player_volume = i32::from(player.volume());
+                    let new_volume = player.volume();
+                    config.player_volume = i32::from(new_volume);
                     info!("after volumeup: {}", player.volume());
                     let mut p_tick = playerstats.lock();
-                    p_tick.volume = config.player_volume;
+                    p_tick.volume = new_volume;
                 }
                 PlayerCmd::Pause => {
                     player.pause();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -287,7 +287,7 @@ async fn actual_main() -> Result<()> {
                 PlayerCmd::VolumeDown => {
                     info!("before volumedown: {}", player.volume());
                     player.volume_down();
-                    config.player_volume = player.volume();
+                    config.player_volume = i32::from(player.volume());
                     info!("after volumedown: {}", player.volume());
                     let mut p_tick = playerstats.lock();
                     p_tick.volume = config.player_volume;
@@ -295,7 +295,7 @@ async fn actual_main() -> Result<()> {
                 PlayerCmd::VolumeUp => {
                     info!("before volumeup: {}", player.volume());
                     player.volume_up();
-                    config.player_volume = player.volume();
+                    config.player_volume = i32::from(player.volume());
                     info!("after volumeup: {}", player.volume());
                     let mut p_tick = playerstats.lock();
                     p_tick.volume = config.player_volume;

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -275,12 +275,12 @@ impl UI {
                 }
                 PlayerCmd::VolumeDown => {
                     let volume = self.playback.volume_down().await?;
-                    self.model.config.player_volume = i32::from(volume);
+                    self.model.config.player_volume = volume;
                     self.model.progress_update_title();
                 }
                 PlayerCmd::VolumeUp => {
                     let volume = self.playback.volume_up().await?;
-                    self.model.config.player_volume = i32::from(volume);
+                    self.model.config.player_volume = volume;
                     self.model.progress_update_title();
                 }
                 _ => {}

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -275,12 +275,12 @@ impl UI {
                 }
                 PlayerCmd::VolumeDown => {
                     let volume = self.playback.volume_down().await?;
-                    self.model.config.player_volume = volume;
+                    self.model.config.player_volume = i32::from(volume);
                     self.model.progress_update_title();
                 }
                 PlayerCmd::VolumeUp => {
                     let volume = self.playback.volume_up().await?;
-                    self.model.config.player_volume = volume;
+                    self.model.config.player_volume = i32::from(volume);
                     self.model.progress_update_title();
                 }
                 _ => {}

--- a/tui/src/ui/playback.rs
+++ b/tui/src/ui/playback.rs
@@ -42,20 +42,24 @@ impl Playback {
         Ok(response)
     }
 
-    pub async fn volume_up(&mut self) -> Result<i32> {
+    pub async fn volume_up(&mut self) -> Result<u16> {
         let request = tonic::Request::new(VolumeUpRequest {});
         let response = self.client.volume_up(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
-        Ok(response.volume)
+        // clamped to u16::MAX, also send is a u16, but protobuf does not support u16 directly
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(response.volume.min(u32::from(u16::MAX)) as u16)
     }
 
-    pub async fn volume_down(&mut self) -> Result<i32> {
+    pub async fn volume_down(&mut self) -> Result<u16> {
         let request = tonic::Request::new(VolumeDownRequest {});
         let response = self.client.volume_down(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
-        Ok(response.volume)
+        // clamped to u16::MAX, also send is a u16, but protobuf does not support u16 directly
+        #[allow(clippy::cast_possible_truncation)]
+        Ok(response.volume.min(u32::from(u16::MAX)) as u16)
     }
 
     pub async fn cycle_loop(&mut self) -> Result<()> {


### PR DESCRIPTION
This PR refactors `PlayerTrait`'s volume functions to take / return `u16`, including all backends and config, in more details:
- store volume as `u16` on all backends instead of `i32`
- store volume as `u16` in the config (which makes configs invalid which have negative volumes or way too high of volumes; which requires manual editing to even achieve)
- change proto definition to use `uint32` (no sizes below 32 bits are available in protobuf)

Why `u16` instead of something else like staying with `i32` or using `f32`?
I think `u16` is the best choice for the current spec, because:
- volume is never negative so signed values (`i*`) should fall out (as half would never be used)
- we are currently using volume as percent (both in tui, settings and config), so changing to floats (without the * 100 scaling) would be heavily breaking (it would likely also incur a incompatibility with existing configs)
- as for higher / lower bit types, `u8` *would* fit and allow to go way higher than we currently support (0 to 100), up to 255, but the backends also *could* go higher than that (even though it would likely not be practical), and anything higher than `u16` would likely be way overkill and so wasted space.

@tramhao is `u16` fine, or should it be changed to `u8`, or should a completely different type be used?