### PR TITLE
Better version in `--version` via git

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Default backend: `rusty`
 #### MSRV
 You will need to build with the stable rust toolchain. Minimal Supported Rust Version 1.70.0.
 
+### git
+
+`git` will be required to build the package.
 
 =======
 | Backend   | Requirements                                                                                                                                                                                                                                                                       |

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    // set what version string to use for the build
+    // currently it depends on what git outputs, or if failed use "unknown"
+    {
+        // paths are relative to the workspace root
+        println!("cargo:rerun-if-changed=server/build.rs");
+        println!("cargo:rerun-if-changed=.git/HEAD");
+
+        // How to read the version:
+        // Termusic-server v0.7.11-302-g63396ee5-dirty
+        // "Termusic-server" is the binary name
+        // "v0.7.11" is the latest tag on the branch
+        // "302" is the number of commits since the tag
+        // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
+        // the rest "63396ee5" is the abbreviated commit sha
+        // "dirty" indicates the build has uncommited changes
+        let version = Command::new("git")
+            .args(["describe", "--tags", "--always", "--dirty"])
+            .output()
+            .ok()
+            .and_then(|v| String::from_utf8(v.stdout).ok())
+            .unwrap_or(String::from("unknown"));
+        println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
+    }
+}

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -27,9 +27,10 @@ use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 use termusicplayback::BackendSelect;
 
 #[derive(Parser, Debug)]
-#[clap(name = "Termusic-server", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)] // Read from `Cargo.toml`
-                                                                                                      // #[clap(next_line_help = true)]
-                                                                                                      // #[clap(propagate_version = true)]
+// mostly read from `Cargo.toml`
+#[clap(name = "Termusic-server", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)]
+// #[clap(next_line_help = true)]
+// #[clap(propagate_version = true)]
 pub struct Args {
     /// Commands for podcast
     #[command(subcommand)]

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -27,9 +27,9 @@ use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 use termusicplayback::BackendSelect;
 
 #[derive(Parser, Debug)]
-#[clap(name = "Termusic-server", author, version, about, long_about=None)] // Read from `Cargo.toml`
-                                                                           // #[clap(next_line_help = true)]
-                                                                           // #[clap(propagate_version = true)]
+#[clap(name = "Termusic-server", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)] // Read from `Cargo.toml`
+                                                                                                      // #[clap(next_line_help = true)]
+                                                                                                      // #[clap(propagate_version = true)]
 pub struct Args {
     /// Commands for podcast
     #[command(subcommand)]

--- a/tui/build.rs
+++ b/tui/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    // set what version string to use for the build
+    // currently it depends on what git outputs, or if failed use "unknown"
+    {
+        // paths are relative to the workspace root
+        println!("cargo:rerun-if-changed=tui/build.rs");
+        println!("cargo:rerun-if-changed=.git/HEAD");
+
+        // How to read the version:
+        // Termusic v0.7.11-302-g63396ee5-dirty
+        // "Termusic" is the binary name
+        // "v0.7.11" is the latest tag on the branch
+        // "302" is the number of commits since the tag
+        // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
+        // the rest "63396ee5" is the abbreviated commit sha
+        // "dirty" indicates the build has uncommited changes
+        let version = Command::new("git")
+            .args(["describe", "--tags", "--always", "--dirty"])
+            .output()
+            .ok()
+            .and_then(|v| String::from_utf8(v.stdout).ok())
+            .unwrap_or(String::from("unknown"));
+        println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
+    }
+}

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -26,9 +26,9 @@ use std::path::PathBuf;
 use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
-#[clap(name = "Termusic", author, version, about, long_about=None)] // Read from `Cargo.toml`
-                                                                    // #[clap(next_line_help = true)]
-                                                                    // #[clap(propagate_version = true)]
+#[clap(name = "Termusic", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)] // Read from `Cargo.toml`
+                                                                                               // #[clap(next_line_help = true)]
+                                                                                               // #[clap(propagate_version = true)]
 pub struct Args {
     /// Commands for podcast
     #[command(subcommand)]

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -26,9 +26,10 @@ use std::path::PathBuf;
 use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
-#[clap(name = "Termusic", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)] // Read from `Cargo.toml`
-                                                                                               // #[clap(next_line_help = true)]
-                                                                                               // #[clap(propagate_version = true)]
+// mostly read from `Cargo.toml`
+#[clap(name = "Termusic", author, version = env!("TERMUSIC_VERSION"), about, long_about=None)]
+// #[clap(next_line_help = true)]
+// #[clap(propagate_version = true)]
 pub struct Args {
     /// Commands for podcast
     #[command(subcommand)]


### PR DESCRIPTION
This PR changes it so that `--version` better represents what actual version is in use.
This means now `git` (and being in the repository) is a required build dependency.

new possible formats:
`Termusic v0.7.11` - release
`Termusic v0.7.11-302-g63396ee5` - nightly (or only commited changes)
`Termusic v0.7.11-302-g63396ee5-dirty` - dev (uncommited changes)
`unknown` - `git` is missing or errored (like not being in a repository)

explanation of the different parts:
`Termusic` is the binary name (first letter capitalized)
`v0.7.11` is the latest tag on the branch
`302` is the number of commits since the tag
`g63396ee5` is 2 parts, the `g` in the beginning means `git`
the rest `63396ee5` is the abbreviated commit sha
`dirty` indicates the build has uncommited changes

These changes *should* work with the release build properly, as those builds are only [triggered on tags](https://github.com/tramhao/termusic/blob/d3efb1355810fa132bc98c9e2ea2d396de1dc581/.github/workflows/release.yml#L6-L8).

the only downside i can think of is that now the version in `Cargo.toml` is *not* being used as a version in `--version`, which *could* lead to de-syncs of versions.

PS: this PR also removes some ridiculous indentation from both `cli.rs` files