### PR TITLE
Update `stream-download` and set a custom temporary file prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "stream-download"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decd530574f4938c724cb4f60e83fd357fc579ed0ed4524f15752298ee312704"
+checksum = "809ed111dc3f00305dcbbce2172e0834b3a291d62e2d20c20d01e23907462126"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shellexpand = "3"
 souvlaki = "0.7.2"
-stream-download = "0.4.2"
+stream-download = "0.5"
 symphonia = { version = "0.5.1", features = [
     "default",
     "aac",

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -578,7 +578,7 @@ async fn queue_next(
             let reader = StreamDownload::from_stream(
                 stream,
                 AdaptiveStorageProvider::new(
-                    TempStorageProvider::default(),
+                    TempStorageProvider::with_prefix(".termusic-stream-cache-"),
                     // ensure we have enough buffer space to store the prefetch data
                     NonZeroUsize::new(usize::try_from(settings.get_prefetch_bytes() * 2)?).unwrap(),
                 ),


### PR DESCRIPTION
This PR updates `stream-download` which added the ability to change the prefix for the temporary files (which we already used before switching to `stream-download`)