### PR TITLE
fix(tui::ui::components::database): show track title instead of filename for "Tracks" in "Database"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix(tui): wait until tonic is connected instead of static sleeps.
 - Fix(tui): only display `ueberzug` "Not found" errors once.
 - Fix(tui): blanket disable `ueberzug` for windows.
+- Fix(tui): in `Database -> Tracks` view, display track title instead of filename.
 - Fix(server): log port used.
 - Fix(server): log on quit.
 - Fix(server): properly exit on player thread crash (instead of being pseudo-zombie).

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -458,10 +458,20 @@ impl Model {
                 table.add_row();
             }
 
+            let name = {
+                // TODO: refactor this once "title" can be optional
+                // this check likely is never empty, because "Unknown"(or similar) is stored in the db
+                if record.title.is_empty() {
+                    record.name.clone()
+                } else {
+                    record.title.clone()
+                }
+            };
+
             table
                 .add_col(TextSpan::from(format!("{}", idx + 1)))
                 .add_col(TextSpan::from(" "))
-                .add_col(TextSpan::from(record.name.to_string()));
+                .add_col(TextSpan::from(name));
         }
         if self.db_search_results.is_empty() {
             table.add_col(TextSpan::from("empty results"));


### PR DESCRIPTION
This PR changes the displayed Track's name to be the title instead of the filename for `Database -> Tracks`