### PR TITLE
Refactor radio title parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix: in backend `rusty`, skip all tracks (and packets) that are not the selected track in backend in decode.
 - Fix: in backend `rusty`, correctly select a audio track (instead of symphonia's default which might be something else).
 - Fix: in backend `rusty`, when using radio, always use overwrite the last radio title instead of appending.
+- Fix: in backend `rusty`, when using radio, parse until `';` instead of just `'`, now things like `Don't` actually work correctly.
 - Fix: in backend `gst`, fix gapless track change not being tracked correctly, fixes #192.
 - Fix(tui): add panic hook to reset screen before printing backtrace.
 - Fix(tui): dont extra clear screen on quit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix: log *something* if a file is not going to be added to the playlist.
 - Fix: in backend `rusty`, skip all tracks (and packets) that are not the selected track in backend in decode.
 - Fix: in backend `rusty`, correctly select a audio track (instead of symphonia's default which might be something else).
+- Fix: in backend `rusty`, when using radio, always use overwrite the last radio title instead of appending.
 - Fix: in backend `gst`, fix gapless track change not being tracked correctly, fixes #192.
 - Fix(tui): add panic hook to reset screen before printing backtrace.
 - Fix(tui): dont extra clear screen on quit.

--- a/stream/src/http.rs
+++ b/stream/src/http.rs
@@ -226,6 +226,13 @@ mod test {
     }
 
     #[test]
+    fn find_title_metadata_should_find_empty_string() {
+        let bytes = b"StreamTitle='';";
+
+        assert_eq!(Some(""), find_title_metadata(bytes));
+    }
+
+    #[test]
     fn find_title_metadata_should_not_find_metadata_with_no_start() {
         // no `STREAM_TITLE_KEYWORD`
         let bytes = b"\0\0\0\0\0\0\0";

--- a/stream/src/http.rs
+++ b/stream/src/http.rs
@@ -141,7 +141,7 @@ impl SourceStream for HttpStream {
                                                     title_string += " ";
                                                     title_string += trimmed_song_title;
                                                     *radio_title.lock() =
-                                                        format!("Current playing: {title_string}");
+                                                        format!("Current playing: {}", title_string.trim());
                                                 }
                                             }
                                         }

--- a/stream/src/http.rs
+++ b/stream/src/http.rs
@@ -185,8 +185,9 @@ impl SourceStream for HttpStream {
 fn find_title_metadata(metadata: &[u8]) -> Option<&str> {
     let metadata_string = std::str::from_utf8(metadata).unwrap_or("");
     if !metadata_string.is_empty() {
+        // some reference https://cast.readme.io/docs/icy#metadata
         const STREAM_TITLE_KEYWORD: &str = "StreamTitle='";
-        const STREAM_TITLE_END_KEYWORD: char = '\'';
+        const STREAM_TITLE_END_KEYWORD: &str = "\';";
         if let Some(index) = metadata_string.find(STREAM_TITLE_KEYWORD) {
             let left_index = index + 13;
             let stream_title_substring = &metadata_string[left_index..];
@@ -205,7 +206,21 @@ mod test {
 
     #[test]
     fn find_title_metadata_should_find_metadata() {
+        // basic title
         let bytes = b"StreamTitle='Artist - Title';\0\0\0\0\0\0\0";
+
+        assert_eq!(Some("Artist - Title"), find_title_metadata(bytes));
+
+        // title with end string character
+        let bytes = b"StreamTitle='Artist - Don't we need a title?';\0\0\0\0\0\0\0";
+
+        assert_eq!(
+            Some("Artist - Don't we need a title?"),
+            find_title_metadata(bytes)
+        );
+
+        // basic title with no padding
+        let bytes = b"StreamTitle='Artist - Title';";
 
         assert_eq!(Some("Artist - Title"), find_title_metadata(bytes));
     }


### PR DESCRIPTION
This PR changes the radio title parsing to be its own function and overwrite the full string instead of appending, in more details:
- dont append new title to old
- move parsing to own function for better code clarity and direct testing
- parse until `';` instead of just `'` (for things like `Don't`)
- add tests for the parsing

Now instead of `Currently Playing:  Artist - Some Title - Artist - Some other Title - Artist - Some other other Title` it will only display `Currently Playing: Artist - Some other other Title`

also somehow before this PR sometimes the string would just go blank and never recover for reasons unknown to me, but now it seemingly does not anymore