### PR TITLE
Refactor `ueberzug` instance

### DIFF
--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -5,6 +5,7 @@ use std::process::Child;
 use std::process::Stdio;
 use std::sync::RwLock;
 
+#[derive(Debug)]
 pub struct UeInstance {
     ueberzug: RwLock<Option<Child>>,
 }

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -2,24 +2,59 @@ use crate::config::Xywh;
 use anyhow::{bail, Result};
 use std::io::Write;
 use std::process::Child;
+use std::process::Command;
 use std::process::Stdio;
-use std::sync::RwLock;
 
 #[derive(Debug)]
+pub enum UeInstanceState {
+    New,
+    Child(Child),
+    /// Permanent Error
+    Error,
+}
+
+impl PartialEq for UeInstanceState {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Child(_), Self::Child(_)) => true,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+impl UeInstanceState {
+    /// unwrap value in [`UeInstanceState::Child`], panicing if not that variant
+    fn unwrap_child_mut(&mut self) -> &mut Child {
+        if let Self::Child(v) = self {
+            return v;
+        }
+        unreachable!()
+    }
+}
+
+/// Run `ueberzug` commands
+///
+/// If there is a permanent error (like `ueberzug` not being installed), will silently ignore all commands after initial error
+#[derive(Debug)]
 pub struct UeInstance {
-    ueberzug: RwLock<Option<Child>>,
+    ueberzug: UeInstanceState,
 }
 
 impl Default for UeInstance {
     fn default() -> Self {
         Self {
-            ueberzug: RwLock::new(None),
+            ueberzug: UeInstanceState::New,
         }
     }
 }
 
 impl UeInstance {
-    pub fn draw_cover_ueberzug(&self, url: &str, draw_xywh: &Xywh, use_sixel: bool) -> Result<()> {
+    pub fn draw_cover_ueberzug(
+        &mut self,
+        url: &str,
+        draw_xywh: &Xywh,
+        use_sixel: bool,
+    ) -> Result<()> {
         if draw_xywh.width <= 1 || draw_xywh.height <= 1 {
             return Ok(());
         }
@@ -55,7 +90,7 @@ impl UeInstance {
         Ok(())
     }
 
-    pub fn clear_cover_ueberzug(&self) -> Result<()> {
+    pub fn clear_cover_ueberzug(&mut self) -> Result<()> {
         let cmd = "{\"action\": \"remove\", \"identifier\": \"cover\"}\n";
         if let Err(e) = self.run_ueberzug_cmd(cmd) {
             bail!("Failed to run Ueberzug: {}", e)
@@ -64,48 +99,75 @@ impl UeInstance {
         Ok(())
     }
 
-    fn run_ueberzug_cmd(&self, cmd: &str) -> Result<()> {
-        let mut ueberzug = self.ueberzug.write().unwrap();
-
+    fn run_ueberzug_cmd(&mut self, cmd: &str) -> Result<()> {
         // error!("using x11 output for ueberzugpp");
 
-        if ueberzug.is_none() {
-            *ueberzug = Some(
-                std::process::Command::new("ueberzug")
+        let ueberzug = match self.ueberzug {
+            UeInstanceState::New => self.spawn_cmd(
+                Command::new("ueberzug")
                     .args(["layer", "--silent"])
                     .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()?,
-            );
-        }
+                    .stdout(Stdio::piped()),
+            )?,
+            UeInstanceState::Child(ref mut v) => v,
+            UeInstanceState::Error => return on_error(),
+        };
 
-        let stdin = (*ueberzug).as_mut().unwrap().stdin.as_mut().unwrap();
+        let stdin = ueberzug.stdin.as_mut().unwrap();
         stdin.write_all(cmd.as_bytes())?;
 
         Ok(())
     }
 
-    fn run_ueberzug_cmd_sixel(&self, cmd: &str) -> Result<()> {
-        let mut ueberzug = self.ueberzug.write().unwrap();
-
+    fn run_ueberzug_cmd_sixel(&mut self, cmd: &str) -> Result<()> {
         // error!("using sixel output for ueberzugpp");
 
-        if ueberzug.is_none() {
-            *ueberzug = Some(
-                std::process::Command::new("ueberzug")
-                    .args(["layer", "--silent"])
-                    // .args(["layer", "--silent", "--no-cache", "--output", "sixel"])
-                    // .args(["layer", "--sixel"])
-                    // .args(["--sixel"])
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .spawn()?,
-            );
-        }
+        let ueberzug = match self.ueberzug {
+            UeInstanceState::New => {
+                self.spawn_cmd(
+                    Command::new("ueberzug")
+                        .args(["layer", "--silent"])
+                        // .args(["layer", "--silent", "--no-cache", "--output", "sixel"])
+                        // .args(["layer", "--sixel"])
+                        // .args(["--sixel"])
+                        .stdin(Stdio::piped())
+                        .stdout(Stdio::piped()),
+                )?
+            }
+            UeInstanceState::Child(ref mut v) => v,
+            UeInstanceState::Error => return on_error(),
+        };
 
-        let stdin = (*ueberzug).as_mut().unwrap().stdin.as_mut().unwrap();
+        let stdin = ueberzug.stdin.as_mut().unwrap();
         stdin.write_all(cmd.as_bytes())?;
 
         Ok(())
     }
+
+    /// Spawn the given `cmd`, and set `self.ueberzug` and return a reference to the child for direct use
+    ///
+    /// On fail, also set `set.ueberzug` to [`UeInstanceState::Error`]
+    fn spawn_cmd(&mut self, cmd: &mut Command) -> Result<&mut Child> {
+        match cmd.spawn() {
+            Ok(child) => {
+                self.ueberzug = UeInstanceState::Child(child);
+                return Ok(self.ueberzug.unwrap_child_mut());
+            }
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    self.ueberzug = UeInstanceState::Error;
+                }
+                bail!(err)
+            }
+        }
+    }
+}
+
+/// Small helper to always print a message and return a consistent return
+#[inline]
+#[allow(clippy::unnecessary_wraps)]
+fn on_error() -> Result<()> {
+    info!("Not re-trying ueberzug, because it has a permanent error!");
+
+    Ok(())
 }

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -76,26 +76,17 @@ impl UeInstance {
         //     draw_xywh.x, draw_xywh.y, draw_xywh.width, draw_xywh.height,
         // );
         if use_sixel {
-            if let Err(e) = self.run_ueberzug_cmd_sixel(&cmd) {
-                bail!("Failed to run Ueberzug: {}", e)
-                // Ok(())
-            }
-            return Ok(());
-        }
+            self.run_ueberzug_cmd_sixel(&cmd).map_err(map_err)?;
+        } else {
+            self.run_ueberzug_cmd(&cmd).map_err(map_err)?;
+        };
 
-        if let Err(e) = self.run_ueberzug_cmd(&cmd) {
-            bail!("Failed to run Ueberzug: {}", e)
-            // Ok(())
-        }
         Ok(())
     }
 
     pub fn clear_cover_ueberzug(&mut self) -> Result<()> {
         let cmd = "{\"action\": \"remove\", \"identifier\": \"cover\"}\n";
-        if let Err(e) = self.run_ueberzug_cmd(cmd) {
-            bail!("Failed to run Ueberzug: {}", e)
-            // Ok(())
-        }
+        self.run_ueberzug_cmd(cmd).map_err(map_err)?;
         Ok(())
     }
 
@@ -170,4 +161,12 @@ fn on_error() -> Result<()> {
     info!("Not re-trying ueberzug, because it has a permanent error!");
 
     Ok(())
+}
+
+/// Map a given error to include extra context
+#[inline]
+#[allow(clippy::needless_pass_by_value)]
+fn map_err(err: anyhow::Error) -> anyhow::Error {
+    // err.context("Failed to run Ueberzug")
+    anyhow::anyhow!("Failed to run Ueberzug: {}", err)
 }

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -204,7 +204,7 @@ impl Model {
                             .map_err(|e| anyhow!("viuer print error: {}", e))?;
                     }
                     ViuerSupported::NotSupported => {
-                        #[cfg(feature = "cover")]
+                        #[cfg(all(feature = "cover", not(target_os = "windows")))]
                         {
                             let mut cache_file =
                                 dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
@@ -266,7 +266,7 @@ impl Model {
             // }
             // ViuerSupported::NotSupported | ViuerSupported::Sixel => {
             ViuerSupported::NotSupported => {
-                #[cfg(feature = "cover")]
+                #[cfg(all(feature = "cover", not(target_os = "windows")))]
                 self.ueberzug_instance.clear_cover_ueberzug()?;
             }
         }

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -28,7 +28,7 @@ use crate::ui::Application;
 use termusiclib::sqlite::{DataBase, SearchCriteria};
 use termusiclib::types::{Id, Msg, SearchLyricState, YoutubeOptions};
 
-#[cfg(feature = "cover")]
+#[cfg(all(feature = "cover", not(target_os = "windows")))]
 use termusiclib::ueberzug::UeInstance;
 use termusiclib::{
     config::Settings,
@@ -83,7 +83,7 @@ pub struct Model {
     pub time_pos: Duration,
     pub lyric_line: String,
     youtube_options: YoutubeOptions,
-    #[cfg(feature = "cover")]
+    #[cfg(all(feature = "cover", not(target_os = "windows")))]
     pub ueberzug_instance: UeInstance,
     pub songtag_options: Vec<SongTag>,
     pub sender_songtag: Sender<SearchLyricState>,
@@ -141,7 +141,7 @@ impl Model {
         // let viuer_supported =
         //     viuer::KittySupport::None != viuer::get_kitty_support() || viuer::is_iterm_supported();
 
-        #[cfg(feature = "cover")]
+        #[cfg(all(feature = "cover", not(target_os = "windows")))]
         let ueberzug_instance = UeInstance::default();
         let db_path = get_app_config_path().expect("failed to get podcast db path.");
 
@@ -177,7 +177,7 @@ impl Model {
             youtube_options: tokio::task::spawn_blocking(YoutubeOptions::default)
                 .await
                 .expect("Failed to initialize YoutubeOptions in a blocking task due to a panic"),
-            #[cfg(feature = "cover")]
+            #[cfg(all(feature = "cover", not(target_os = "windows")))]
             ueberzug_instance,
             songtag_options: vec![],
             sender_songtag: tx3,

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -441,6 +441,7 @@ impl Model {
     }
     // Mount error and give focus to it
     pub fn mount_error_popup<S: AsRef<str>>(&mut self, err: S) {
+        error!("Displaying error popup: {}", err.as_ref());
         assert!(self
             .app
             .remount(Id::ErrorPopup, Box::new(ErrorPopup::new(err)), vec![])


### PR DESCRIPTION
This PR refactors how `ueberzug` is handled in error cases and windows, in more detail:
- dont re-try starting `ueberzug` on a permanent error (like binary not found)
- disable `ueberzug` even if feature `cover` is enabled on `windows`
- some general de-duplication in `ueberzug` instance

fixes #202 

PS: i do not know if the `not(target_os = "windows")` also affect mingw as i didnt find any documentation if mingw counts as that `target_os`