### PR TITLE
QuitPopup & ConfigSavePopup: allow confirming choices with "Y" and "N"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Feat(server): for backend `mpv`, switch to use `libmpv-sirno` and use mpv API 2.0.
 - Feat(tui): add a "currently playing" symbol to active track in playlist.
 - Feat(tui): add search function for Podcast Episodes.
+- Feat(tui): allow confirming quit-confirm choices with `Y` or `N`.
 - Fix: try to find the server binary adjacent to the TUI binary.
 - Fix: change many panics to be results instead.
 - Fix: dont panic if "music_dir" value is empty when entering config editor, fixes #161.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Feat(tui): add a "currently playing" symbol to active track in playlist.
 - Feat(tui): add search function for Podcast Episodes.
 - Feat(tui): allow confirming quit-confirm choices with `Y` or `N`.
+- Feat(tui): allow confirming config save confirm choices with `Y` or `N`.
 - Fix: try to find the server binary adjacent to the TUI binary.
 - Fix: change many panics to be results instead.
 - Fix: dont panic if "music_dir" value is empty when entering config editor, fixes #161.

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -35,12 +35,15 @@ pub use general::*;
 pub use key_combo::*;
 
 use tui_realm_stdlib::{Radio, Span};
-use tuirealm::props::{Alignment, BorderSides, BorderType, Borders, Color, Style, TextSpan};
+use tuirealm::props::{
+    Alignment, BorderSides, BorderType, Borders, Color, PropPayload, PropValue, Style, TextSpan,
+};
 use tuirealm::{
     command::{Cmd, CmdResult, Direction},
     event::{Key, KeyEvent, NoUserEvent},
     Component, Event, MockComponent, State, StateValue,
 };
+use tuirealm::{AttrValue, Attribute};
 
 #[derive(MockComponent)]
 pub struct CEHeader {
@@ -207,6 +210,28 @@ impl Component<Msg, NoUserEvent> for ConfigSavePopup {
             }
             Event::Keyboard(key) if key == self.config.keys.global_esc.key_event() => {
                 return Some(Msg::ConfigEditor(ConfigEditorMsg::ConfigSaveCancel))
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Char('y'),
+                ..
+            }) => {
+                // ordering is 0 = No, 1 = Yes
+                self.component.attr(
+                    Attribute::Value,
+                    AttrValue::Payload(PropPayload::One(PropValue::Usize(1))),
+                );
+                self.perform(Cmd::Submit)
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Char('n'),
+                ..
+            }) => {
+                // ordering is 0 = No, 1 = Yes
+                self.component.attr(
+                    Attribute::Value,
+                    AttrValue::Payload(PropPayload::One(PropValue::Usize(0))),
+                );
+                self.perform(Cmd::Submit)
             }
 
             Event::Keyboard(KeyEvent {

--- a/tui/src/ui/components/popups.rs
+++ b/tui/src/ui/components/popups.rs
@@ -27,9 +27,10 @@ use tui_realm_stdlib::{Input, Paragraph, Radio, Table};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
-    Alignment, BorderType, Borders, Color, InputType, TableBuilder, TextModifiers, TextSpan,
+    Alignment, BorderType, Borders, Color, InputType, PropPayload, PropValue, TableBuilder,
+    TextModifiers, TextSpan,
 };
-use tuirealm::{Component, Event, MockComponent, State, StateValue};
+use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
 pub struct QuitPopup {
@@ -99,6 +100,28 @@ impl Component<Msg, NoUserEvent> for QuitPopup {
             }
             Event::Keyboard(key) if key == self.keys.global_esc.key_event() => {
                 return Some(Msg::QuitPopupCloseCancel)
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Char('y'),
+                ..
+            }) => {
+                // ordering is 0 = No, 1 = Yes
+                self.component.attr(
+                    Attribute::Value,
+                    AttrValue::Payload(PropPayload::One(PropValue::Usize(1))),
+                );
+                self.perform(Cmd::Submit)
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Char('n'),
+                ..
+            }) => {
+                // ordering is 0 = No, 1 = Yes
+                self.component.attr(
+                    Attribute::Value,
+                    AttrValue::Payload(PropPayload::One(PropValue::Usize(0))),
+                );
+                self.perform(Cmd::Submit)
             }
 
             Event::Keyboard(KeyEvent {


### PR DESCRIPTION
This PR adds keybindings for `Y` and `N` to the `QuitPopup` to confirm the choices.
Please note that i am not proficient in tuirealm, so i dont if i set it properly (it looks quite verbose to me)

fixes #108