### PR TITLE
Update uerberzug references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can optionally install [yt-dlp](https://github.com/yt-dlp/yt-dlp/) and [FFmp
 
 #### Album cover support
 
-For kitty, album cover support is default. For other terminals, need ueberzug installed and `cover` feature flag compiled.
+For kitty, album cover support is default. For other terminals, need ueberzug/ueberzugpp installed and `cover` feature flag compiled.
 
 ### Packages
 
@@ -142,7 +142,7 @@ make install
 ```
 
 By default, termusic can display album covers in Kitty or iTerm2 (mac, not tested).
-If you need album covers displayed on other terminals, please install [ueberzug](https://github.com/seebye/ueberzug), then:
+If you need album covers displayed on other terminals, please install [ueberzug](https://github.com/ueber-devel/ueberzug) or [ueberzugpp](https://github.com/jstkdng/ueberzugpp), then:
 
 ```bash
 make full


### PR DESCRIPTION
Ueberzug original repository was abandonned by its author. It was forked under a new organization for some time which is the new point of reference for distros.
Ueberzugpp is a drop-in replacement written in C++.

As those were mentioned twice in README, I hesitated if first occurrence would need links too, and could also write it something like `ueberzug[pp]` instead of the way I did.

I was not sure if README was the place to mention that `ueberzugpp` was a drop-in replacement, so I opted for not write it there. I can update those depending on feedbacks, of course.