### PR TITLE
Refactor rusty_backend function to properly return results & move main player loop to own function

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -115,7 +115,7 @@ async fn actual_main() -> Result<()> {
         TcpIncoming::from_listener(tcp_listener, true, None).map_err(|e| anyhow::anyhow!(e))?;
 
     let player_handle = tokio::task::spawn_blocking(move || -> Result<()> {
-        let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx.clone())?;
+        let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx)?;
         // move "cmd_rx" and change to be mutable
         let mut cmd_rx = cmd_rx;
         while let Some(cmd) = cmd_rx.blocking_recv() {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -3,18 +3,23 @@ mod logger;
 mod music_player_service;
 
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use music_player_service::MusicPlayerService;
+use parking_lot::Mutex;
 use termusiclib::config::Settings;
 use termusiclib::track::MediaType;
 use termusicplayback::player::music_player_server::MusicPlayerServer;
 use termusicplayback::player::{GetProgressResponse, PlayerTime};
 use termusicplayback::{
-    Backend, GeneralPlayer, PlayerCmd, PlayerCmdSender, PlayerProgress, PlayerTrait, Status,
+    Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
+    PlayerProgress, PlayerTrait, Status,
 };
+use tokio::runtime::Handle;
+use tokio::sync::oneshot;
 use tonic::transport::server::TcpIncoming;
 use tonic::transport::Server;
 
@@ -90,7 +95,7 @@ async fn actual_main() -> Result<()> {
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
 
     let music_player_service: MusicPlayerService = MusicPlayerService::new(cmd_tx.clone());
-    let mut config = get_config(&args)?;
+    let config = get_config(&args)?;
     let playerstats = music_player_service.player_stats.clone();
 
     let cmd_tx_ctrlc = cmd_tx.clone();
@@ -114,211 +119,15 @@ async fn actual_main() -> Result<()> {
     let tcp_stream =
         TcpIncoming::from_listener(tcp_listener, true, None).map_err(|e| anyhow::anyhow!(e))?;
 
-    let player_handle = tokio::task::spawn_blocking(move || -> Result<()> {
-        let mut player = GeneralPlayer::new_backend(args.backend.into(), &config, cmd_tx)?;
-        // move "cmd_rx" and change to be mutable
-        let mut cmd_rx = cmd_rx;
-        while let Some(cmd) = cmd_rx.blocking_recv() {
-            #[allow(unreachable_patterns)]
-            match cmd {
-                PlayerCmd::AboutToFinish => {
-                    info!("about to finish signal received");
-                    if !player.playlist.is_empty()
-                        && !player.playlist.has_next_track()
-                        && player.config.player_gapless
-                    {
-                        player.enqueue_next_from_playlist();
-                    }
-                }
-                PlayerCmd::Quit => {
-                    info!("PlayerCmd::Quit received");
-                    player.player_save_last_position();
-                    if let Err(e) = player.playlist.save() {
-                        error!("error when saving playlist: {e}");
-                    };
-                    if let Err(e) = config.save() {
-                        error!("error when saving config: {e}");
-                    };
-                    std::process::exit(0);
-                }
-                PlayerCmd::CycleLoop => {
-                    config.player_loop_mode = player.playlist.cycle_loop_mode();
-                }
-                PlayerCmd::Eos => {
-                    info!("Eos received");
-                    if player.playlist.is_empty() {
-                        player.stop();
-                        continue;
-                    }
-                    debug!(
-                        "current track index: {:?}",
-                        player.playlist.get_current_track_index()
-                    );
-                    player.playlist.clear_current_track();
-                    player.start_play();
-                    debug!(
-                        "playing index is: {}",
-                        player.playlist.get_current_track_index()
-                    );
-                }
-                PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
-                PlayerCmd::PlaySelected => {
-                    info!("play selected");
-                    player.player_save_last_position();
-                    player.playlist.proceed_false();
-                    player.next();
-                }
-                PlayerCmd::SkipPrevious => {
-                    info!("skip to previous track");
-                    player.player_save_last_position();
-                    player.previous();
-                }
-                PlayerCmd::ReloadConfig => {
-                    config.load()?;
-                    info!("config reloaded");
-                    player.config = config.clone();
-                }
-                PlayerCmd::ReloadPlaylist => {
-                    player.playlist.reload_tracks().ok();
-                }
-                PlayerCmd::SeekBackward => {
-                    player.seek_relative(false);
-                    let mut p_tick = playerstats.lock();
-                    if let Some(progress) = player.get_progress() {
-                        p_tick.progress = progress
-                    }
-                }
-                PlayerCmd::SeekForward => {
-                    player.seek_relative(true);
-                    let mut p_tick = playerstats.lock();
-                    if let Some(progress) = player.get_progress() {
-                        p_tick.progress = progress
-                    }
-                }
-                PlayerCmd::SkipNext => {
-                    info!("skip to next track.");
-                    player.player_save_last_position();
-                    player.next();
-                }
-                PlayerCmd::SpeedDown => {
-                    player.speed_down();
-                    info!("after speed down: {}", player.speed());
-                    config.player_speed = player.speed();
-                    let mut p_tick = playerstats.lock();
-                    p_tick.speed = config.player_speed;
-                }
-
-                PlayerCmd::SpeedUp => {
-                    player.speed_up();
-                    info!("after speed up: {}", player.speed());
-                    config.player_speed = player.speed();
-                    let mut p_tick = playerstats.lock();
-                    p_tick.speed = config.player_speed;
-                }
-                PlayerCmd::Tick => {
-                    // info!("tick received");
-                    if config.player_use_mpris {
-                        player.update_mpris();
-                    }
-                    let mut p_tick = playerstats.lock();
-                    p_tick.status = player.playlist.status().as_u32();
-                    // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
-                    if player.playlist.status() == Status::Stopped {
-                        if player.playlist.is_empty() {
-                            continue;
-                        }
-                        debug!(
-                            "current track index: {:?}",
-                            player.playlist.get_current_track_index()
-                        );
-                        player.playlist.clear_current_track();
-                        player.playlist.proceed_false();
-                        player.start_play();
-                        continue;
-                    }
-                    if let Some(progress) = player.get_progress() {
-                        p_tick.progress = progress
-                    }
-                    if player.current_track_updated {
-                        p_tick.current_track_index =
-                            player.playlist.get_current_track_index() as u32;
-                        p_tick.current_track_updated = player.current_track_updated;
-                        player.current_track_updated = false;
-                    }
-                    if let Some(track) = player.playlist.current_track() {
-                        if MediaType::LiveRadio == track.media_type {
-                            // TODO: consider changing "radio_title" and "media_title" to be consistent
-                            match player.backend {
-                                #[cfg(feature = "mpv")]
-                                Backend::Mpv(ref mut backend) => {
-                                    p_tick.radio_title = backend.media_title.lock().clone();
-                                }
-                                #[cfg(feature = "rusty")]
-                                Backend::Rusty(ref mut backend) => {
-                                    p_tick.radio_title = backend.radio_title.lock().clone();
-                                    p_tick.progress.total_duration = Some(Duration::from_secs(
-                                        ((*backend.radio_downloaded.lock() as f32 * 44100.0
-                                            / 1000000.0
-                                            / 1024.0)
-                                            * (backend.speed() as f32 / 10.0))
-                                            as u64,
-                                    ));
-                                }
-                                #[cfg(feature = "gst")]
-                                Backend::GStreamer(ref mut backend) => {
-                                    // p_tick.duration = player.backend.get_buffer_duration();
-                                    // error!("buffer duration: {}", p_tick.duration);
-                                    p_tick.progress.total_duration = Some(
-                                        p_tick.progress.position.unwrap_or_default()
-                                            + Duration::from_secs(20),
-                                    );
-                                    p_tick.radio_title = backend.radio_title.lock().clone();
-                                    // error!("radio title: {}", p_tick.radio_title);
-                                }
-                            }
-                        }
-                    }
-                }
-                PlayerCmd::ToggleGapless => {
-                    config.player_gapless = player.toggle_gapless();
-                    let mut p_tick = playerstats.lock();
-                    p_tick.gapless = config.player_gapless;
-                }
-                PlayerCmd::TogglePause => {
-                    info!("player toggled pause");
-                    player.toggle_pause();
-                    let mut p_tick = playerstats.lock();
-                    p_tick.status = player.playlist.status().as_u32();
-                }
-                PlayerCmd::VolumeDown => {
-                    info!("before volumedown: {}", player.volume());
-                    player.volume_down();
-                    let new_volume = player.volume();
-                    config.player_volume = new_volume;
-                    info!("after volumedown: {}", player.volume());
-                    let mut p_tick = playerstats.lock();
-                    p_tick.volume = new_volume;
-                }
-                PlayerCmd::VolumeUp => {
-                    info!("before volumeup: {}", player.volume());
-                    player.volume_up();
-                    let new_volume = player.volume();
-                    config.player_volume = new_volume;
-                    info!("after volumeup: {}", player.volume());
-                    let mut p_tick = playerstats.lock();
-                    p_tick.volume = new_volume;
-                }
-                PlayerCmd::Pause => {
-                    player.pause();
-                }
-                PlayerCmd::Play => {
-                    player.resume();
-                }
-            }
-        }
-
-        Ok(())
-    });
+    let tokio_handle = Handle::current();
+    let (player_handle_os_tx, player_handle_os_rx) = oneshot::channel();
+    let player_handle = std::thread::Builder::new()
+        .name("main player loop".into())
+        .spawn(move || {
+            let _guard = tokio_handle.enter();
+            let res = player_loop(args.backend.into(), cmd_tx, cmd_rx, config, playerstats);
+            let _ = player_handle_os_tx.send(res);
+        })?;
 
     ticker_thread(cmd_tx_ticker)?;
 
@@ -328,9 +137,221 @@ async fn actual_main() -> Result<()> {
             .serve_with_incoming(tcp_stream),
     );
 
-    // if the underlying task/thread panicked, the error will be "task X panicked" instead of the actual panic (with no workaround?)
-    // see the log or stderr for actual panic
-    player_handle.await??;
+    // await the oneshot completing in a async fashion
+    player_handle_os_rx.await??;
+    // do this *after* the oneshot, because this is a blocking operation
+    // and by doing this after the oneshot we can be sure the thread is actually exited, or exiting
+    let _ = player_handle.join();
+
+    Ok(())
+}
+
+/// The main player loop where we handle all events
+fn player_loop(
+    backend: BackendSelect,
+    cmd_tx: PlayerCmdSender,
+    mut cmd_rx: PlayerCmdReciever,
+    mut config: Settings,
+    playerstats: Arc<Mutex<PlayerStats>>,
+) -> Result<()> {
+    let mut player = GeneralPlayer::new_backend(backend, &config, cmd_tx)?;
+    while let Some(cmd) = cmd_rx.blocking_recv() {
+        #[allow(unreachable_patterns)]
+        match cmd {
+            PlayerCmd::AboutToFinish => {
+                info!("about to finish signal received");
+                if !player.playlist.is_empty()
+                    && !player.playlist.has_next_track()
+                    && player.config.player_gapless
+                {
+                    player.enqueue_next_from_playlist();
+                }
+            }
+            PlayerCmd::Quit => {
+                info!("PlayerCmd::Quit received");
+                player.player_save_last_position();
+                if let Err(e) = player.playlist.save() {
+                    error!("error when saving playlist: {e}");
+                };
+                if let Err(e) = config.save() {
+                    error!("error when saving config: {e}");
+                };
+                std::process::exit(0);
+            }
+            PlayerCmd::CycleLoop => {
+                config.player_loop_mode = player.playlist.cycle_loop_mode();
+            }
+            PlayerCmd::Eos => {
+                info!("Eos received");
+                if player.playlist.is_empty() {
+                    player.stop();
+                    continue;
+                }
+                debug!(
+                    "current track index: {:?}",
+                    player.playlist.get_current_track_index()
+                );
+                player.playlist.clear_current_track();
+                player.start_play();
+                debug!(
+                    "playing index is: {}",
+                    player.playlist.get_current_track_index()
+                );
+            }
+            PlayerCmd::GetProgress | PlayerCmd::ProcessID => {}
+            PlayerCmd::PlaySelected => {
+                info!("play selected");
+                player.player_save_last_position();
+                player.playlist.proceed_false();
+                player.next();
+            }
+            PlayerCmd::SkipPrevious => {
+                info!("skip to previous track");
+                player.player_save_last_position();
+                player.previous();
+            }
+            PlayerCmd::ReloadConfig => {
+                config.load()?;
+                info!("config reloaded");
+                player.config = config.clone();
+            }
+            PlayerCmd::ReloadPlaylist => {
+                player.playlist.reload_tracks().ok();
+            }
+            PlayerCmd::SeekBackward => {
+                player.seek_relative(false);
+                let mut p_tick = playerstats.lock();
+                if let Some(progress) = player.get_progress() {
+                    p_tick.progress = progress
+                }
+            }
+            PlayerCmd::SeekForward => {
+                player.seek_relative(true);
+                let mut p_tick = playerstats.lock();
+                if let Some(progress) = player.get_progress() {
+                    p_tick.progress = progress
+                }
+            }
+            PlayerCmd::SkipNext => {
+                info!("skip to next track.");
+                player.player_save_last_position();
+                player.next();
+            }
+            PlayerCmd::SpeedDown => {
+                player.speed_down();
+                info!("after speed down: {}", player.speed());
+                config.player_speed = player.speed();
+                let mut p_tick = playerstats.lock();
+                p_tick.speed = config.player_speed;
+            }
+
+            PlayerCmd::SpeedUp => {
+                player.speed_up();
+                info!("after speed up: {}", player.speed());
+                config.player_speed = player.speed();
+                let mut p_tick = playerstats.lock();
+                p_tick.speed = config.player_speed;
+            }
+            PlayerCmd::Tick => {
+                // info!("tick received");
+                if config.player_use_mpris {
+                    player.update_mpris();
+                }
+                let mut p_tick = playerstats.lock();
+                p_tick.status = player.playlist.status().as_u32();
+                // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
+                if player.playlist.status() == Status::Stopped {
+                    if player.playlist.is_empty() {
+                        continue;
+                    }
+                    debug!(
+                        "current track index: {:?}",
+                        player.playlist.get_current_track_index()
+                    );
+                    player.playlist.clear_current_track();
+                    player.playlist.proceed_false();
+                    player.start_play();
+                    continue;
+                }
+                if let Some(progress) = player.get_progress() {
+                    p_tick.progress = progress
+                }
+                if player.current_track_updated {
+                    p_tick.current_track_index = player.playlist.get_current_track_index() as u32;
+                    p_tick.current_track_updated = player.current_track_updated;
+                    player.current_track_updated = false;
+                }
+                if let Some(track) = player.playlist.current_track() {
+                    if MediaType::LiveRadio == track.media_type {
+                        // TODO: consider changing "radio_title" and "media_title" to be consistent
+                        match player.backend {
+                            #[cfg(feature = "mpv")]
+                            Backend::Mpv(ref mut backend) => {
+                                p_tick.radio_title = backend.media_title.lock().clone();
+                            }
+                            #[cfg(feature = "rusty")]
+                            Backend::Rusty(ref mut backend) => {
+                                p_tick.radio_title = backend.radio_title.lock().clone();
+                                p_tick.progress.total_duration = Some(Duration::from_secs(
+                                    ((*backend.radio_downloaded.lock() as f32 * 44100.0
+                                        / 1000000.0
+                                        / 1024.0)
+                                        * (backend.speed() as f32 / 10.0))
+                                        as u64,
+                                ));
+                            }
+                            #[cfg(feature = "gst")]
+                            Backend::GStreamer(ref mut backend) => {
+                                // p_tick.duration = player.backend.get_buffer_duration();
+                                // error!("buffer duration: {}", p_tick.duration);
+                                p_tick.progress.total_duration = Some(
+                                    p_tick.progress.position.unwrap_or_default()
+                                        + Duration::from_secs(20),
+                                );
+                                p_tick.radio_title = backend.radio_title.lock().clone();
+                                // error!("radio title: {}", p_tick.radio_title);
+                            }
+                        }
+                    }
+                }
+            }
+            PlayerCmd::ToggleGapless => {
+                config.player_gapless = player.toggle_gapless();
+                let mut p_tick = playerstats.lock();
+                p_tick.gapless = config.player_gapless;
+            }
+            PlayerCmd::TogglePause => {
+                info!("player toggled pause");
+                player.toggle_pause();
+                let mut p_tick = playerstats.lock();
+                p_tick.status = player.playlist.status().as_u32();
+            }
+            PlayerCmd::VolumeDown => {
+                info!("before volumedown: {}", player.volume());
+                player.volume_down();
+                let new_volume = player.volume();
+                config.player_volume = new_volume;
+                info!("after volumedown: {}", player.volume());
+                let mut p_tick = playerstats.lock();
+                p_tick.volume = new_volume;
+            }
+            PlayerCmd::VolumeUp => {
+                info!("before volumeup: {}", player.volume());
+                player.volume_up();
+                let new_volume = player.volume();
+                config.player_volume = new_volume;
+                info!("after volumeup: {}", player.volume());
+                let mut p_tick = playerstats.lock();
+                p_tick.volume = new_volume;
+            }
+            PlayerCmd::Pause => {
+                player.pause();
+            }
+            PlayerCmd::Play => {
+                player.resume();
+            }
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This PR does:
- convert `rusty_backend::queue_next` to always return Results instead of just logging `error!`
- dont construct a new tokio runtime, use the current one already available*1
- move `server`'s main command handling loop to own function
- move `server`'s main command handling loop to be its own thread instead of tokio's spawn_blocking ([more adhering to](https://ryhl.io/blog/async-what-is-blocking/))

*1 in the future, we could convert that function to also be async