### PR TITLE
Some Quality-of-Life improvements

### DIFF
--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -24,94 +24,97 @@ impl Default for Rpc {
         let mut artist = String::new();
         let mut title = String::new();
 
-        std::thread::spawn(move || loop {
-            match rx.try_recv() {
-                Ok(RpcCommand::Update(artist_cmd, title_cmd)) => {
-                    let assets = activity::Assets::new()
-                        .large_image("termusic")
-                        .large_text("terminal music player written in Rust");
-                    // .small_image(smol_image)
-                    // .small_text(state);
-                    let time = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs() as i64;
-                    let timestamp = activity::Timestamps::new().start(time);
-                    // .end(self.time + self.duration);
+        std::thread::Builder::new()
+            .name("discord rpc loop".into())
+            .spawn(move || loop {
+                match rx.try_recv() {
+                    Ok(RpcCommand::Update(artist_cmd, title_cmd)) => {
+                        let assets = activity::Assets::new()
+                            .large_image("termusic")
+                            .large_text("terminal music player written in Rust");
+                        // .small_image(smol_image)
+                        // .small_text(state);
+                        let time = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs() as i64;
+                        let timestamp = activity::Timestamps::new().start(time);
+                        // .end(self.time + self.duration);
 
-                    loop {
-                        if client.connect().is_ok() {
-                            break;
+                        loop {
+                            if client.connect().is_ok() {
+                                break;
+                            }
+                            sleep(Duration::from_secs(2));
                         }
-                        sleep(Duration::from_secs(2));
+
+                        artist = artist_cmd;
+                        title = title_cmd;
+
+                        client
+                            .set_activity(
+                                activity::Activity::new()
+                                    .assets(assets)
+                                    .timestamps(timestamp)
+                                    .state(&artist)
+                                    .details(&title),
+                            )
+                            .ok();
                     }
-
-                    artist = artist_cmd;
-                    title = title_cmd;
-
-                    client
-                        .set_activity(
-                            activity::Activity::new()
-                                .assets(assets)
-                                .timestamps(timestamp)
-                                .state(&artist)
-                                .details(&title),
-                        )
-                        .ok();
-                }
-                Ok(RpcCommand::Pause) => {
-                    loop {
-                        if client.connect().is_ok() {
-                            break;
+                    Ok(RpcCommand::Pause) => {
+                        loop {
+                            if client.connect().is_ok() {
+                                break;
+                            }
+                            sleep(Duration::from_secs(2));
                         }
-                        sleep(Duration::from_secs(2));
+
+                        let assets = activity::Assets::new()
+                            .large_image("termusic")
+                            .large_text("terminal music player written in Rust");
+
+                        client
+                            .set_activity(
+                                activity::Activity::new()
+                                    .assets(assets)
+                                    .state(&artist)
+                                    .details(format!("{}: Paused", title.as_str()).as_str()),
+                            )
+                            .ok();
                     }
+                    Ok(RpcCommand::Resume(time_pos)) => {
+                        let assets = activity::Assets::new()
+                            .large_image("termusic")
+                            .large_text("terminal music player written in Rust");
 
-                    let assets = activity::Assets::new()
-                        .large_image("termusic")
-                        .large_text("terminal music player written in Rust");
+                        let time = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs() as i64;
+                        let timestamp = activity::Timestamps::new().start(time - time_pos);
 
-                    client
-                        .set_activity(
-                            activity::Activity::new()
-                                .assets(assets)
-                                .state(&artist)
-                                .details(format!("{}: Paused", title.as_str()).as_str()),
-                        )
-                        .ok();
-                }
-                Ok(RpcCommand::Resume(time_pos)) => {
-                    let assets = activity::Assets::new()
-                        .large_image("termusic")
-                        .large_text("terminal music player written in Rust");
-
-                    let time = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs() as i64;
-                    let timestamp = activity::Timestamps::new().start(time - time_pos);
-
-                    loop {
-                        if client.connect().is_ok() {
-                            break;
+                        loop {
+                            if client.connect().is_ok() {
+                                break;
+                            }
+                            sleep(Duration::from_secs(2));
                         }
-                        sleep(Duration::from_secs(2));
-                    }
 
-                    client
-                        .set_activity(
-                            activity::Activity::new()
-                                .assets(assets)
-                                .timestamps(timestamp)
-                                .state(&artist)
-                                .details(&title),
-                        )
-                        .ok();
+                        client
+                            .set_activity(
+                                activity::Activity::new()
+                                    .assets(assets)
+                                    .timestamps(timestamp)
+                                    .state(&artist)
+                                    .details(&title),
+                            )
+                            .ok();
+                    }
+                    Err(_) => {}
                 }
-                Err(_) => {}
-            }
-            sleep(Duration::from_secs(1));
-        });
+                sleep(Duration::from_secs(1));
+            })
+            .expect("failed to start discord rpc loop thread");
 
         Self { tx }
     }

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -1,10 +1,11 @@
-use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
-use termusiclib::track::Track;
-const APP_ID: &str = "968407067889131520";
 use crate::PlayerTimeUnit;
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use termusiclib::track::Track;
+
+const APP_ID: &str = "968407067889131520";
 
 pub struct Rpc {
     tx: Sender<RpcCommand>,

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -33,7 +33,6 @@ use gstreamer::prelude::*;
 use parking_lot::Mutex;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::time::Duration;
 use termusiclib::config::Settings;
@@ -60,7 +59,7 @@ pub struct GStreamerBackend {
     volume: u16,
     speed: i32,
     pub gapless: bool,
-    pub message_tx: Sender<PlayerCmd>,
+    pub message_tx: async_channel::Sender<PlayerCmd>,
     pub radio_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }
@@ -83,11 +82,13 @@ impl GStreamerBackend {
 
         let eos_watcher_clone = eos_watcher.clone();
 
-        let (message_tx, message_rx) = std::sync::mpsc::channel();
+        // Asynchronous channel to communicate with main() with
+        let (main_tx, main_rx) = async_channel::bounded(3);
+        let message_tx = main_tx.clone();
         std::thread::Builder::new()
             .name("gstreamer event loop".into())
             .spawn(move || loop {
-                if let Ok(msg) = message_rx.try_recv() {
+                if let Ok(msg) = main_rx.try_recv() {
                     match msg {
                         PlayerCmd::Eos => {
                             if let Err(e) = cmd_tx.send(PlayerCmd::Eos) {
@@ -137,8 +138,6 @@ impl GStreamerBackend {
             .unwrap();
         playbin.set_property_from_value("flags", &flags);
 
-        // Asynchronous channel to communicate with main() with
-        let (main_tx, main_rx) = async_channel::bounded(3);
         // Handle messages from GStreamer bus
 
         let radio_title = Arc::new(Mutex::new(String::new()));
@@ -206,7 +205,6 @@ impl GStreamerBackend {
             }))
             .expect("Failed to connect to GStreamer message bus");
 
-        let tx = message_tx.clone();
         // extra thread to run the glib mainloop on
         std::thread::Builder::new()
             .name("gst glib mainloop".into())
@@ -214,13 +212,6 @@ impl GStreamerBackend {
                 mainloop.run();
             })
             .expect("failed to start gstreamer mainloop thread");
-
-        glib::spawn_future(async move {
-            while let Ok(msg) = main_rx.recv().await {
-                info!("{:?} received!!", msg);
-                tx.send(msg).ok();
-            }
-        });
 
         let volume = config.player_volume;
         let speed = config.player_speed;
@@ -249,7 +240,7 @@ impl GStreamerBackend {
         this
     }
     pub fn skip_one(&mut self) {
-        self.message_tx.send(PlayerCmd::SkipNext).ok();
+        self.message_tx.send_blocking(PlayerCmd::SkipNext).ok();
     }
     pub fn enqueue_next(&mut self, next_track: &str) {
         if next_track.starts_with("http") {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -58,8 +58,8 @@ pub struct GStreamerBackend {
     playbin: Element,
     volume: u16,
     speed: i32,
-    pub gapless: bool,
-    pub message_tx: async_channel::Sender<PlayerCmd>,
+    gapless: bool,
+    message_tx: async_channel::Sender<PlayerCmd>,
     pub radio_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -39,6 +39,8 @@ use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
 
+static VOLUME_STEP: u16 = 5;
+
 /// This trait allows for easy conversion of a path to a URI
 pub trait PathToURI {
     fn to_uri(&self) -> String;
@@ -349,11 +351,11 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn volume_up(&mut self) {
-        self.set_volume(self.volume.saturating_add(5));
+        self.set_volume(self.volume.saturating_add(VOLUME_STEP));
     }
 
     fn volume_down(&mut self) {
-        self.set_volume(self.volume.saturating_sub(5));
+        self.set_volume(self.volume.saturating_sub(VOLUME_STEP));
     }
 
     fn volume(&self) -> u16 {

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -45,11 +45,11 @@ pub struct MpvBackend {
     // player: Mpv,
     volume: u16,
     speed: i32,
-    pub gapless: bool,
+    gapless: bool,
     command_tx: Sender<PlayerInternalCmd>,
-    pub position: Arc<Mutex<Duration>>,
+    position: Arc<Mutex<Duration>>,
     // TODO: this should likely be a Option
-    pub duration: Arc<Mutex<Duration>>,
+    duration: Arc<Mutex<Duration>>,
     pub media_title: Arc<Mutex<String>>,
     // cmd_tx: crate::PlayerCmdSender,
 }

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -39,6 +39,8 @@ use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::Track;
 
+static VOLUME_STEP: u16 = 5;
+
 pub struct MpvBackend {
     // player: Mpv,
     volume: u16,
@@ -303,11 +305,11 @@ impl PlayerTrait for MpvBackend {
     }
 
     fn volume_up(&mut self) {
-        self.set_volume(self.volume.saturating_add(5));
+        self.set_volume(self.volume.saturating_add(VOLUME_STEP));
     }
 
     fn volume_down(&mut self) {
-        self.set_volume(self.volume.saturating_sub(5));
+        self.set_volume(self.volume.saturating_sub(VOLUME_STEP));
     }
 
     fn set_volume(&mut self, volume: u16) {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -63,10 +63,10 @@ pub enum PlayerInternalCmd {
 pub struct RustyBackend {
     volume: Arc<AtomicU16>,
     speed: i32,
-    pub gapless: bool,
+    gapless: bool,
     command_tx: Sender<PlayerInternalCmd>,
-    pub position: Arc<Mutex<Duration>>,
-    pub total_duration: ArcTotalDuration,
+    position: Arc<Mutex<Duration>>,
+    total_duration: ArcTotalDuration,
     pub radio_title: Arc<Mutex<String>>,
     pub radio_downloaded: Arc<Mutex<u64>>,
     // cmd_tx_outside: crate::PlayerCmdSender,

--- a/server/build.rs
+++ b/server/build.rs
@@ -8,20 +8,56 @@ fn main() {
         println!("cargo:rerun-if-changed=server/build.rs");
         println!("cargo:rerun-if-changed=.git/HEAD");
 
-        // How to read the version:
-        // Termusic-server v0.7.11-302-g63396ee5-dirty
+        let cargo_toml_version = {
+            let version = env!("CARGO_PKG_VERSION");
+
+            if version.is_empty() {
+                None
+            } else {
+                // format is the literal return of what is set in the "Cargo.toml", so to be consistent with git, we modify it to look the same as git (adding "v")
+                // also add a inidicator for cargo version
+                Some(format!("v{version}[c]"))
+            }
+        };
+
+        let cargo_toml_or_default = cargo_toml_version.unwrap_or(String::from("unknown"));
+
+        // How to read the git version, first all the variants:
+        // Termusic-server v0.7.11-302-g63396ee5-dirty[g]
+        // Termusic-server v0.7.11-302-g63396ee5[g]
+        // Termusic-server v0.7.11[g]
+        // Termusic-server v0.7.11[c]
+        // Termusic-server unknown
+        //
         // "Termusic-server" is the binary name
         // "v0.7.11" is the latest tag on the branch
-        // "302" is the number of commits since the tag
+        // "302" is the number of commits since the tag, not always present
         // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
         // the rest "63396ee5" is the abbreviated commit sha
         // "dirty" indicates the build has uncommited changes
+        // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
         let version = Command::new("git")
             .args(["describe", "--tags", "--always", "--dirty"])
             .output()
             .ok()
-            .and_then(|v| String::from_utf8(v.stdout).ok())
-            .unwrap_or(String::from("unknown"));
+            .and_then(|v| {
+                // print stderr for debugging purposes, it will not be shown unless the build.rs panics
+                if !v.stderr.is_empty() {
+                    eprintln!(
+                        "{}",
+                        String::from_utf8(v.stderr).unwrap_or("couldnt parse utf8 stderr".into())
+                    );
+                }
+
+                String::from_utf8(v.stdout).ok()
+            })
+            // ignore output if the string gotten is empty
+            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            // add a indicator for git version
+            .map(|v| format!("{}[g]", v.trim()))
+            // fallback to Cargo.toml version, if git is unavailable (like having downloaded the source archive)
+            .unwrap_or(cargo_toml_or_default);
+
         println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
     }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -47,7 +47,7 @@ pub struct Args {
     /// Max depth(NUMBER) of folder, default is 4.
     #[arg(short, long)]
     pub max_depth: Option<usize>,
-    #[arg(short, long, default_value_t = Backend::Default)]
+    #[arg(short, long, default_value_t = Backend::Default, env = "TMS_BACKEND")]
     pub backend: Backend,
     #[clap(flatten)]
     pub log_options: LogOptions,

--- a/tui/build.rs
+++ b/tui/build.rs
@@ -8,20 +8,56 @@ fn main() {
         println!("cargo:rerun-if-changed=tui/build.rs");
         println!("cargo:rerun-if-changed=.git/HEAD");
 
-        // How to read the version:
-        // Termusic v0.7.11-302-g63396ee5-dirty
+        let cargo_toml_version = {
+            let version = env!("CARGO_PKG_VERSION");
+
+            if version.is_empty() {
+                None
+            } else {
+                // format is the literal return of what is set in the "Cargo.toml", so to be consistent with git, we modify it to look the same as git (adding "v")
+                // also add a inidicator for cargo version
+                Some(format!("v{version}[c]"))
+            }
+        };
+
+        let cargo_toml_or_default = cargo_toml_version.unwrap_or(String::from("unknown"));
+
+        // How to read the git version, first all the variants:
+        // Termusic v0.7.11-302-g63396ee5-dirty[g]
+        // Termusic v0.7.11-302-g63396ee5[g]
+        // Termusic v0.7.11[g]
+        // Termusic v0.7.11[c]
+        // Termusic unknown
+        //
         // "Termusic" is the binary name
         // "v0.7.11" is the latest tag on the branch
-        // "302" is the number of commits since the tag
+        // "302" is the number of commits since the tag, not always present
         // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
         // the rest "63396ee5" is the abbreviated commit sha
         // "dirty" indicates the build has uncommited changes
+        // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
         let version = Command::new("git")
             .args(["describe", "--tags", "--always", "--dirty"])
             .output()
             .ok()
-            .and_then(|v| String::from_utf8(v.stdout).ok())
-            .unwrap_or(String::from("unknown"));
+            .and_then(|v| {
+                // print stderr for debugging purposes, it will not be shown unless the build.rs panics
+                if !v.stderr.is_empty() {
+                    eprintln!(
+                        "{}",
+                        String::from_utf8(v.stderr).unwrap_or("couldnt parse utf8 stderr".into())
+                    );
+                }
+
+                String::from_utf8(v.stdout).ok()
+            })
+            // ignore output if the string gotten is empty
+            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            // add a indicator for git version
+            .map(|v| format!("{}[g]", v.trim()))
+            // fallback to Cargo.toml version, if git is unavailable (like having downloaded the source archive)
+            .unwrap_or(cargo_toml_or_default);
+
         println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
     }
 }

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -46,7 +46,7 @@ pub struct Args {
     /// Max depth(NUMBER) of folder, default is 4.
     #[arg(short, long)]
     pub max_depth: Option<usize>,
-    #[arg(short, long, default_value_t = Backend::Default)]
+    #[arg(short, long, default_value_t = Backend::Default, env = "TMS_BACKEND")]
     pub backend: Backend,
     #[clap(flatten)]
     pub log_options: LogOptions,


### PR DESCRIPTION
This PR does some QoL improvements, namely:
- allow building termusic without git or `.git` and fall-back to the Cargo.toml version (with indicators), this is for example used for [`termusic` AUR](https://aur.archlinux.org/packages/termusic)
- allow setting the backend via a environment variable (`TMS_BACKEND`)
- add a thread name to discord's thread
- consistent `VOLUME_STEP` for backends
- all backends: change internal-only fields to be non-public
- gstreamer: reduce amount of channel's needed / channel proxying
- some slight formatting things