### PR TITLE
Fix some thing regarding the recent commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@
 - Change: small optimizations.
 - Change: change almost all `eprintln` to be `log::error`.
 - Change: change almost all `println` to be appropriate log levels.
+- Change: updated to `tuirealm` 1.9, which in turn makes use of newer `bitflags` (through `crossterm`), making old key values in `config.toml` invalid and have to be deleted.
 - Feat: change logger to be `flexi_logger`, including logging to file.
 - Feat: add cli arguments to the server binary.
 - Feat: add a lot more metadata to media controls, like cover art, duration, seek, volume(RW), quit.
 - Feat: support `mkv` & `webm` in backend `rusty` (no metadata, support depends on codec).
 - Feat: in backend `rusty`, buffer files in 4Mb chunks.
 - Feat: better version via `--version`.
-- Feat(server): allow compiling multiple backends via features and select at binary start.
+- Feat: allow specifiying which interface (ip) to run on.
+- Feat(server): allow compiling multiple backends via features and select at binary start (via `--backend` or `TMS_BACKEND`).
+- Feat(server): for backend `mpv`, switch to use `libmpv-sirno` and use mpv API 2.0.
 - Feat(tui): add a "currently playing" symbol to active track in playlist.
+- Feat(tui): add search function for Podcast Episodes.
 - Fix: try to find the server binary adjacent to the TUI binary.
 - Fix: change many panics to be results instead.
 - Fix: dont panic if "music_dir" value is empty when entering config editor, fixes #161.
@@ -25,9 +29,15 @@
 - Fix(tui): add panic hook to reset screen before printing backtrace.
 - Fix(tui): dont extra clear screen on quit.
 - Fix(tui): reset screen if a Error(Result) happens and exit properly.
+- Fix(tui): wait until tonic is connected instead of static sleeps.
+- Fix(tui): only display `ueberzug` "Not found" errors once.
+- Fix(tui): blanket disable `ueberzug` for windows.
 - Fix(server): log port used.
 - Fix(server): log on quit.
 - Fix(server): properly exit on player thread crash (instead of being pseudo-zombie).
+- Fix(server): potentially fix media display in windows.
+- Fix(server): in backend `rusty`, fix radio not starting if `gapless` is enabled and the track changes to be radio (from something else).
+- Fix(server): in backend `rusty`, fix radio streams not being stopped once they have been skipped.
 - Fix(build): install to `$CARGO_HOME/bin` instead of always into a static path.
 - a **bunch** of internal refactors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Change: small optimizations.
 - Change: change almost all `eprintln` to be `log::error`.
 - Change: change almost all `println` to be appropriate log levels.
-- Change: updated to `tuirealm` 1.9, which in turn makes use of newer `bitflags` (through `crossterm`), making old key values in `config.toml` invalid and have to be deleted.
 - Feat: change logger to be `flexi_logger`, including logging to file.
 - Feat: add cli arguments to the server binary.
 - Feat: add a lot more metadata to media controls, like cover art, duration, seek, volume(RW), quit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### unreleased
 - Released on: unreleased.
-- Change: updated MSRV to 1.70.
+- Change: updated MSRV to 1.74.
 - Change: better Error messages if the server binary cannot be started.
 - Change: small optimizations.
 - Change: change almost all `eprintln` to be `log::error`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -500,15 +497,6 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "cc"
@@ -682,19 +670,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -1909,12 +1884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.1.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d12be4595afdf58bd19e4a9f4e24187da2a66700786ff660a418e9059937a4c"
+checksum = "ff63c423c68ea6814b7da9e88ce585f793c87ddd9e78f646970891769c8235d4"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -2023,14 +1992,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.1.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bcd58e6c97a7fcbaffcdc95728b393b8d98933bfadad49ed4097845b57ef0b"
+checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.53",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2183,15 +2152,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "lru"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
-dependencies = [
- "hashbrown 0.14.3",
-]
 
 [[package]]
 name = "mach2"
@@ -2988,26 +2948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
-name = "ratatui"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
-dependencies = [
- "bitflags 2.4.2",
- "cassowary",
- "compact_str",
- "crossterm 0.27.0",
- "indoc",
- "itertools 0.12.1",
- "lru",
- "paste",
- "stability",
- "strum",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,22 +3479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,28 +3495,6 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "strum"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.53",
-]
 
 [[package]]
 name = "symphonia"
