### PR TITLE
Change tui `mount_error_popup` to accept raw Errors instead of strings

### DIFF
--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -167,6 +167,5 @@ fn on_error() -> Result<()> {
 #[inline]
 #[allow(clippy::needless_pass_by_value)]
 fn map_err(err: anyhow::Error) -> anyhow::Error {
-    // err.context("Failed to run Ueberzug")
-    anyhow::anyhow!("Failed to run Ueberzug: {}", err)
+    err.context("Failed to run Ueberzug")
 }

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -158,7 +158,7 @@ impl UeInstance {
 #[inline]
 #[allow(clippy::unnecessary_wraps)]
 fn on_error() -> Result<()> {
-    info!("Not re-trying ueberzug, because it has a permanent error!");
+    trace!("Not re-trying ueberzug, because it has a permanent error!");
 
     Ok(())
 }

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -149,13 +149,13 @@ impl Model {
                                 self.command(&PlayerCmd::ReloadConfig);
                             }
                             Err(e) => {
-                                self.mount_error_popup(format!("error when saving config: {e}"));
+                                self.mount_error_popup(e.context("save config"));
                             }
                         }
                         self.umount_config_editor();
                     }
                     Err(e) => {
-                        self.mount_error_popup(format!("save config error: {e}"));
+                        self.mount_error_popup(e.context("collect config data"));
                         self.config_changed = true;
                     }
                 }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1722,11 +1722,11 @@ impl Model {
             .is_ok());
 
         if let Err(e) = self.theme_select_load_themes() {
-            self.mount_error_popup(format!("Error load themes: {e}"));
+            self.mount_error_popup(e.context("load themes"));
         }
         self.theme_select_sync();
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("clear photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -2961,7 +2961,7 @@ impl Model {
             .is_ok());
 
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -256,7 +256,7 @@ impl Model {
     pub fn lyric_update(&mut self) {
         if self.layout == TermusicLayout::Podcast {
             if let Err(e) = self.lyric_update_for_podcast() {
-                self.mount_error_popup(format!("update episode description error: {e}"));
+                self.mount_error_popup(e.context("lyric update for podcast"));
             }
             return;
         }
@@ -334,7 +334,7 @@ impl Model {
     pub fn lyric_adjust_delay(&mut self, offset: i64) {
         if let Some(track) = self.playlist.current_track_as_mut() {
             if let Err(e) = track.adjust_lyric_delay(self.time_pos, offset) {
-                self.mount_error_popup(format!("adjust lyric delay error: {e}"));
+                self.mount_error_popup(e.context("adjust lyric delay"));
             };
         }
     }

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -333,10 +333,10 @@ impl Model {
         let vec2: Vec<String> = vec.iter().map(|f| f.file.clone()).collect();
         let vec3: Vec<&str> = vec2.iter().map(std::convert::AsRef::as_ref).collect();
         if let Err(e) = self.playlist.add_playlist(vec3) {
-            self.mount_error_popup(format!("Error add all from db: {e}"));
+            self.mount_error_popup(e.context("add all to playlist from database"));
         }
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.playlist_sync();
     }
@@ -459,7 +459,7 @@ impl Model {
         }
         self.playlist.remove(index);
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.playlist_sync();
     }
@@ -467,7 +467,7 @@ impl Model {
     pub fn playlist_clear(&mut self) {
         self.playlist.clear();
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.playlist_sync();
     }
@@ -475,7 +475,7 @@ impl Model {
     pub fn playlist_shuffle(&mut self) {
         self.playlist.shuffle();
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.playlist_sync();
     }
@@ -483,7 +483,7 @@ impl Model {
     pub fn playlist_update_library_delete(&mut self) {
         self.playlist.remove_deleted_items();
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.playlist_sync();
     }
@@ -507,7 +507,7 @@ impl Model {
     pub fn playlist_play_selected(&mut self, index: usize) {
         self.playlist.set_current_track_index(index);
         if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(format!("sync playlist error: {e}"));
+            self.mount_error_popup(e.context("player sync playlist"));
         }
         self.command(&PlayerCmd::PlaySelected);
     }

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -480,7 +480,7 @@ impl Model {
             )
             .ok();
         if let Err(e) = self.podcast_sync_episodes() {
-            self.mount_error_popup(format!("Error sync episodes: {e}"));
+            self.mount_error_popup(e.context("podcast sync episodes"));
         }
     }
 

--- a/tui/src/ui/components/popups.rs
+++ b/tui/src/ui/components/popups.rs
@@ -152,6 +152,8 @@ pub struct ErrorPopup {
 
 impl ErrorPopup {
     pub fn new<S: AsRef<str>>(msg: S) -> Self {
+        let msg = msg.as_ref();
+        error!("Displaying error popup: {}", msg);
         Self {
             component: Paragraph::default()
                 .borders(
@@ -163,7 +165,7 @@ impl ErrorPopup {
                 // .background(Color::Black)
                 .modifiers(TextModifiers::BOLD)
                 .alignment(Alignment::Center)
-                .text(vec![TextSpan::from(msg.as_ref().to_string())].as_slice()),
+                .text(&vec![TextSpan::from(msg)]),
         }
     }
 }

--- a/tui/src/ui/components/popups.rs
+++ b/tui/src/ui/components/popups.rs
@@ -161,6 +161,7 @@ impl ErrorPopup {
                         .color(Color::Red)
                         .modifiers(BorderType::Rounded),
                 )
+                .title(" Error ", Alignment::Center)
                 .foreground(Color::Red)
                 // .background(Color::Black)
                 .modifiers(TextModifiers::BOLD)

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -294,7 +294,7 @@ impl Model {
             match song.save_tag() {
                 Ok(()) => self.init_by_song(&song),
                 Err(e) => {
-                    self.mount_error_popup(&e.to_string());
+                    self.mount_error_popup(e);
                 }
             }
         }

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -50,17 +50,17 @@ impl Model {
             }
             TEMsg::TEDownload(index) => {
                 if let Err(e) = self.te_songtag_download(*index) {
-                    self.mount_error_popup(format!("download song by tag error: {e}"));
+                    self.mount_error_popup(e.context("download by songtag"));
                 }
             }
             TEMsg::TEEmbed(index) => {
                 if let Err(e) = self.te_load_lyric_and_photo(*index) {
-                    self.mount_error_popup(format!("embed error: {e}"));
+                    self.mount_error_popup(e.context("log lyric and photo"));
                 }
             }
             TEMsg::TERename => {
                 if let Err(e) = self.te_rename_song_by_tag() {
-                    self.mount_error_popup(format!("rename song by tag error: {e}"));
+                    self.mount_error_popup(e.context("rename song by tag"));
                 }
             }
             TEMsg::TEFocus(m) => self.update_tag_editor_focus(m),

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -175,7 +175,7 @@ impl Model {
     pub fn mount_tageditor(&mut self, node_id: &str) {
         let p: &Path = Path::new(node_id);
         if p.is_dir() {
-            self.mount_error_popup("directory doesn't have tag!");
+            self.mount_error_popup(anyhow::anyhow!("{p:?} directory doesn't have tag!"));
             return;
         }
 
@@ -262,11 +262,11 @@ impl Model {
                 self.init_by_song(&s);
             }
             Err(e) => {
-                self.mount_error_popup(format!("song load error: {e}"));
+                self.mount_error_popup(e.context("track parse"));
             }
         };
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("clear photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
     pub fn umount_tageditor(&mut self) {
@@ -298,7 +298,7 @@ impl Model {
             .umount(&Id::TagEditor(IdTagEditor::TextareaLyric))
             .ok();
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -184,7 +184,7 @@ impl Model {
     #[allow(clippy::cast_possible_truncation)]
     pub fn show_image(&mut self, img: &DynamicImage) -> Result<()> {
         match self.config.album_photo_xywh.update_size(img) {
-            Err(e) => self.mount_error_popup(e.to_string()),
+            Err(e) => self.mount_error_popup(e),
             Ok(xywh) => {
                 // error!("{:?}", self.viuer_supported);
                 match self.viuer_supported {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -112,7 +112,7 @@ impl UI {
             match self.model.app.tick(PollStrategy::Once) {
                 Err(err) => {
                     self.model
-                        .mount_error_popup(format!("Application error: {err}"));
+                        .mount_error_popup((anyhow::anyhow!(err)).context("tick poll error"));
                 }
                 Ok(messages) if !messages.is_empty() => {
                     // NOTE: redraw if at least one msg has been processed
@@ -175,7 +175,7 @@ impl UI {
 
         if let Err(e) = self.model.podcast_mark_current_track_played() {
             self.model
-                .mount_error_popup(format!("Error when mark episode as played: {e}"));
+                .mount_error_popup(e.context("Marking podcast track as played"));
         }
     }
 

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -35,7 +35,7 @@ use termusiclib::{
     track::{MediaType, Track},
 };
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
@@ -219,7 +219,7 @@ impl Model {
 
     pub fn init_config(&mut self) {
         if let Err(e) = Self::theme_select_save() {
-            self.mount_error_popup(format!("theme save error: {e}"));
+            self.mount_error_popup(e.context("theme save"));
         }
         self.mount_label_help();
         self.db.sync_database(&self.path);
@@ -268,7 +268,7 @@ impl Model {
     pub fn player_update_current_track_after(&mut self) {
         self.time_pos = Duration::default();
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         };
         self.progress_update_title();
         self.lyric_update_title();
@@ -290,7 +290,7 @@ impl Model {
 
     pub fn command(&mut self, cmd: &PlayerCmd) {
         if let Err(e) = self.cmd_tx.send(cmd.clone()) {
-            self.mount_error_popup(format!("error in {cmd:?}: {e}"));
+            self.mount_error_popup((anyhow!(e)).context(format!("{cmd:?}")));
         }
     }
 

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -438,8 +438,9 @@ impl Model {
             app.view(&Id::ErrorPopup, f, popup);
         }
     }
-    // Mount error and give focus to it
-    pub fn mount_error_popup<S: AsRef<str>>(&mut self, err: S) {
+    /// Mount error and give focus to it
+    // This should likely be refactored to be "std::error::Error", but see https://github.com/dtolnay/anyhow/issues/63 on why it was easier this way
+    pub fn mount_error_popup<E: Into<anyhow::Error>>(&mut self, err: E) {
         assert!(self
             .app
             .remount(Id::ErrorPopup, Box::new(ErrorPopup::new(err)), vec![])
@@ -492,7 +493,7 @@ impl Model {
 
         assert!(self.app.active(&Id::GeneralSearchInput).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -515,7 +516,7 @@ impl Model {
             .is_ok());
         assert!(self.app.active(&Id::GeneralSearchInput).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -538,7 +539,7 @@ impl Model {
             .is_ok());
         assert!(self.app.active(&Id::GeneralSearchInput).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -562,7 +563,7 @@ impl Model {
 
         assert!(self.app.active(&Id::GeneralSearchInput).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -586,7 +587,7 @@ impl Model {
 
         assert!(self.app.active(&Id::GeneralSearchInput).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 
@@ -613,7 +614,7 @@ impl Model {
             .is_ok());
         assert!(self.app.active(&Id::YoutubeSearchTablePopup).is_ok());
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
     pub fn mount_message(&mut self, title: &str, text: &str) {
@@ -752,7 +753,7 @@ impl Model {
             assert!(self.app.umount(&Id::YoutubeSearchTablePopup).is_ok());
         }
         if let Err(e) = self.update_photo() {
-            self.mount_error_popup(format!("update photo error: {e}"));
+            self.mount_error_popup(e.context("update_photo"));
         }
     }
 

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -440,7 +440,6 @@ impl Model {
     }
     // Mount error and give focus to it
     pub fn mount_error_popup<S: AsRef<str>>(&mut self, err: S) {
-        error!("Displaying error popup: {}", err.as_ref());
         assert!(self
             .app
             .remount(Id::ErrorPopup, Box::new(ErrorPopup::new(err)), vec![])

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -81,13 +81,13 @@ impl Model {
     pub fn youtube_options_prev_page(&mut self) {
         match self.youtube_options.prev_page() {
             Ok(()) => self.sync_youtube_options(),
-            Err(e) => self.mount_error_popup(format!("search error: {e}")),
+            Err(e) => self.mount_error_popup(e.context("youtube-dl search")),
         }
     }
     pub fn youtube_options_next_page(&mut self) {
         match self.youtube_options.next_page() {
             Ok(()) => self.sync_youtube_options(),
-            Err(e) => self.mount_error_popup(format!("search error: {e}")),
+            Err(e) => self.mount_error_popup(e.context("youtube-dl search")),
         }
     }
     pub fn sync_youtube_options(&mut self) {


### PR DESCRIPTION
This PR changes the Error-Popup to accept raw Errors, this way we can fully log the error cause and chain to the log and also to the tui. in some more details:
- move error logging from `mount_error_popup` to `ErrorPopup::new`
- change both function to accept `anyhow::Error` instead of `str`
- add a title to the `ErrorPopup`

some downsides:
the ErrorPopup is [limited to 4 lines of height](https://github.com/tramhao/termusic/blob/e85f574a48befbf4a53560ec8a2200a350c987dd/tui/src/ui/model/view.rs#L436), meaning better printing like the following is not possible until it changes:
```txt
Some Error

Caused by:
    0: Some Context
    1: Some original Error
```
and instead printed is
```txt
Some Error: Some Context: Some original Error
```
(which in longer chains may get cutoff)