### PR TITLE
refactor(lib::track): change "media_type" to be non-optional

### DIFF
--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -75,7 +75,7 @@ pub struct Track {
     // Performer
     // Disc
     // Comment
-    pub media_type: Option<MediaType>,
+    pub media_type: MediaType,
     pub podcast_localfile: Option<String>,
 }
 
@@ -121,7 +121,7 @@ impl Track {
             album_photo: ep.image_url.clone(),
             file_type: None,
             genre: None,
-            media_type: Some(MediaType::Podcast),
+            media_type: MediaType::Podcast,
             podcast_localfile,
         }
     }
@@ -149,7 +149,7 @@ impl Track {
                 song.album = tag.album().map(std::borrow::Cow::into_owned);
                 song.title = tag.title().map(std::borrow::Cow::into_owned);
                 song.genre = tag.genre().map(std::borrow::Cow::into_owned);
-                song.media_type = Some(MediaType::Music);
+                song.media_type = MediaType::Music;
 
                 if for_db {
                     return Ok(song);
@@ -223,7 +223,7 @@ impl Track {
         track.artist = Some("Radio".to_string());
         track.title = Some("Radio Station".to_string());
         track.album = Some("Live".to_string());
-        track.media_type = Some(MediaType::LiveRadio);
+        track.media_type = MediaType::LiveRadio;
         track
     }
     fn new<P: AsRef<Path>>(path: P) -> Self {
@@ -267,7 +267,7 @@ impl Track {
             album_photo,
             last_modified,
             genre,
-            media_type: Some(MediaType::Music),
+            media_type: MediaType::Music,
             podcast_localfile: None,
         }
     }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -492,17 +492,16 @@ impl Drop for GStreamerBackend {
 /// Helper function to consistently set the `uri` on `playbin` from a [`Track`]
 fn set_uri_from_track(playbin: &Element, track: &Track) {
     match track.media_type {
-        Some(MediaType::Music) => {
+        MediaType::Music => {
             if let Some(file) = track.file() {
                 let path = Path::new(file);
                 playbin.set_property("uri", path.to_uri());
             }
         }
-        Some(MediaType::Podcast | MediaType::LiveRadio) => {
+        MediaType::Podcast | MediaType::LiveRadio => {
             if let Some(url) = track.file() {
                 playbin.set_property("uri", url);
             }
         }
-        None => error!("no media type found for track"),
     }
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -466,14 +466,14 @@ impl GeneralPlayer {
                     // let time_pos = self.player.position.lock().unwrap();
                     let time_pos = self.get_player().position();
                     match track.media_type {
-                        Some(MediaType::Music) => self
+                        MediaType::Music => self
                             .db
                             .set_last_position(track, time_pos.unwrap_or_default()),
-                        Some(MediaType::Podcast) => {
+                        MediaType::Podcast => {
                             self.db_podcast
                                 .set_last_position(track, time_pos.unwrap_or_default());
                         }
-                        Some(MediaType::LiveRadio) | None => {}
+                        MediaType::LiveRadio => {}
                     }
                 }
             }
@@ -485,14 +485,14 @@ impl GeneralPlayer {
                         // let time_pos = self.player.position.lock().unwrap();
                         let time_pos = self.get_player().position();
                         match track.media_type {
-                            Some(MediaType::Music) => self
+                            MediaType::Music => self
                                 .db
                                 .set_last_position(track, time_pos.unwrap_or_default()),
-                            Some(MediaType::Podcast) => {
+                            MediaType::Podcast => {
                                 self.db_podcast
                                     .set_last_position(track, time_pos.unwrap_or_default());
                             }
-                            Some(MediaType::LiveRadio) | None => {}
+                            MediaType::LiveRadio => {}
                         }
                     }
                 }
@@ -507,20 +507,20 @@ impl GeneralPlayer {
             LastPosition::Yes => {
                 if let Some(track) = self.playlist.current_track() {
                     match track.media_type {
-                        Some(MediaType::Music) => {
+                        MediaType::Music => {
                             if let Ok(last_pos) = self.db.get_last_position(track) {
                                 self.get_player_mut().seek_to(last_pos);
                                 restored = true;
                             }
                         }
 
-                        Some(MediaType::Podcast) => {
+                        MediaType::Podcast => {
                             if let Ok(last_pos) = self.db_podcast.get_last_position(track) {
                                 self.get_player_mut().seek_to(last_pos);
                                 restored = true;
                             }
                         }
-                        Some(MediaType::LiveRadio) | None => {}
+                        MediaType::LiveRadio => {}
                     }
                 }
             }
@@ -530,20 +530,20 @@ impl GeneralPlayer {
                     // 10 minutes
                     if track.duration().as_secs() >= 600 {
                         match track.media_type {
-                            Some(MediaType::Music) => {
+                            MediaType::Music => {
                                 if let Ok(last_pos) = self.db.get_last_position(track) {
                                     self.get_player_mut().seek_to(last_pos);
                                     restored = true;
                                 }
                             }
 
-                            Some(MediaType::Podcast) => {
+                            MediaType::Podcast => {
                                 if let Ok(last_pos) = self.db_podcast.get_last_position(track) {
                                     self.get_player_mut().seek_to(last_pos);
                                     restored = true;
                                 }
                             }
-                            Some(MediaType::LiveRadio) | None => {}
+                            MediaType::LiveRadio => {}
                         }
                     }
                 }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -290,12 +290,12 @@ impl Playlist {
         let mut result = None;
         if let Some(track) = self.current_track() {
             match track.media_type {
-                Some(MediaType::Music | MediaType::LiveRadio) => {
+                MediaType::Music | MediaType::LiveRadio => {
                     if let Some(file) = track.file() {
                         result = Some(file.to_string());
                     }
                 }
-                Some(MediaType::Podcast) => {
+                MediaType::Podcast => {
                     if let Some(local_file) = &track.podcast_localfile {
                         let path = Path::new(&local_file);
                         if path.exists() {
@@ -306,7 +306,6 @@ impl Playlist {
                         result = Some(file.to_string());
                     }
                 }
-                None => {}
             }
         }
         result

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -27,7 +27,7 @@ use self::decoder::buffered_source::BufferedSource;
 use self::decoder::read_seek_source::ReadSeekSource;
 
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use parking_lot::Mutex;
 use std::fs::File;
 use std::path::Path;
@@ -531,9 +531,7 @@ async fn queue_next(
     // _radio_downloaded: &Arc<Mutex<u64>>,
     enqueue: bool,
 ) -> Result<()> {
-    let Some(ref media_type) = track.media_type else {
-        bail!("No media_type, cannot add track!");
-    };
+    let media_type = &track.media_type;
     let file_path = track
         .file()
         .ok_or_else(|| anyhow!("No file path found"))?

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -246,7 +246,7 @@ async fn actual_main() -> Result<()> {
                         player.current_track_updated = false;
                     }
                     if let Some(track) = player.playlist.current_track() {
-                        if let Some(MediaType::LiveRadio) = &track.media_type {
+                        if MediaType::LiveRadio == track.media_type {
                             // TODO: consider changing "radio_title" and "media_title" to be consistent
                             match player.backend {
                                 #[cfg(feature = "mpv")]

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -144,7 +144,7 @@ impl Model {
         let mut pod_title = String::new();
         let mut ep_for_lyric = Episode::default();
         if let Some(track) = self.playlist.current_track().cloned() {
-            if let Some(MediaType::Podcast) = track.media_type {
+            if MediaType::Podcast == track.media_type {
                 if let Some(file) = track.file() {
                     'outer: for pod in &self.podcasts {
                         for ep in &pod.episodes {
@@ -265,7 +265,7 @@ impl Model {
             return;
         }
         if let Some(song) = &self.current_song {
-            if let Some(MediaType::LiveRadio) = song.media_type {
+            if MediaType::LiveRadio == song.media_type {
                 return;
             }
 
@@ -290,7 +290,7 @@ impl Model {
 
     pub fn lyric_update_for_radio(&mut self, radio_title: &str) {
         if let Some(song) = self.playlist.current_track() {
-            if let Some(MediaType::LiveRadio) = song.media_type {
+            if MediaType::LiveRadio == song.media_type {
                 let line = radio_title.to_string();
                 if line.is_empty() {
                     return;
@@ -350,18 +350,17 @@ impl Model {
 
         if let Some(track) = &self.current_song {
             match track.media_type {
-                Some(MediaType::Music) => {
+                MediaType::Music => {
                     let artist = track.artist().unwrap_or("Unknown Artist");
                     let title = track.title().unwrap_or("Unknown Title");
                     lyric_title = format!(" Lyrics of {artist:^.20} - {title:^.20} ");
                 }
-                Some(MediaType::Podcast) => {
+                MediaType::Podcast => {
                     lyric_title = " Details: ".to_string();
                 }
-                Some(MediaType::LiveRadio) => {
+                MediaType::LiveRadio => {
                     lyric_title = " Live Radio ".to_string();
                 }
-                None => {}
             }
         }
         self.lyric_title_set(&lyric_title);

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -957,7 +957,7 @@ impl Model {
             return Ok(());
         }
         if let Some(track) = self.playlist.current_track() {
-            if let Some(MediaType::Podcast) = track.media_type {
+            if MediaType::Podcast == track.media_type {
                 if let Some(url) = track.file() {
                     'outer: for pod in &mut self.podcasts {
                         for ep in &mut pod.episodes {

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -83,7 +83,7 @@ impl Model {
         let mut progress_title = String::new();
         if let Some(track) = &self.current_song {
             match track.media_type {
-                Some(MediaType::Music | MediaType::LiveRadio) => {
+                MediaType::Music | MediaType::LiveRadio => {
                     progress_title = format!(
                         " Status: {} | Volume: {} | Speed: {:^.1} | Gapless: {} ",
                         self.playlist.status(),
@@ -92,7 +92,7 @@ impl Model {
                         gapless,
                     );
                 }
-                Some(MediaType::Podcast) => {
+                MediaType::Podcast => {
                     progress_title = format!(
                         " Status: {} {:^.20} | Volume: {} | Speed: {:^.1} | Gapless: {} ",
                         self.playlist.status(),
@@ -102,7 +102,6 @@ impl Model {
                         gapless,
                     );
                 }
-                None => {}
             }
         }
 

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -113,7 +113,7 @@ impl Model {
         };
 
         match track.media_type {
-            Some(MediaType::Music) => {
+            MediaType::Music => {
                 // just show the first photo
                 if let Some(picture) = track.picture() {
                     if let Ok(image) = image::load_from_memory(picture.data()) {
@@ -127,7 +127,7 @@ impl Model {
                     self.show_image(&img)?;
                 }
             }
-            Some(MediaType::Podcast) => {
+            MediaType::Podcast => {
                 let mut url = String::new();
                 if let Some(episode_photo_url) = track.album_photo() {
                     url = episode_photo_url.to_string();
@@ -177,7 +177,7 @@ impl Model {
                     // }
                 });
             }
-            Some(MediaType::LiveRadio) | None => {}
+            MediaType::LiveRadio => {}
         }
 
         Ok(())

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -296,7 +296,7 @@ impl Model {
 
     pub fn is_radio(&self) -> bool {
         if let Some(track) = self.playlist.current_track() {
-            if track.media_type == Some(MediaType::LiveRadio) {
+            if track.media_type == MediaType::LiveRadio {
                 return true;
             }
         }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -995,19 +995,18 @@ impl Model {
     pub fn update_layout_for_current_track(&mut self) {
         if let Some(track) = self.playlist.current_track() {
             match track.media_type {
-                Some(MediaType::Podcast) => {
+                MediaType::Podcast => {
                     if self.layout == TermusicLayout::Podcast {
                         return;
                     }
                     self.update_layout(&Msg::LayoutPodCast);
                 }
-                Some(MediaType::Music | MediaType::LiveRadio) => match self.layout {
+                MediaType::Music | MediaType::LiveRadio => match self.layout {
                     TermusicLayout::TreeView | TermusicLayout::DataBase => {}
                     TermusicLayout::Podcast => {
                         self.update_layout(&Msg::LayoutTreeView);
                     }
                 },
-                None => {}
             }
         }
     }


### PR DESCRIPTION
This PR changes `Track`'s `media_type` to not be option, as it has not been used optionally. also a track should likely always identify what type it is.