### PR TITLE
This PR lessens the size of the binaries somewhat

### DIFF
--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -70,8 +70,7 @@ use tuirealm::{AttrValue, Attribute, Frame, State, StateValue};
 impl Model {
     #[allow(clippy::too_many_lines)]
     pub fn view_config_editor_general(&mut self) {
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -222,7 +221,7 @@ impl Model {
 
                 Self::view_config_editor_commons(f, &mut self.app);
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     fn view_config_editor_commons(f: &mut Frame<'_>, app: &mut Application<Id, Msg, NoUserEvent>) {
@@ -340,8 +339,7 @@ impl Model {
             Ok(State::One(_)) => 3,
             _ => 8,
         };
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -562,7 +560,7 @@ impl Model {
                 );
                 Self::view_config_editor_commons(f, &mut self.app);
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     #[allow(clippy::too_many_lines)]
@@ -786,8 +784,7 @@ impl Model {
             _ => 8,
         };
 
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -1072,7 +1069,7 @@ impl Model {
                 );
                 Self::view_config_editor_commons(f, &mut self.app);
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     #[allow(clippy::too_many_lines)]
@@ -1281,8 +1278,7 @@ impl Model {
             _ => 8,
         };
 
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -1552,7 +1548,7 @@ impl Model {
                 );
                 Self::view_config_editor_commons(f, &mut self.app);
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     #[allow(clippy::too_many_lines)]

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -39,8 +39,7 @@ use tuirealm::State;
 impl Model {
     #[allow(clippy::too_many_lines)]
     pub fn view_tag_editor(&mut self) {
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let select_lyric_len =
@@ -169,7 +168,7 @@ impl Model {
                     }
                 }
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     pub fn mount_tageditor(&mut self, node_id: &str) {

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -181,8 +181,7 @@ impl Model {
     }
 
     pub fn view_layout_podcast(&mut self) {
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -223,11 +222,10 @@ impl Model {
 
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
     pub fn view_layout_database(&mut self) {
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -278,12 +276,11 @@ impl Model {
                 self.app.view(&Id::Lyric, f, chunks_right[2]);
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     pub fn view_layout_treeview(&mut self) {
-        assert!(self
-            .terminal
+        self.terminal
             .raw_mut()
             .draw(|f| {
                 let chunks_main = Layout::default()
@@ -317,7 +314,7 @@ impl Model {
 
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
-            .is_ok());
+            .expect("Expected to draw without error");
     }
 
     #[allow(clippy::too_many_lines)]

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -642,8 +642,7 @@ impl Model {
     }
 
     pub fn mount_label_help(&mut self) {
-        assert!(self
-            .app
+        self.app
             .remount(
                 Id::Label,
                 Box::new(LabelSpan::new(
@@ -734,11 +733,11 @@ impl Model {
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
-                    ]
+                    ],
                 )),
                 Vec::default(),
             )
-            .is_ok());
+            .expect("Expected to remount without error");
     }
 
     pub fn umount_error_popup(&mut self) {
@@ -785,8 +784,7 @@ impl Model {
         let mut path_string = get_parent_folder(&current_node);
         path_string.push('/');
 
-        assert!(self
-            .app
+        self.app
             .remount(
                 Id::SavePlaylistLabel,
                 Box::new(LabelSpan::new(
@@ -814,11 +812,11 @@ impl Model {
                                 .library_foreground()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
-                    ]
+                    ],
                 )),
                 Vec::default(),
             )
-            .is_ok());
+            .expect("Expected to remount without error");
         Ok(())
     }
 


### PR DESCRIPTION
This PR changes some `assert!` macros to be `.expect` because `assert!` includes the full code it gets passed in the binary to print on error.

stats:
format: master(e85f574a48befbf4a53560ec8a2200a350c987dd) -> this pr(e77b6897cf705f44f45520f7b37777f1f81fa99d)
features: default + `all-backends`
both versions build using the same system libraries and linker

debug:
termusic: `312232568 bytes` (298M) -> `312004360 bytes` (298M) [`-228208 bytes`, ~ -222KB]
termusic-server: `292698264 bytes` (280M) -> `292698264 bytes` (280M) [-0]

release:
termusic: `30696952 bytes` (30M) -> `30658784 bytes` (30M) [`-38168 bytes`, ~ -37KB]
termusic-server: `23586352 bytes` (23M) -> `23586352 bytes` (23M) [-0]