### PR TITLE
Refactor `PlayerTrait::enqueue_next` to pass a track, and some Rusty backend refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-util",
+ "log",
  "parking_lot",
  "rangemap",
  "reqwest",
@@ -4065,6 +4066,7 @@ dependencies = [
  "tap",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ tap = "1"
 tempfile = "3"
 textwrap = "0.16"
 tokio = { version = "1", features = ["sync", "macros", "rt"] }
+tokio-util = "0.7"
 # tokio-stream = "*"
 toml = "0.8"
 tonic = "0.10"

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -40,6 +40,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
+// TODO: add some kind of identifier for easy printing, like a uri that is NOT optional
 #[derive(Clone, Debug)]
 pub struct Track {
     /// Artist of the song
@@ -49,6 +50,7 @@ pub struct Track {
     /// Title of the song
     title: Option<String>,
     /// File path to the song
+    // TODO: why is this a http(s) url in Radio case?
     file: Option<String>,
     /// Duration of the song
     duration: Duration,
@@ -56,6 +58,7 @@ pub struct Track {
     name: Option<String>,
     /// Extension of the song
     ext: Option<String>,
+    // TODO: why is this set to the http(s) url in Radio case?
     directory: Option<String>,
     pub last_modified: SystemTime,
     /// USLT lyrics

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -239,17 +239,7 @@ impl GStreamerBackend {
 
         this
     }
-    fn skip_one(&mut self) {
-        self.message_tx.send_blocking(PlayerCmd::SkipNext).ok();
-    }
-    fn enqueue_next(&mut self, next_track: &str) {
-        if next_track.starts_with("http") {
-            self.playbin.set_property("uri", next_track);
-        } else {
-            let path = Path::new(next_track);
-            self.playbin.set_property("uri", path.to_uri());
-        }
-    }
+
     fn set_volume_inside(&mut self, volume: f64) {
         self.playbin.set_property("volume", volume);
     }
@@ -465,11 +455,16 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn skip_one(&mut self) {
-        self.skip_one();
+        self.message_tx.send_blocking(PlayerCmd::SkipNext).ok();
     }
 
     fn enqueue_next(&mut self, file: &str) {
-        self.enqueue_next(file);
+        if file.starts_with("http") {
+            self.playbin.set_property("uri", file);
+        } else {
+            let path = Path::new(file);
+            self.playbin.set_property("uri", path.to_uri());
+        }
     }
 }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -259,9 +259,9 @@ impl GStreamerBackend {
         }
     }
 
-    fn send_seek_event(&mut self, rate: i32) -> bool {
-        self.speed = rate;
-        let rate = rate as f64 / 10.0;
+    fn send_seek_event_speed(&mut self, speed: i32) -> bool {
+        self.speed = speed;
+        let rate = speed as f64 / 10.0;
         // Obtain the current position, needed for the seek event
         let position = self.get_position();
 
@@ -413,7 +413,7 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn set_speed(&mut self, speed: i32) {
-        self.send_seek_event(speed);
+        self.send_seek_event_speed(speed);
     }
 
     fn speed_up(&mut self) {
@@ -421,7 +421,7 @@ impl PlayerTrait for GStreamerBackend {
         if speed > 30 {
             speed = 30;
         }
-        if !self.send_seek_event(speed) {
+        if !self.send_seek_event_speed(speed) {
             error!("error set speed");
         }
     }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -239,10 +239,10 @@ impl GStreamerBackend {
 
         this
     }
-    pub fn skip_one(&mut self) {
+    fn skip_one(&mut self) {
         self.message_tx.send_blocking(PlayerCmd::SkipNext).ok();
     }
-    pub fn enqueue_next(&mut self, next_track: &str) {
+    fn enqueue_next(&mut self, next_track: &str) {
         if next_track.starts_with("http") {
             self.playbin.set_property("uri", next_track);
         } else {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -291,6 +291,9 @@ impl GeneralPlayer {
 
         if let Some(track) = self.playlist.current_track() {
             let track = track.clone();
+
+            info!("Starting Track {:#?}", track);
+
             if self.playlist.has_next_track() {
                 self.playlist.set_next_track(None);
                 self.current_track_updated = true;
@@ -346,11 +349,9 @@ impl GeneralPlayer {
         };
 
         self.playlist.set_next_track(Some(&track));
-        if let Some(file) = track.file() {
-            self.get_player_mut().enqueue_next(file);
+        self.get_player_mut().enqueue_next(&track);
 
-            info!("Next track enqueued: {:#?}", file);
-        }
+        info!("Next track enqueued: {:#?}", track);
     }
 
     pub fn next(&mut self) {
@@ -629,8 +630,8 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player().position()
     }
 
-    fn enqueue_next(&mut self, file: &str) {
-        self.get_player_mut().enqueue_next(file);
+    fn enqueue_next(&mut self, track: &Track) {
+        self.get_player_mut().enqueue_next(track);
     }
 }
 
@@ -701,5 +702,5 @@ pub trait PlayerTrait {
         self.get_progress().position
     }
     /// Add the given URI to be played, but do not skip currently playing track
-    fn enqueue_next(&mut self, file: &str);
+    fn enqueue_next(&mut self, track: &Track);
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -666,6 +666,7 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
 pub trait PlayerTrait {
+    /// Add the given track, skip to it (if not already) and start playing
     async fn add_and_play(&mut self, current_track: &Track);
     fn volume(&self) -> u16;
     fn volume_up(&mut self);
@@ -699,5 +700,6 @@ pub trait PlayerTrait {
     fn position(&self) -> PlayerTimeUnit {
         self.get_progress().position
     }
+    /// Add the given URI to be played, but do not skip currently playing track
     fn enqueue_next(&mut self, file: &str);
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -553,8 +553,8 @@ impl GeneralPlayer {
 
 #[async_trait]
 impl PlayerTrait for GeneralPlayer {
-    async fn add_and_play(&mut self, current_track: &Track) {
-        self.get_player_mut().add_and_play(current_track).await;
+    async fn add_and_play(&mut self, track: &Track) {
+        self.get_player_mut().add_and_play(track).await;
     }
     fn volume(&self) -> u16 {
         self.get_player().volume()
@@ -667,7 +667,7 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
 #[async_trait]
 pub trait PlayerTrait {
     /// Add the given track, skip to it (if not already) and start playing
-    async fn add_and_play(&mut self, current_track: &Track);
+    async fn add_and_play(&mut self, track: &Track);
     fn volume(&self) -> u16;
     fn volume_up(&mut self);
     fn volume_down(&mut self);

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -377,9 +377,14 @@ impl PlayerTrait for MpvBackend {
         self.command_tx.send(PlayerInternalCmd::Eos).ok();
     }
 
-    fn enqueue_next(&mut self, file: &str) {
+    fn enqueue_next(&mut self, track: &Track) {
+        let Some(file) = track.file() else {
+            error!("Got track, but cant handle it without a file!");
+            return;
+        };
+
         self.command_tx
             .send(PlayerInternalCmd::QueueNext(file.to_string()))
-            .ok();
+            .expect("failed to queue next");
     }
 }

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -264,24 +264,6 @@ impl MpvBackend {
             media_title,
         }
     }
-
-    fn enqueue_next(&mut self, next: &str) {
-        self.command_tx
-            .send(PlayerInternalCmd::QueueNext(next.to_string()))
-            .ok();
-    }
-
-    fn queue_and_play(&mut self, new: &Track) {
-        if let Some(file) = new.file() {
-            self.command_tx
-                .send(PlayerInternalCmd::Play(file.to_string()))
-                .expect("failed to queue and play");
-        }
-    }
-
-    fn skip_one(&mut self) {
-        self.command_tx.send(PlayerInternalCmd::Eos).ok();
-    }
 }
 
 /// Format a duration in "SS.mm" format
@@ -297,7 +279,11 @@ fn format_duration(dur: Duration) -> String {
 #[async_trait]
 impl PlayerTrait for MpvBackend {
     async fn add_and_play(&mut self, track: &Track) {
-        self.queue_and_play(track);
+        if let Some(file) = track.file() {
+            self.command_tx
+                .send(PlayerInternalCmd::Play(file.to_string()))
+                .expect("failed to queue and play");
+        }
     }
 
     fn volume(&self) -> u16 {
@@ -388,10 +374,12 @@ impl PlayerTrait for MpvBackend {
     }
 
     fn skip_one(&mut self) {
-        self.skip_one();
+        self.command_tx.send(PlayerInternalCmd::Eos).ok();
     }
 
     fn enqueue_next(&mut self, file: &str) {
-        self.enqueue_next(file);
+        self.command_tx
+            .send(PlayerInternalCmd::QueueNext(file.to_string()))
+            .ok();
     }
 }

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -265,7 +265,7 @@ impl MpvBackend {
         }
     }
 
-    pub fn enqueue_next(&mut self, next: &str) {
+    fn enqueue_next(&mut self, next: &str) {
         self.command_tx
             .send(PlayerInternalCmd::QueueNext(next.to_string()))
             .ok();
@@ -279,7 +279,7 @@ impl MpvBackend {
         }
     }
 
-    pub fn skip_one(&mut self) {
+    fn skip_one(&mut self) {
         self.command_tx.send(PlayerInternalCmd::Eos).ok();
     }
 }

--- a/playback/src/mpv_backend/mod.rs
+++ b/playback/src/mpv_backend/mod.rs
@@ -296,8 +296,8 @@ fn format_duration(dur: Duration) -> String {
 
 #[async_trait]
 impl PlayerTrait for MpvBackend {
-    async fn add_and_play(&mut self, current_item: &Track) {
-        self.queue_and_play(current_item);
+    async fn add_and_play(&mut self, track: &Track) {
+        self.queue_and_play(track);
     }
 
     fn volume(&self) -> u16 {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -161,30 +161,6 @@ impl RustyBackend {
         Ok(Cursor::new(bytes))
     }
 
-    fn enqueue(&mut self, item: &Track) {
-        self.command(PlayerInternalCmd::Play(
-            Box::new(item.clone()),
-            self.gapless,
-        ));
-    }
-
-    fn enqueue_next(&mut self, item: &str) {
-        self.command(PlayerInternalCmd::QueueNext(item.to_string(), self.gapless));
-    }
-
-    fn play(&mut self, current_item: &Track) {
-        self.enqueue(current_item);
-        self.resume();
-    }
-
-    fn stop(&mut self) {
-        self.command(PlayerInternalCmd::Stop);
-    }
-
-    fn skip_one(&mut self) {
-        self.command(PlayerInternalCmd::Skip);
-    }
-
     pub fn message_on_end(&self) {
         self.command(PlayerInternalCmd::MessageOnEnd);
     }
@@ -193,7 +169,11 @@ impl RustyBackend {
 #[async_trait]
 impl PlayerTrait for RustyBackend {
     async fn add_and_play(&mut self, track: &Track) {
-        self.play(track);
+        self.command(PlayerInternalCmd::Play(
+            Box::new(track.clone()),
+            self.gapless,
+        ));
+        self.resume();
     }
 
     fn volume(&self) -> u16 {
@@ -269,8 +249,9 @@ impl PlayerTrait for RustyBackend {
     fn speed(&self) -> i32 {
         self.speed
     }
+
     fn stop(&mut self) {
-        self.stop();
+        self.command(PlayerInternalCmd::Stop);
     }
 
     #[allow(clippy::cast_precision_loss)]
@@ -291,11 +272,11 @@ impl PlayerTrait for RustyBackend {
     }
 
     fn skip_one(&mut self) {
-        self.skip_one();
+        self.command(PlayerInternalCmd::Skip);
     }
 
     fn enqueue_next(&mut self, file: &str) {
-        self.enqueue_next(file);
+        self.command(PlayerInternalCmd::QueueNext(file.to_string(), self.gapless));
     }
 }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -192,8 +192,8 @@ impl RustyBackend {
 
 #[async_trait]
 impl PlayerTrait for RustyBackend {
-    async fn add_and_play(&mut self, current_track: &Track) {
-        self.play(current_track);
+    async fn add_and_play(&mut self, track: &Track) {
+        self.play(track);
     }
 
     fn volume(&self) -> u16 {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -47,8 +47,12 @@ pub type ArcTotalDuration = Arc<Mutex<TotalDuration>>;
 #[derive(Clone, Debug)]
 pub enum PlayerInternalCmd {
     MessageOnEnd,
+    /// Enqueue a new track to be played, and skip to it
+    /// (Track, gapless)
     Play(Box<Track>, bool),
     Progress(Duration),
+    /// Enqueue a new track to be played, but do not skip current track
+    /// (Track URI, gapless)
     QueueNext(String, bool),
     Resume,
     SeekAbsolute(Duration),

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -161,14 +161,14 @@ impl RustyBackend {
         Ok(Cursor::new(bytes))
     }
 
-    pub fn enqueue(&mut self, item: &Track) {
+    fn enqueue(&mut self, item: &Track) {
         self.command(PlayerInternalCmd::Play(
             Box::new(item.clone()),
             self.gapless,
         ));
     }
 
-    pub fn enqueue_next(&mut self, item: &str) {
+    fn enqueue_next(&mut self, item: &str) {
         self.command(PlayerInternalCmd::QueueNext(item.to_string(), self.gapless));
     }
 
@@ -181,7 +181,7 @@ impl RustyBackend {
         self.command(PlayerInternalCmd::Stop);
     }
 
-    pub fn skip_one(&mut self) {
+    fn skip_one(&mut self) {
         self.command(PlayerInternalCmd::Skip);
     }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -161,8 +161,7 @@ impl RustyBackend {
         Ok(Cursor::new(bytes))
     }
 
-    #[allow(clippy::unused_async)]
-    pub async fn enqueue(&mut self, item: &Track) {
+    pub fn enqueue(&mut self, item: &Track) {
         self.command(PlayerInternalCmd::Play(
             Box::new(item.clone()),
             self.gapless,
@@ -173,8 +172,8 @@ impl RustyBackend {
         self.command(PlayerInternalCmd::QueueNext(item.to_string(), self.gapless));
     }
 
-    async fn play(&mut self, current_item: &Track) {
-        self.enqueue(current_item).await;
+    fn play(&mut self, current_item: &Track) {
+        self.enqueue(current_item);
         self.resume();
     }
 
@@ -194,7 +193,7 @@ impl RustyBackend {
 #[async_trait]
 impl PlayerTrait for RustyBackend {
     async fn add_and_play(&mut self, current_track: &Track) {
-        self.play(current_track).await;
+        self.play(current_track);
     }
 
     fn volume(&self) -> u16 {

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -26,6 +26,8 @@ tempfile.workspace = true
 tokio.workspace = true 
 tracing.workspace = true 
 symphonia.workspace = true
+log.workspace = true
+tokio-util.workspace = true
 
 [features]
 default = []

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -36,7 +36,7 @@ impl StreamDownload {
         radio_title: Arc<Mutex<String>>,
         radio_downloaded: Arc<Mutex<u64>>,
     ) -> io::Result<Self> {
-        let tempfile = tempfile::Builder::new().tempfile()?;
+        let tempfile = tempfile::Builder::new().prefix(".termusic-stream-cache-").tempfile()?;
         let source = Source::new(tempfile.reopen()?);
         let handle = source.source_handle();
         let radio_title_inside = radio_title.clone();

--- a/stream/src/lib.rs
+++ b/stream/src/lib.rs
@@ -8,7 +8,12 @@ use std::{
 use symphonia::core::io::MediaSource;
 use tap::{Tap, TapFallible};
 use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate log;
 
 pub mod http;
 pub mod source;
@@ -18,6 +23,8 @@ pub struct StreamDownload {
     output_reader: BufReader<NamedTempFile>,
     handle: SourceHandle,
     pub radio_title: Arc<Mutex<String>>,
+    /// dropguard to stop the download once this instance is dropped
+    _drop_guard: tokio_util::sync::DropGuard,
 }
 
 impl StreamDownload {
@@ -36,17 +43,26 @@ impl StreamDownload {
         radio_title: Arc<Mutex<String>>,
         radio_downloaded: Arc<Mutex<u64>>,
     ) -> io::Result<Self> {
-        let tempfile = tempfile::Builder::new().prefix(".termusic-stream-cache-").tempfile()?;
+        let tempfile = tempfile::Builder::new()
+            .prefix(".termusic-stream-cache-")
+            .tempfile()?;
         let source = Source::new(tempfile.reopen()?);
         let handle = source.source_handle();
         let radio_title_inside = radio_title.clone();
         let radio_downloaded_inside1 = radio_downloaded.clone();
+        let shutdown_token = CancellationToken::new();
+        let shutdown_token_clone = shutdown_token.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let stream = S::create(url, is_radio, radio_title_inside)
                     .await
                     .tap_err(|e| error!("Error creating stream: {e}"))?;
-                source.download(stream, radio_downloaded_inside1).await?;
+
+                tokio::select! {
+                    _ = source.download(stream, radio_downloaded_inside1) => {},
+                    _ = shutdown_token_clone.cancelled() => {},
+                }
+
                 Ok::<_, io::Error>(())
             });
         } else {
@@ -59,7 +75,12 @@ impl StreamDownload {
                     let stream = S::create(url, is_radio, radio_title_inside)
                         .await
                         .tap_err(|e| error!("Error creating stream {e}"))?;
-                    source.download(stream, radio_downloaded).await?;
+
+                    tokio::select! {
+                        _ = source.download(stream, radio_downloaded) => {},
+                        _ = shutdown_token_clone.cancelled() => {},
+                    }
+
                     Ok::<_, io::Error>(())
                 })?;
                 Ok::<_, io::Error>(())
@@ -69,6 +90,7 @@ impl StreamDownload {
             output_reader: BufReader::new(tempfile),
             handle,
             radio_title,
+            _drop_guard: shutdown_token.drop_guard(),
         })
     }
 
@@ -81,12 +103,17 @@ impl StreamDownload {
         let source = Source::new(tempfile.reopen()?);
         let handle = source.source_handle();
         let radio_downloaded_inside1 = radio_downloaded.clone();
+        let shutdown_token = CancellationToken::new();
+        let shutdown_token_clone = shutdown_token.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                source
-                    .download(stream, radio_downloaded_inside1)
-                    .await
-                    .tap_err(|e| error!("Error downloading stream: {e}"))?;
+                tokio::select! {
+                    res = source.download(stream, radio_downloaded_inside1) => {
+                        res.tap_err(|e| error!("Error downloading stream: {e}"))?;
+                    },
+                    _ = shutdown_token_clone.cancelled() => {},
+                }
+
                 Ok::<_, io::Error>(())
             });
         } else {
@@ -96,10 +123,13 @@ impl StreamDownload {
                     .build()
                     .tap_err(|e| error!("Error creating tokio runtime: {e}"))?;
                 rt.block_on(async move {
-                    source
-                        .download(stream, radio_downloaded)
-                        .await
-                        .tap_err(|e| error!("Error downloading stream: {e}"))?;
+                    tokio::select! {
+                        res = source.download(stream, radio_downloaded) => {
+                            res.tap_err(|e| error!("Error downloading stream: {e}"))?;
+                        },
+                        _ = shutdown_token_clone.cancelled() => {},
+                    }
+
                     Ok::<_, io::Error>(())
                 })?;
                 Ok::<_, io::Error>(())
@@ -109,6 +139,7 @@ impl StreamDownload {
             output_reader: BufReader::new(tempfile),
             handle,
             radio_title,
+            _drop_guard: shutdown_token.drop_guard(),
         })
     }
 }


### PR DESCRIPTION
Let me say that i am sorry to not split these changes, but they somewhat work hand-in-hand with each-other.

This PR does (sorted by most significant first):
- refactor `playback::PlayerTrait::enqueue_next` to pass along a `&Track` instead of a `&str` (to be in-sync with `::add_and_play`)
- rusty backend: use the same matching for `QueueNext` as `Play` has, fixes #210
- stream: actually stop downloading once the source is dropped, re https://github.com/tramhao/termusic/issues/210#issuecomment-1954409018
- stream: add a more proper name to the temporary file (so it can be identified, instead of `.tmpXXXX` it is now `.termusic-stream-cache-XXXX`)
- inline all duplicate (single / double line) functions in all backends that are meant to be called via the trait
- add some documentation here and there for backends / traits