@@ -3915,7 +3817,7 @@ dependencies = [
  "sysinfo",
  "termusic-lib",
  "termusic-playback",
- "textwrap",
+ "textwrap 0.16.1",
  "tokio",
  "tonic",
  "tui-realm-stdlib",
@@ -3970,7 +3872,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "symphonia",
- "textwrap",
+ "textwrap 0.16.1",
  "toml",
  "tui-realm-stdlib",
  "tui-realm-treeview",
@@ -4058,6 +3960,17 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -4461,20 +4374,20 @@ dependencies = [
 
 [[package]]
 name = "tui-realm-stdlib"
-version = "1.3.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ad506e872692d85265328353d92f4f633dd5add7f73ebd93e8d0368a708447"
+checksum = "66f252bf8b07c6fd708ddd6349b5f044ae5b488b26929c745728d9c7e2cebfa6"
 dependencies = [
- "textwrap",
+ "textwrap 0.15.2",
  "tuirealm",
  "unicode-width",
 ]
 
 [[package]]
 name = "tui-realm-treeview"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d2d6c059f6adbb2ba7194ab50765dac793cb98fae097e0bb5bf8c23ffaf27c"
+checksum = "1897a2074c8a5162968961a1a00b5378b2cdda5ce043cb13920801e91898e672"
 dependencies = [
  "orange-trees",
  "tuirealm",
@@ -4483,14 +4396,13 @@ dependencies = [
 
 [[package]]
 name = "tuirealm"
-version = "1.9.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c358c39cb9e1b45702ea46afc77d39589d720ca9cf5f1e11a3106342ea6a4e76"
+checksum = "265411b5606f400459af94fbc5aae6a7bc0e98094d08cb5868390c932be88e26"
 dependencies = [
- "bitflags 2.4.2",
- "crossterm 0.27.0",
+ "bitflags 1.3.2",
+ "crossterm 0.25.0",
  "lazy-regex",
- "ratatui",
  "serde",
  "thiserror",
  "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ termusic-playback = { path = "playback/", version = "0.7.12" }
 termusic-stream = { path = "stream/", version = "0.7.12" }
 ahash = "^0.8"
 anyhow = { version = "1.0", features = ["backtrace"] }
-async-channel = "2"
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
@@ -101,9 +100,9 @@ toml = "0.8"
 tonic = "0.11"
 tonic-build = "0.11"
 tracing = "0.1"
-tuirealm = { version = "~1.9", features = ["serialize"] }
-tui-realm-stdlib = "~1.3"
-tui-realm-treeview = "~1.2"
+tuirealm = { version = "~1.8", features = ["serialize"] }
+tui-realm-stdlib = "~1.2"
+tui-realm-treeview = "~1.1"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2"
@@ -113,6 +112,7 @@ walkdir = "2"
 wildmatch = "2"
 yaml-rust = "^0.4.5"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }
+async-channel = "2"
 # winit = "0.27.0"
 # windows = "0.52"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build status](https://github.com/tramhao/termusic/actions/workflows/build.yml/badge.svg)](https://github.com/tramhao/termusic/actions)
 [![crates.io](https://img.shields.io/crates/v/termusic.svg)](https://crates.io/crates/termusic)
 [![dependency status](https://deps.rs/repo/github/tramhao/termusic/status.svg)](https://deps.rs/repo/github/tramhao/termusic)
-[![MSRV](https://img.shields.io/badge/MSRV-1.70.0-blue)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.74.0-blue)](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html)
 # Terminal Music and Podcast Player written in Rust
 
 Listen to music and podcasts freely as both in freedom and free of charge!

--- a/lib/src/utils/mod.rs
+++ b/lib/src/utils/mod.rs
@@ -496,7 +496,7 @@ mod tests {
         let child: Rect = draw_area_in_relative(area, 75, 30);
         assert_eq!(child.x, 43);
         assert_eq!(child.y, 63);
-        assert_eq!(child.width, 272);
-        assert_eq!(child.height, 55);
+        assert_eq!(child.width, 271);
+        assert_eq!(child.height, 54);
     }
 }

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -37,8 +37,8 @@ use tuirealm::props::{
     PropValue, Props, Style, TextModifiers,
 };
 use tuirealm::tui::{
-    layout::{Constraint, Direction as LayoutDirection, Layout, Rect},
-    text::Span,
+    layout::{Constraint, Corner, Direction as LayoutDirection, Layout, Rect},
+    text::Spans,
     widgets::{Block, List, ListItem, ListState, Paragraph},
 };
 
@@ -445,7 +445,7 @@ impl KeyCombo {
             .states
             .choices
             .iter()
-            .map(|x| ListItem::new(Span::from(x.clone())))
+            .map(|x| ListItem::new(Spans::from(x.clone())))
             .collect();
         let mut foreground = self
             .props
@@ -545,8 +545,7 @@ impl KeyCombo {
         }
         let mut list = List::new(choices)
             .block(block)
-            // .start_corner(Corner::TopLeft)
-            .direction(tuirealm::tui::widgets::ListDirection::TopToBottom)
+            .start_corner(Corner::TopLeft)
             .style(Style::default().fg(foreground).bg(background))
             .highlight_style(
                 Style::default()

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -116,7 +116,7 @@ impl Model {
         self.force_redraw();
     }
 
-    // TODO: refactor to have "duration" optional
+    // TODO: refactor to have "total_duration" optional
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
     pub fn progress_update(&mut self, time_pos: Option<Duration>, total_duration: Duration) {
         // for unsupported file format, don't update progress


### PR DESCRIPTION
This PR fixes some things regarding recent commits, which includes:
- update the MSRV in the README
- add changes to CHANGELOG since last such commit
- revert the upgrade to tuirealm 1.9 as https://github.com/veeso/tui-realm/issues/70 (and https://github.com/veeso/tui-realm/issues/71)

*1 this mean if you use any kind of mouse event (which includes *hovering*), the TUI's input is basically locked-up and fix you have some kind of exit event (like `q`) and then have some mouse events again, those events will be spammed to the terminal.

also i think we can do better than having to do manual changes to the `config.toml`

Edit: changed `tuirealm#64` to `tuirealm#70`