### PR TITLE
Deduplicate in-memory Settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,6 +3773,7 @@ dependencies = [
  "lazy_static",
  "lofty",
  "log",
+ "parking_lot",
  "percent-encoding",
  "pretty_assertions",
  "rand",

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -257,7 +257,7 @@ impl std::fmt::Display for SeekStep {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Copy)]
 pub enum LastPosition {
     Yes,
     No,

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
-use crate::Volume;
+use crate::{Speed, Volume};
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -282,7 +282,6 @@ impl GStreamerBackend {
     }
 
     fn send_seek_event_speed(&mut self, speed: i32) -> bool {
-        self.speed = speed;
         let rate = speed as f64 / 10.0;
         // Obtain the current position, needed for the seek event
         let position = self.get_position();
@@ -426,30 +425,31 @@ impl PlayerTrait for GStreamerBackend {
         }
         self.set_volume_inside(f64::from(self.volume) / 100.0);
     }
-    fn speed(&self) -> i32 {
+    fn speed(&self) -> Speed {
         self.speed
     }
 
-    fn set_speed(&mut self, speed: i32) {
+    fn set_speed(&mut self, speed: Speed) -> Speed {
+        self.speed = speed;
         self.send_seek_event_speed(speed);
+
+        self.speed
     }
 
-    fn speed_up(&mut self) {
+    fn speed_up(&mut self) -> Speed {
         let mut speed = self.speed + 1;
         if speed > 30 {
             speed = 30;
         }
-        if !self.send_seek_event_speed(speed) {
-            error!("error set speed");
-        }
+        self.set_speed(speed)
     }
 
-    fn speed_down(&mut self) {
+    fn speed_down(&mut self) -> Speed {
         let mut speed = self.speed - 1;
         if speed < 1 {
             speed = 1;
         }
-        self.set_speed(speed);
+        self.set_speed(speed)
     }
     fn stop(&mut self) {
         self.playbin.set_state(gst::State::Null).ok();

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
+use crate::Volume;
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -339,22 +340,24 @@ impl PlayerTrait for GStreamerBackend {
             .expect("set gst state playing error");
     }
 
-    fn volume_up(&mut self) {
-        self.set_volume(self.volume.saturating_add(VOLUME_STEP));
+    fn volume_up(&mut self) -> Volume {
+        self.set_volume(self.volume.saturating_add(VOLUME_STEP))
     }
 
-    fn volume_down(&mut self) {
-        self.set_volume(self.volume.saturating_sub(VOLUME_STEP));
+    fn volume_down(&mut self) -> Volume {
+        self.set_volume(self.volume.saturating_sub(VOLUME_STEP))
     }
 
-    fn volume(&self) -> u16 {
+    fn volume(&self) -> Volume {
         self.volume
     }
 
-    fn set_volume(&mut self, volume: u16) {
+    fn set_volume(&mut self, volume: Volume) -> Volume {
         let volume = volume.min(100);
         self.volume = volume;
         self.set_volume_inside(f64::from(volume) / 100.0);
+
+        volume
     }
 
     fn pause(&mut self) {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -571,17 +571,17 @@ impl PlayerTrait for GeneralPlayer {
     async fn add_and_play(&mut self, track: &Track) {
         self.get_player_mut().add_and_play(track).await;
     }
-    fn volume(&self) -> u16 {
+    fn volume(&self) -> Volume {
         self.get_player().volume()
     }
-    fn volume_up(&mut self) {
-        self.get_player_mut().volume_up();
+    fn volume_up(&mut self) -> Volume {
+        self.get_player_mut().volume_up()
     }
-    fn volume_down(&mut self) {
-        self.get_player_mut().volume_down();
+    fn volume_down(&mut self) -> Volume {
+        self.get_player_mut().volume_down()
     }
-    fn set_volume(&mut self, volume: u16) {
-        self.get_player_mut().set_volume(volume);
+    fn set_volume(&mut self, volume: Volume) -> Volume {
+        self.get_player_mut().set_volume(volume)
     }
     fn pause(&mut self) {
         self.playlist.set_status(Status::Paused);
@@ -678,15 +678,27 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
     }
 }
 
+pub type Volume = u16;
+
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
 pub trait PlayerTrait {
     /// Add the given track, skip to it (if not already) and start playing
     async fn add_and_play(&mut self, track: &Track);
-    fn volume(&self) -> u16;
-    fn volume_up(&mut self);
-    fn volume_down(&mut self);
-    fn set_volume(&mut self, volume: u16);
+    /// Get the currently set volume
+    fn volume(&self) -> Volume;
+    /// Step the volume up by a backend-set step amount
+    ///
+    /// Returns the new volume
+    fn volume_up(&mut self) -> Volume;
+    /// Step the volume down by a backend-set step amount
+    ///
+    /// Returns the new volume
+    fn volume_down(&mut self) -> Volume;
+    /// Set the volume to a specific amount.
+    ///
+    /// Returns the new volume
+    fn set_volume(&mut self, volume: Volume) -> Volume;
     fn pause(&mut self);
     fn resume(&mut self);
     fn is_paused(&self) -> bool;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -268,7 +268,6 @@ impl GeneralPlayer {
     ///
     /// - if connecting to the database fails
     /// - if config path creation fails
-    #[allow(clippy::missing_panics_doc)]
     pub fn new(config: Settings, cmd_tx: PlayerCmdSender) -> Result<Self> {
         Self::new_backend(BackendSelect::Default, config, cmd_tx)
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -601,19 +601,19 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player_mut().seek_to(position);
     }
 
-    fn set_speed(&mut self, speed: i32) {
-        self.get_player_mut().set_speed(speed);
+    fn set_speed(&mut self, speed: Speed) -> Speed {
+        self.get_player_mut().set_speed(speed)
     }
 
-    fn speed_up(&mut self) {
-        self.get_player_mut().speed_up();
+    fn speed_up(&mut self) -> Speed {
+        self.get_player_mut().speed_up()
     }
 
-    fn speed_down(&mut self) {
-        self.get_player_mut().speed_down();
+    fn speed_down(&mut self) -> Speed {
+        self.get_player_mut().speed_down()
     }
 
-    fn speed(&self) -> i32 {
+    fn speed(&self) -> Speed {
         self.get_player().speed()
     }
 
@@ -679,6 +679,7 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
 }
 
 pub type Volume = u16;
+pub type Speed = i32;
 
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
@@ -713,10 +714,20 @@ pub trait PlayerTrait {
     fn seek_to(&mut self, position: Duration);
     /// Get current track time position
     fn get_progress(&self) -> Option<PlayerProgress>;
-    fn set_speed(&mut self, speed: i32);
-    fn speed_up(&mut self);
-    fn speed_down(&mut self);
-    fn speed(&self) -> i32;
+    /// Set the speed to a specific amount.
+    ///
+    /// Returns the new speed
+    fn set_speed(&mut self, speed: Speed) -> Speed;
+    /// Step the speed up by a backend-set step amount
+    ///
+    /// Returns the new speed
+    fn speed_up(&mut self) -> Speed;
+    /// Step the speed down by a backend-set step amount
+    ///
+    /// Returns the new speed
+    fn speed_down(&mut self) -> Speed;
+    /// Get the currently set speed
+    fn speed(&self) -> Speed;
     fn stop(&mut self);
     fn gapless(&self) -> bool;
     fn set_gapless(&mut self, to: bool);

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -231,23 +231,25 @@ impl GeneralPlayer {
     /// - if config path creation fails
     pub fn new_backend(
         backend: BackendSelect,
-        config: &Settings,
+        config: Settings,
         cmd_tx: PlayerCmdSender,
     ) -> Result<Self> {
-        let backend = Backend::new_select(backend, config, cmd_tx.clone());
-        let playlist = Playlist::new(config).unwrap_or_default();
+        let backend = Backend::new_select(backend, &config, cmd_tx.clone());
+        let playlist = Playlist::new(&config).unwrap_or_default();
 
         let db_path = get_app_config_path().with_context(|| "failed to get podcast db path.")?;
 
         let db_podcast =
             DBPod::connect(&db_path).with_context(|| "error connecting to podcast db.")?;
+        let db = DataBase::new(&config);
+
         Ok(Self {
             backend,
             playlist,
-            config: config.clone(),
+            config,
             mpris: mpris::Mpris::new(cmd_tx.clone()),
             discord: discord::Rpc::default(),
-            db: DataBase::new(config),
+            db,
             db_podcast,
             cmd_tx,
             current_track_updated: false,
@@ -261,7 +263,7 @@ impl GeneralPlayer {
     /// - if connecting to the database fails
     /// - if config path creation fails
     #[allow(clippy::missing_panics_doc)]
-    pub fn new(config: &Settings, cmd_tx: PlayerCmdSender) -> Result<Self> {
+    pub fn new(config: Settings, cmd_tx: PlayerCmdSender) -> Result<Self> {
         Self::new_backend(BackendSelect::Default, config, cmd_tx)
     }
 

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
+use crate::Volume;
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -284,23 +285,25 @@ impl PlayerTrait for MpvBackend {
         }
     }
 
-    fn volume(&self) -> u16 {
+    fn volume(&self) -> Volume {
         self.volume
     }
 
-    fn volume_up(&mut self) {
-        self.set_volume(self.volume.saturating_add(VOLUME_STEP));
+    fn volume_up(&mut self) -> Volume {
+        self.set_volume(self.volume.saturating_add(VOLUME_STEP))
     }
 
-    fn volume_down(&mut self) {
-        self.set_volume(self.volume.saturating_sub(VOLUME_STEP));
+    fn volume_down(&mut self) -> Volume {
+        self.set_volume(self.volume.saturating_sub(VOLUME_STEP))
     }
 
-    fn set_volume(&mut self, volume: u16) {
+    fn set_volume(&mut self, volume: Volume) -> Volume {
         self.volume = volume.min(100);
         self.command_tx
             .send(PlayerInternalCmd::Volume(self.volume))
             .ok();
+
+        self.volume
     }
 
     fn pause(&mut self) {

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
-use crate::Volume;
+use crate::{Speed, Volume};
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -329,31 +329,33 @@ impl PlayerTrait for MpvBackend {
             .send(PlayerInternalCmd::SeekAbsolute(position))
             .ok();
     }
-    fn speed(&self) -> i32 {
+    fn speed(&self) -> Speed {
         self.speed
     }
 
-    fn set_speed(&mut self, speed: i32) {
+    fn set_speed(&mut self, speed: Speed) -> Speed {
         self.speed = speed;
         self.command_tx
             .send(PlayerInternalCmd::Speed(self.speed))
             .ok();
+
+        self.speed
     }
 
-    fn speed_up(&mut self) {
+    fn speed_up(&mut self) -> Speed {
         let mut speed = self.speed + 1;
         if speed > 30 {
             speed = 30;
         }
-        self.set_speed(speed);
+        self.set_speed(speed)
     }
 
-    fn speed_down(&mut self) {
+    fn speed_down(&mut self) -> Speed {
         let mut speed = self.speed - 1;
         if speed < 1 {
             speed = 1;
         }
-        self.set_speed(speed);
+        self.set_speed(speed)
     }
     fn stop(&mut self) {
         self.command_tx.send(PlayerInternalCmd::Stop).ok();

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -23,6 +23,8 @@ use std::num::{NonZeroU16, NonZeroUsize};
 pub use stream::OutputStream;
 use tokio::runtime::Handle;
 
+use crate::Volume;
+
 use self::decoder::buffered_source::BufferedSource;
 use self::decoder::read_seek_source::ReadSeekSource;
 
@@ -166,30 +168,32 @@ impl PlayerTrait for RustyBackend {
         self.resume();
     }
 
-    fn volume(&self) -> u16 {
+    fn volume(&self) -> Volume {
         self.volume.load(Ordering::SeqCst)
     }
 
-    fn volume_up(&mut self) {
+    fn volume_up(&mut self) -> Volume {
         let volume = self
             .volume
             .load(Ordering::SeqCst)
             .saturating_add(VOLUME_STEP);
-        self.set_volume(volume);
+        self.set_volume(volume)
     }
 
-    fn volume_down(&mut self) {
+    fn volume_down(&mut self) -> Volume {
         let volume = self
             .volume
             .load(Ordering::SeqCst)
             .saturating_sub(VOLUME_STEP);
-        self.set_volume(volume);
+        self.set_volume(volume)
     }
 
-    fn set_volume(&mut self, volume: u16) {
+    fn set_volume(&mut self, volume: Volume) -> Volume {
         let volume = volume.min(100);
         self.volume.store(volume, Ordering::SeqCst);
         self.command(PlayerInternalCmd::Volume(volume));
+
+        volume
     }
 
     fn pause(&mut self) {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -23,7 +23,7 @@ use std::num::{NonZeroU16, NonZeroUsize};
 pub use stream::OutputStream;
 use tokio::runtime::Handle;
 
-use crate::Volume;
+use crate::{Speed, Volume};
 
 use self::decoder::buffered_source::BufferedSource;
 use self::decoder::read_seek_source::ReadSeekSource;
@@ -219,28 +219,30 @@ impl PlayerTrait for RustyBackend {
         self.command(PlayerInternalCmd::SeekAbsolute(position));
     }
 
-    fn speed_up(&mut self) {
+    fn speed_up(&mut self) -> Speed {
         let mut speed = self.speed + 1;
         if speed > 30 {
             speed = 30;
         }
-        self.set_speed(speed);
+        self.set_speed(speed)
     }
 
-    fn speed_down(&mut self) {
+    fn speed_down(&mut self) -> Speed {
         let mut speed = self.speed - 1;
         if speed < 1 {
             speed = 1;
         }
-        self.set_speed(speed);
+        self.set_speed(speed)
     }
 
-    fn set_speed(&mut self, speed: i32) {
+    fn set_speed(&mut self, speed: Speed) -> Speed {
         self.speed = speed;
         self.command(PlayerInternalCmd::Speed(speed));
+
+        self.speed
     }
 
-    fn speed(&self) -> i32 {
+    fn speed(&self) -> Speed {
         self.speed
     }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -237,21 +237,19 @@ fn player_loop(
                 player.next();
             }
             PlayerCmd::SpeedDown => {
-                player.speed_down();
-                info!("after speed down: {}", player.speed());
-                let mut player_config = player.config.write();
-                player_config.player_speed = player.speed();
+                let new_speed = player.speed_down();
+                info!("after speed down: {}", new_speed);
+                player.config.write().player_speed = new_speed;
                 let mut p_tick = playerstats.lock();
-                p_tick.speed = player_config.player_speed;
+                p_tick.speed = new_speed;
             }
 
             PlayerCmd::SpeedUp => {
-                player.speed_up();
-                info!("after speed up: {}", player.speed());
-                let mut player_config = player.config.write();
-                player_config.player_speed = player.speed();
+                let new_speed = player.speed_up();
+                info!("after speed up: {}", new_speed);
+                player.config.write().player_speed = new_speed;
                 let mut p_tick = playerstats.lock();
-                p_tick.speed = player_config.player_speed;
+                p_tick.speed = new_speed;
             }
             PlayerCmd::Tick => {
                 // info!("tick received");

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -329,19 +329,17 @@ fn player_loop(
             }
             PlayerCmd::VolumeDown => {
                 info!("before volumedown: {}", player.volume());
-                player.volume_down();
-                let new_volume = player.volume();
+                let new_volume = player.volume_down();
                 player.config.write().player_volume = new_volume;
-                info!("after volumedown: {}", player.volume());
+                info!("after volumedown: {}", new_volume);
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
             }
             PlayerCmd::VolumeUp => {
                 info!("before volumeup: {}", player.volume());
-                player.volume_up();
-                let new_volume = player.volume();
+                let new_volume = player.volume_up();
                 player.config.write().player_volume = new_volume;
-                info!("after volumeup: {}", player.volume());
+                info!("after volumeup: {}", new_volume);
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
             }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -68,6 +68,7 @@ tokio.workspace = true
 reqwest.workspace = true
 # reqwest = { version="0.11", features = ["stream"] }
 # tokio = { version = "1", features = ["full"] }
+parking_lot.workspace = true
 
 
 [features]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -140,7 +140,7 @@ async fn actual_main() -> Result<()> {
     .await?;
     info!("Connected!");
 
-    let mut ui = UI::new(&config, client).await?;
+    let mut ui = UI::new(config, client).await?;
     ui.run().await?;
 
     Ok(())

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -24,7 +24,7 @@
 use crate::config::{LastPosition, SeekStep, Settings};
 use crate::ui::{ConfigEditorMsg, Msg};
 
-use termusiclib::config::Alignment as XywhAlign;
+use termusiclib::config::{Alignment as XywhAlign, Keys};
 use tui_realm_stdlib::{Input, Radio};
 use tuirealm::props::{Alignment, BorderType, Borders, Color, InputType, Style};
 use tuirealm::{
@@ -204,11 +204,11 @@ impl ExitConfirmation {
 
 impl Component<Msg, NoUserEvent> for ExitConfirmation {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurUp),
         )
@@ -219,13 +219,13 @@ impl Component<Msg, NoUserEvent> for ExitConfirmation {
 fn handle_radio_ev(
     component: &mut dyn Component<Msg, NoUserEvent>,
     ev: Event<NoUserEvent>,
-    config: &Settings,
+    keys: &Keys,
     on_key_down: Msg,
     on_key_up: Msg,
 ) -> Option<Msg> {
     match ev {
         // Global Hotkeys
-        Event::Keyboard(keyevent) if keyevent == config.keys.config_save.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::CloseOk))
         }
         Event::Keyboard(KeyEvent {
@@ -235,16 +235,12 @@ fn handle_radio_ev(
         Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::ChangeLayout))
         }
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_down.key_event() => {
-            Some(on_key_down)
-        }
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_up.key_event() => {
-            Some(on_key_up)
-        }
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_quit.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => Some(on_key_down),
+        Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => Some(on_key_up),
+        Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel))
         }
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_esc.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel))
         }
 
@@ -304,11 +300,11 @@ impl PlaylistDisplaySymbol {
 
 impl Component<Msg, NoUserEvent> for PlaylistDisplaySymbol {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurUp),
         )
@@ -615,11 +611,11 @@ impl AlbumPhotoAlign {
 
 impl Component<Msg, NoUserEvent> for AlbumPhotoAlign {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurUp),
         )
@@ -668,11 +664,11 @@ impl SaveLastPosition {
 
 impl Component<Msg, NoUserEvent> for SaveLastPosition {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::SaveLastPositionBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::SaveLastPosotionBlurUp),
         )
@@ -720,11 +716,11 @@ impl ConfigSeekStep {
 
 impl Component<Msg, NoUserEvent> for ConfigSeekStep {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurUp),
         )
@@ -769,11 +765,11 @@ impl KillDaemon {
 
 impl Component<Msg, NoUserEvent> for KillDaemon {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurUp),
         )
@@ -818,11 +814,11 @@ impl PlayerUseMpris {
 
 impl Component<Msg, NoUserEvent> for PlayerUseMpris {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurUp),
         )
@@ -867,11 +863,11 @@ impl PlayerUseDiscord {
 
 impl Component<Msg, NoUserEvent> for PlayerUseDiscord {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_radio_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurUp),
         )

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -82,11 +82,11 @@ impl MusicDir {
 
 impl Component<Msg, NoUserEvent> for MusicDir {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurUp),
         )
@@ -97,13 +97,13 @@ impl Component<Msg, NoUserEvent> for MusicDir {
 fn handle_input_ev(
     component: &mut dyn MockComponent,
     ev: Event<NoUserEvent>,
-    config: &Settings,
+    keys: &Keys,
     on_key_down: Msg,
     on_key_up: Msg,
 ) -> Option<Msg> {
     match ev {
         // Global Hotkeys
-        Event::Keyboard(keyevent) if keyevent == config.keys.config_save.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::CloseOk))
         }
         Event::Keyboard(KeyEvent {
@@ -113,7 +113,7 @@ fn handle_input_ev(
         Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::ChangeLayout))
         }
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_esc.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
             Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel))
         }
 
@@ -349,11 +349,11 @@ impl PlaylistRandomTrack {
 
 impl Component<Msg, NoUserEvent> for PlaylistRandomTrack {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurUp),
         )
@@ -401,11 +401,11 @@ impl PlaylistRandomAlbum {
 
 impl Component<Msg, NoUserEvent> for PlaylistRandomAlbum {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurUp),
         )
@@ -453,11 +453,11 @@ impl PodcastDir {
 
 impl Component<Msg, NoUserEvent> for PodcastDir {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurUp),
         )
@@ -505,11 +505,11 @@ impl PodcastSimulDownload {
 
 impl Component<Msg, NoUserEvent> for PodcastSimulDownload {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurUp),
         )
@@ -557,11 +557,11 @@ impl PodcastMaxRetries {
 
 impl Component<Msg, NoUserEvent> for PodcastMaxRetries {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurUp),
         )
@@ -915,11 +915,11 @@ impl PlayerPort {
 
 impl Component<Msg, NoUserEvent> for PlayerPort {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurUp),
         )

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -95,7 +95,7 @@ impl Component<Msg, NoUserEvent> for MusicDir {
 
 #[allow(clippy::needless_pass_by_value)]
 fn handle_input_ev(
-    component: &mut dyn Component<Msg, NoUserEvent>,
+    component: &mut dyn MockComponent,
     ev: Event<NoUserEvent>,
     config: &Settings,
     on_key_down: Msg,
@@ -217,7 +217,7 @@ impl Component<Msg, NoUserEvent> for ExitConfirmation {
 
 #[allow(clippy::needless_pass_by_value)]
 fn handle_radio_ev(
-    component: &mut dyn Component<Msg, NoUserEvent>,
+    component: &mut dyn MockComponent,
     ev: Event<NoUserEvent>,
     keys: &Keys,
     on_key_down: Msg,

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -204,11 +204,10 @@ impl ExitConfirmation {
 
 impl Component<Msg, NoUserEvent> for ExitConfirmation {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurUp),
         )
@@ -300,11 +299,10 @@ impl PlaylistDisplaySymbol {
 
 impl Component<Msg, NoUserEvent> for PlaylistDisplaySymbol {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurUp),
         )
@@ -611,11 +609,10 @@ impl AlbumPhotoAlign {
 
 impl Component<Msg, NoUserEvent> for AlbumPhotoAlign {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurUp),
         )
@@ -664,11 +661,10 @@ impl SaveLastPosition {
 
 impl Component<Msg, NoUserEvent> for SaveLastPosition {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::SaveLastPositionBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::SaveLastPosotionBlurUp),
         )
@@ -716,11 +712,10 @@ impl ConfigSeekStep {
 
 impl Component<Msg, NoUserEvent> for ConfigSeekStep {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurUp),
         )
@@ -765,11 +760,10 @@ impl KillDaemon {
 
 impl Component<Msg, NoUserEvent> for KillDaemon {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurUp),
         )
@@ -814,11 +808,10 @@ impl PlayerUseMpris {
 
 impl Component<Msg, NoUserEvent> for PlayerUseMpris {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurUp),
         )
@@ -863,11 +856,10 @@ impl PlayerUseDiscord {
 
 impl Component<Msg, NoUserEvent> for PlayerUseDiscord {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_radio_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurUp),
         )

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -82,11 +82,10 @@ impl MusicDir {
 
 impl Component<Msg, NoUserEvent> for MusicDir {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurUp),
         )
@@ -347,11 +346,10 @@ impl PlaylistRandomTrack {
 
 impl Component<Msg, NoUserEvent> for PlaylistRandomTrack {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurUp),
         )
@@ -399,11 +397,10 @@ impl PlaylistRandomAlbum {
 
 impl Component<Msg, NoUserEvent> for PlaylistRandomAlbum {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurUp),
         )
@@ -451,11 +448,10 @@ impl PodcastDir {
 
 impl Component<Msg, NoUserEvent> for PodcastDir {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurUp),
         )
@@ -503,11 +499,10 @@ impl PodcastSimulDownload {
 
 impl Component<Msg, NoUserEvent> for PodcastSimulDownload {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurUp),
         )
@@ -555,11 +550,10 @@ impl PodcastMaxRetries {
 
 impl Component<Msg, NoUserEvent> for PodcastMaxRetries {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurUp),
         )
@@ -907,11 +901,10 @@ impl PlayerPort {
 
 impl Component<Msg, NoUserEvent> for PlayerPort {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
         handle_input_ev(
-            self,
+            &mut self.component,
             ev,
-            &keys,
+            &self.config.keys,
             Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurDown),
             Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurUp),
         )

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -23,7 +23,9 @@ use crate::config::{load_alacritty, BindingForEvent, ColorTermusic};
  * SOFTWARE.
  */
 use crate::ui::Model;
+use parking_lot::RwLock;
 use std::path::PathBuf;
+use std::sync::Arc;
 use termusiclib::types::{ConfigEditorMsg, Id, IdConfigEditor, IdKey, KFMsg, Msg};
 use termusicplayback::PlayerCmd;
 
@@ -32,8 +34,8 @@ impl Model {
     pub fn update_config_editor(&mut self, msg: &ConfigEditorMsg) -> Option<Msg> {
         match msg {
             ConfigEditorMsg::Open => {
-                self.ce_style_color_symbol = self.config.style_color_symbol.clone();
-                self.ke_key_config = self.config.keys.clone();
+                self.ce_style_color_symbol = self.config.read().style_color_symbol.clone();
+                self.ke_key_config = self.config.read().keys.clone();
                 self.mount_config_editor();
             }
             ConfigEditorMsg::CloseCancel => {
@@ -144,7 +146,8 @@ impl Model {
                     .ok();
                 match self.collect_config_data() {
                     Ok(()) => {
-                        match self.config.save() {
+                        let res = self.config.write().save();
+                        match res {
                             Ok(()) => {
                                 self.command(&PlayerCmd::ReloadConfig);
                             }
@@ -274,16 +277,17 @@ impl Model {
                 if let Some(t) = self.ce_themes.get(*index) {
                     let path = PathBuf::from(t);
                     if let Some(n) = path.file_stem() {
-                        self.config.theme_selected = n.to_string_lossy().to_string();
+                        self.config.write().theme_selected = n.to_string_lossy().to_string();
                         if let Ok(theme) = load_alacritty(t) {
                             self.ce_style_color_symbol.alacritty_theme = theme;
                         }
                     }
                 }
                 self.config_changed = true;
-                let mut config = self.config.clone();
+                let mut config = self.config.read().clone();
                 // This is for preview the theme colors
                 config.style_color_symbol = self.ce_style_color_symbol.clone();
+                let config = Arc::new(RwLock::new(config));
                 self.remount_config_color(&config);
             }
             ConfigEditorMsg::ColorChanged(id, color_config) => {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -52,9 +52,10 @@ use include_dir::DirEntry;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use termusiclib::config::{LastPosition, SeekStep, Settings};
+use termusiclib::config::{LastPosition, SeekStep};
 use termusiclib::utils::{draw_area_in_absolute, get_app_config_path, get_pin_yin};
 use termusiclib::THEME_DIR;
+use termusicplayback::SharedSettings;
 
 use crate::ui::model::{ConfigEditorLayout, Model};
 use crate::ui::{Application, Id, IdConfigEditor, IdKey, Msg};
@@ -1560,7 +1561,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(&layout, &self.config)),
+                Box::new(CEHeader::new(&layout, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -1568,7 +1569,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Footer),
-                Box::new(Footer::new(&self.config)),
+                Box::new(Footer::new(&self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -1578,7 +1579,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::MusicDir),
-                Box::new(MusicDir::new(&self.config)),
+                Box::new(MusicDir::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1587,7 +1588,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ExitConfirmation),
-                Box::new(ExitConfirmation::new(&self.config)),
+                Box::new(ExitConfirmation::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1596,7 +1597,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol),
-                Box::new(PlaylistDisplaySymbol::new(&self.config)),
+                Box::new(PlaylistDisplaySymbol::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1605,7 +1606,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack),
-                Box::new(PlaylistRandomTrack::new(&self.config)),
+                Box::new(PlaylistRandomTrack::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1614,7 +1615,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum),
-                Box::new(PlaylistRandomAlbum::new(&self.config)),
+                Box::new(PlaylistRandomAlbum::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1623,7 +1624,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastDir),
-                Box::new(PodcastDir::new(&self.config)),
+                Box::new(PodcastDir::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1632,7 +1633,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload),
-                Box::new(PodcastSimulDownload::new(&self.config)),
+                Box::new(PodcastSimulDownload::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1641,7 +1642,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries),
-                Box::new(PodcastMaxRetries::new(&self.config)),
+                Box::new(PodcastMaxRetries::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1650,7 +1651,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign),
-                Box::new(AlbumPhotoAlign::new(&self.config)),
+                Box::new(AlbumPhotoAlign::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1659,7 +1660,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::SaveLastPosition),
-                Box::new(SaveLastPosition::new(&self.config)),
+                Box::new(SaveLastPosition::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1668,7 +1669,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::SeekStep),
-                Box::new(ConfigSeekStep::new(&self.config)),
+                Box::new(ConfigSeekStep::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1677,7 +1678,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::KillDamon),
-                Box::new(KillDaemon::new(&self.config)),
+                Box::new(KillDaemon::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1686,7 +1687,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerUseMpris),
-                Box::new(PlayerUseMpris::new(&self.config)),
+                Box::new(PlayerUseMpris::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1695,7 +1696,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord),
-                Box::new(PlayerUseDiscord::new(&self.config)),
+                Box::new(PlayerUseDiscord::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1704,7 +1705,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerPort),
-                Box::new(PlayerPort::new(&self.config)),
+                Box::new(PlayerPort::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1727,13 +1728,13 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn remount_config_color(&mut self, config: &Settings) {
+    pub fn remount_config_color(&mut self, config: &SharedSettings) {
         // Mount color page
         assert!(self
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::CEThemeSelect),
-                Box::new(CEThemeSelectTable::new(config)),
+                Box::new(CEThemeSelectTable::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1750,7 +1751,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LibraryForeground),
-                Box::new(ConfigLibraryForeground::new(config)),
+                Box::new(ConfigLibraryForeground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1759,7 +1760,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LibraryBackground),
-                Box::new(ConfigLibraryBackground::new(config)),
+                Box::new(ConfigLibraryBackground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1768,7 +1769,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LibraryBorder),
-                Box::new(ConfigLibraryBorder::new(config)),
+                Box::new(ConfigLibraryBorder::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1777,7 +1778,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LibraryHighlight),
-                Box::new(ConfigLibraryHighlight::new(config)),
+                Box::new(ConfigLibraryHighlight::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1795,7 +1796,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistForeground),
-                Box::new(ConfigPlaylistForeground::new(config)),
+                Box::new(ConfigPlaylistForeground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1804,7 +1805,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistBackground),
-                Box::new(ConfigPlaylistBackground::new(config)),
+                Box::new(ConfigPlaylistBackground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1813,7 +1814,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistBorder),
-                Box::new(ConfigPlaylistBorder::new(config)),
+                Box::new(ConfigPlaylistBorder::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1822,7 +1823,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistHighlight),
-                Box::new(ConfigPlaylistHighlight::new(config)),
+                Box::new(ConfigPlaylistHighlight::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1840,7 +1841,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ProgressForeground),
-                Box::new(ConfigProgressForeground::new(config)),
+                Box::new(ConfigProgressForeground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1849,7 +1850,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ProgressBackground),
-                Box::new(ConfigProgressBackground::new(config)),
+                Box::new(ConfigProgressBackground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1858,7 +1859,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ProgressBorder),
-                Box::new(ConfigProgressBorder::new(config)),
+                Box::new(ConfigProgressBorder::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1876,7 +1877,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LyricForeground),
-                Box::new(ConfigLyricForeground::new(config)),
+                Box::new(ConfigLyricForeground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1885,7 +1886,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LyricBackground),
-                Box::new(ConfigLyricBackground::new(config)),
+                Box::new(ConfigLyricBackground::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1894,7 +1895,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LyricBorder),
-                Box::new(ConfigLyricBorder::new(config)),
+                Box::new(ConfigLyricBorder::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1903,7 +1904,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::LibraryHighlightSymbol),
-                Box::new(ConfigLibraryHighlightSymbol::new(config)),
+                Box::new(ConfigLibraryHighlightSymbol::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1912,7 +1913,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol),
-                Box::new(ConfigPlaylistHighlightSymbol::new(config)),
+                Box::new(ConfigPlaylistHighlightSymbol::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1921,7 +1922,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::CurrentlyPlayingTrackSymbol),
-                Box::new(ConfigCurrentlyPlayingTrackSymbol::new(config)),
+                Box::new(ConfigCurrentlyPlayingTrackSymbol::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -1932,7 +1933,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalQuit)),
-                Box::new(ConfigGlobalQuit::new(config)),
+                Box::new(ConfigGlobalQuit::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1940,7 +1941,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLeft)),
-                Box::new(ConfigGlobalLeft::new(config)),
+                Box::new(ConfigGlobalLeft::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1948,7 +1949,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalRight)),
-                Box::new(ConfigGlobalRight::new(config)),
+                Box::new(ConfigGlobalRight::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1956,7 +1957,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalUp)),
-                Box::new(ConfigGlobalUp::new(config)),
+                Box::new(ConfigGlobalUp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1965,7 +1966,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalDown)),
-                Box::new(ConfigGlobalDown::new(config)),
+                Box::new(ConfigGlobalDown::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1973,7 +1974,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalGotoTop)),
-                Box::new(ConfigGlobalGotoTop::new(config)),
+                Box::new(ConfigGlobalGotoTop::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1981,7 +1982,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalGotoBottom)),
-                Box::new(ConfigGlobalGotoBottom::new(config)),
+                Box::new(ConfigGlobalGotoBottom::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1989,7 +1990,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerTogglePause)),
-                Box::new(ConfigGlobalPlayerTogglePause::new(config)),
+                Box::new(ConfigGlobalPlayerTogglePause::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -1997,7 +1998,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerNext)),
-                Box::new(ConfigGlobalPlayerNext::new(config)),
+                Box::new(ConfigGlobalPlayerNext::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2005,7 +2006,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerPrevious)),
-                Box::new(ConfigGlobalPlayerPrevious::new(config)),
+                Box::new(ConfigGlobalPlayerPrevious::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2013,7 +2014,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalHelp)),
-                Box::new(ConfigGlobalHelp::new(config)),
+                Box::new(ConfigGlobalHelp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2021,7 +2022,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalVolumeUp)),
-                Box::new(ConfigGlobalVolumeUp::new(config)),
+                Box::new(ConfigGlobalVolumeUp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2029,7 +2030,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalVolumeDown)),
-                Box::new(ConfigGlobalVolumeDown::new(config)),
+                Box::new(ConfigGlobalVolumeDown::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2037,7 +2038,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerSeekForward)),
-                Box::new(ConfigGlobalPlayerSeekForward::new(config)),
+                Box::new(ConfigGlobalPlayerSeekForward::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2045,7 +2046,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerSeekBackward)),
-                Box::new(ConfigGlobalPlayerSeekBackward::new(config)),
+                Box::new(ConfigGlobalPlayerSeekBackward::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2053,7 +2054,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerSpeedUp)),
-                Box::new(ConfigGlobalPlayerSpeedUp::new(config)),
+                Box::new(ConfigGlobalPlayerSpeedUp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2062,7 +2063,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerSpeedDown)),
-                Box::new(ConfigGlobalPlayerSpeedDown::new(config)),
+                Box::new(ConfigGlobalPlayerSpeedDown::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2071,7 +2072,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLyricAdjustForward)),
-                Box::new(ConfigGlobalLyricAdjustForward::new(config)),
+                Box::new(ConfigGlobalLyricAdjustForward::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2079,7 +2080,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLyricAdjustBackward)),
-                Box::new(ConfigGlobalLyricAdjustBackward::new(config)),
+                Box::new(ConfigGlobalLyricAdjustBackward::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2087,7 +2088,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLyricCycle)),
-                Box::new(ConfigGlobalLyricCycle::new(config)),
+                Box::new(ConfigGlobalLyricCycle::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2095,7 +2096,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalPlayerToggleGapless)),
-                Box::new(ConfigGlobalPlayerToggleGapless::new(config)),
+                Box::new(ConfigGlobalPlayerToggleGapless::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2104,7 +2105,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLayoutTreeview)),
-                Box::new(ConfigGlobalLayoutTreeview::new(config)),
+                Box::new(ConfigGlobalLayoutTreeview::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2113,7 +2114,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLayoutDatabase)),
-                Box::new(ConfigGlobalLayoutDatabase::new(config)),
+                Box::new(ConfigGlobalLayoutDatabase::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2122,7 +2123,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryDelete)),
-                Box::new(ConfigLibraryDelete::new(config)),
+                Box::new(ConfigLibraryDelete::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2130,7 +2131,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryLoadDir)),
-                Box::new(ConfigLibraryLoadDir::new(config)),
+                Box::new(ConfigLibraryLoadDir::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2138,7 +2139,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryYank)),
-                Box::new(ConfigLibraryYank::new(config)),
+                Box::new(ConfigLibraryYank::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2146,7 +2147,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryPaste)),
-                Box::new(ConfigLibraryPaste::new(config)),
+                Box::new(ConfigLibraryPaste::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2154,7 +2155,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibrarySearch)),
-                Box::new(ConfigLibrarySearch::new(config)),
+                Box::new(ConfigLibrarySearch::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2162,7 +2163,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibrarySearchYoutube)),
-                Box::new(ConfigLibrarySearchYoutube::new(config)),
+                Box::new(ConfigLibrarySearchYoutube::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2170,7 +2171,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryTagEditor)),
-                Box::new(ConfigLibraryTagEditor::new(config)),
+                Box::new(ConfigLibraryTagEditor::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2178,7 +2179,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistDelete)),
-                Box::new(ConfigPlaylistDelete::new(config)),
+                Box::new(ConfigPlaylistDelete::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2186,7 +2187,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistDeleteAll)),
-                Box::new(ConfigPlaylistDeleteAll::new(config)),
+                Box::new(ConfigPlaylistDeleteAll::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2194,7 +2195,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistShuffle)),
-                Box::new(ConfigPlaylistShuffle::new(config)),
+                Box::new(ConfigPlaylistShuffle::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2202,7 +2203,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistSearch)),
-                Box::new(ConfigPlaylistSearch::new(config)),
+                Box::new(ConfigPlaylistSearch::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2210,7 +2211,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistPlaySelected)),
-                Box::new(ConfigPlaylistPlaySelected::new(config)),
+                Box::new(ConfigPlaylistPlaySelected::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2218,7 +2219,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistModeCycle)),
-                Box::new(ConfigPlaylistModeCycle::new(config)),
+                Box::new(ConfigPlaylistModeCycle::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2227,7 +2228,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistSwapDown)),
-                Box::new(ConfigPlaylistSwapDown::new(config)),
+                Box::new(ConfigPlaylistSwapDown::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2236,7 +2237,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistSwapUp)),
-                Box::new(ConfigPlaylistSwapUp::new(config)),
+                Box::new(ConfigPlaylistSwapUp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2245,7 +2246,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::DatabaseAddAll)),
-                Box::new(ConfigDatabaseAddAll::new(config)),
+                Box::new(ConfigDatabaseAddAll::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2254,7 +2255,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalConfig)),
-                Box::new(ConfigGlobalConfig::new(config)),
+                Box::new(ConfigGlobalConfig::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2263,7 +2264,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistLqueue)),
-                Box::new(ConfigPlaylistLqueue::new(config)),
+                Box::new(ConfigPlaylistLqueue::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2272,7 +2273,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistTqueue)),
-                Box::new(ConfigPlaylistTqueue::new(config)),
+                Box::new(ConfigPlaylistTqueue::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2281,7 +2282,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibrarySwitchRoot)),
-                Box::new(ConfigLibrarySwitchRoot::new(config)),
+                Box::new(ConfigLibrarySwitchRoot::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2290,7 +2291,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryAddRoot)),
-                Box::new(ConfigLibraryAddRoot::new(config)),
+                Box::new(ConfigLibraryAddRoot::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2299,7 +2300,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryRemoveRoot)),
-                Box::new(ConfigLibraryRemoveRoot::new(config)),
+                Box::new(ConfigLibraryRemoveRoot::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2308,7 +2309,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalSavePlaylist)),
-                Box::new(ConfigGlobalSavePlaylist::new(config)),
+                Box::new(ConfigGlobalSavePlaylist::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2317,7 +2318,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalLayoutPodcast)),
-                Box::new(ConfigGlobalLayoutPodcast::new(config)),
+                Box::new(ConfigGlobalLayoutPodcast::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2326,7 +2327,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhMoveLeft)),
-                Box::new(ConfigGlobalXywhMoveLeft::new(config)),
+                Box::new(ConfigGlobalXywhMoveLeft::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2334,7 +2335,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhMoveRight)),
-                Box::new(ConfigGlobalXywhMoveRight::new(config)),
+                Box::new(ConfigGlobalXywhMoveRight::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2342,7 +2343,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhMoveUp)),
-                Box::new(ConfigGlobalXywhMoveUp::new(config)),
+                Box::new(ConfigGlobalXywhMoveUp::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2350,7 +2351,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhMoveDown)),
-                Box::new(ConfigGlobalXywhMoveDown::new(config)),
+                Box::new(ConfigGlobalXywhMoveDown::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2358,7 +2359,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhZoomIn)),
-                Box::new(ConfigGlobalXywhZoomIn::new(config)),
+                Box::new(ConfigGlobalXywhZoomIn::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2366,7 +2367,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhZoomOut)),
-                Box::new(ConfigGlobalXywhZoomOut::new(config)),
+                Box::new(ConfigGlobalXywhZoomOut::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2374,7 +2375,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalXywhHide)),
-                Box::new(ConfigGlobalXywhHide::new(config)),
+                Box::new(ConfigGlobalXywhHide::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2382,7 +2383,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastMarkPlayed)),
-                Box::new(ConfigPodcastMarkPlayed::new(config)),
+                Box::new(ConfigPodcastMarkPlayed::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2390,7 +2391,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastMarkAllPlayed)),
-                Box::new(ConfigPodcastMarkAllPlayed::new(config)),
+                Box::new(ConfigPodcastMarkAllPlayed::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2398,7 +2399,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastEpDownload)),
-                Box::new(ConfigPodcastEpDownload::new(config)),
+                Box::new(ConfigPodcastEpDownload::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2406,7 +2407,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastEpDeleteFile)),
-                Box::new(ConfigPodcastEpDeleteFile::new(config)),
+                Box::new(ConfigPodcastEpDeleteFile::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2414,7 +2415,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastDeleteFeed)),
-                Box::new(ConfigPodcastDeleteFeed::new(config)),
+                Box::new(ConfigPodcastDeleteFeed::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2422,7 +2423,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastDeleteAllFeeds)),
-                Box::new(ConfigPodcastDeleteAllFeeds::new(config)),
+                Box::new(ConfigPodcastDeleteAllFeeds::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2430,7 +2431,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastRefreshFeed)),
-                Box::new(ConfigPodcastRefreshFeed::new(config)),
+                Box::new(ConfigPodcastRefreshFeed::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2438,7 +2439,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastRefreshAllFeeds)),
-                Box::new(ConfigPodcastRefreshAllFeeds::new(config)),
+                Box::new(ConfigPodcastRefreshAllFeeds::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2446,7 +2447,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::PodcastSearchAddFeed)),
-                Box::new(ConfigPodcastSearchAddFeed::new(config)),
+                Box::new(ConfigPodcastSearchAddFeed::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2951,8 +2952,8 @@ impl Model {
             .app
             .remount(
                 Id::GlobalListener,
-                Box::new(GlobalListener::new(&self.config.keys)),
-                Self::subscribe(&self.config.keys),
+                Box::new(GlobalListener::new(self.config.clone())),
+                Self::subscribe(&self.config.read().keys),
             )
             .is_ok());
 
@@ -2975,7 +2976,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(&layout, &self.config)),
+                Box::new(CEHeader::new(&layout, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -3007,7 +3008,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ConfigSavePopup),
-                Box::new(ConfigSavePopup::new(&self.config)),
+                Box::new(ConfigSavePopup::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -3019,16 +3020,17 @@ impl Model {
 
     #[allow(clippy::too_many_lines)]
     pub fn collect_config_data(&mut self) -> Result<()> {
+        let mut config = self.config.write();
         if self.ke_key_config.has_unique_elements() {
-            self.config.keys = self.ke_key_config.clone();
+            config.keys = self.ke_key_config.clone();
         } else {
             bail!("Duplicate key config found, no changes are saved.");
         }
-        self.config.style_color_symbol = self.ce_style_color_symbol.clone();
+        config.style_color_symbol = self.ce_style_color_symbol.clone();
         if let Ok(State::One(StateValue::String(music_dir))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::MusicDir))
         {
-            // self.config.music_dir = music_dir;
+            // config.music_dir = music_dir;
             // let mut vec = Vec::new();
             let vec = music_dir
                 .split(';')
@@ -3039,21 +3041,21 @@ impl Model {
                     path.exists()
                 })
                 .collect();
-            self.config.music_dir = vec;
+            config.music_dir = vec;
         }
 
         if let Ok(State::One(StateValue::Usize(exit_confirmation))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::ExitConfirmation))
         {
-            self.config.enable_exit_confirmation = matches!(exit_confirmation, 0);
+            config.enable_exit_confirmation = matches!(exit_confirmation, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(display_symbol))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol))
         {
-            self.config.playlist_display_symbol = matches!(display_symbol, 0);
+            config.playlist_display_symbol = matches!(display_symbol, 0);
         }
 
         if let Ok(State::One(StateValue::String(random_track_quantity_str))) = self
@@ -3061,7 +3063,7 @@ impl Model {
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack))
         {
             if let Ok(quantity) = random_track_quantity_str.parse::<u32>() {
-                self.config.playlist_select_random_track_quantity = quantity;
+                config.playlist_select_random_track_quantity = quantity;
             }
         }
 
@@ -3070,7 +3072,7 @@ impl Model {
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum))
         {
             if let Ok(quantity) = random_album_quantity_str.parse::<u32>() {
-                self.config.playlist_select_random_album_quantity = quantity;
+                config.playlist_select_random_album_quantity = quantity;
             }
         }
 
@@ -3081,7 +3083,7 @@ impl Model {
             let absolute_dir = shellexpand::tilde(&podcast_dir).to_string();
             let path = Path::new(&absolute_dir);
             if path.exists() {
-                self.config.podcast_dir = absolute_dir;
+                config.podcast_dir = absolute_dir;
             }
         }
         if let Ok(State::One(StateValue::String(podcast_simul_download))) = self
@@ -3090,7 +3092,7 @@ impl Model {
         {
             if let Ok(quantity) = podcast_simul_download.parse::<usize>() {
                 if (1..101).contains(&quantity) {
-                    self.config.podcast_simultanious_download = quantity;
+                    config.podcast_simultanious_download = quantity;
                 } else {
                     bail!(" It's not suggested to set simultanious download to bigger than 100. ");
                 }
@@ -3102,7 +3104,7 @@ impl Model {
         {
             if let Ok(quantity) = podcast_max_retries.parse::<usize>() {
                 if (1..11).contains(&quantity) {
-                    self.config.podcast_max_retries = quantity;
+                    config.podcast_max_retries = quantity;
                 } else {
                     bail!(" It's not recommended to set max retries to bigger than 10. ");
                 }
@@ -3118,7 +3120,7 @@ impl Model {
                 2 => XywhAlign::TopRight,
                 _ => XywhAlign::TopLeft,
             };
-            self.config.album_photo_xywh.align = align;
+            config.album_photo_xywh.align = align;
         }
 
         if let Ok(State::One(StateValue::Usize(save_last_position))) = self
@@ -3131,7 +3133,7 @@ impl Model {
                 2 => LastPosition::Yes,
                 _ => bail!("Remember playing position must be set to auto, yes or no."),
             };
-            self.config.player_remember_last_played_position = save_last_position;
+            config.player_remember_last_played_position = save_last_position;
         }
 
         if let Ok(State::One(StateValue::Usize(seek_step))) =
@@ -3143,27 +3145,27 @@ impl Model {
                 2 => SeekStep::Long,
                 _ => bail!("Shouldn't happend here."),
             };
-            self.config.player_seek_step = seek_step;
+            config.player_seek_step = seek_step;
         }
 
         if let Ok(State::One(StateValue::Usize(kill_daemon))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::KillDamon))
         {
-            self.config.kill_daemon_when_quit = matches!(kill_daemon, 0);
+            config.kill_daemon_when_quit = matches!(kill_daemon, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(player_use_mpris))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseMpris))
         {
-            self.config.player_use_mpris = matches!(player_use_mpris, 0);
+            config.player_use_mpris = matches!(player_use_mpris, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(player_use_discord))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord))
         {
-            self.config.player_use_discord = matches!(player_use_discord, 0);
+            config.player_use_discord = matches!(player_use_discord, 0);
         }
 
         if let Ok(State::One(StateValue::String(player_port))) = self
@@ -3172,7 +3174,7 @@ impl Model {
         {
             if let Ok(port) = player_port.parse::<u16>() {
                 if (1000..u16::MAX).contains(&port) {
-                    self.config.player_port = port;
+                    config.player_port = port;
                 } else {
                     bail!(" It's not recommended to set player port less than 1000. ");
                 }

--- a/tui/src/ui/components/general_search.rs
+++ b/tui/src/ui/components/general_search.rs
@@ -23,9 +23,10 @@
  */
 use super::{GSMsg, Id, Msg};
 
-use crate::config::{Keys, Settings};
+use crate::config::Settings;
 use crate::ui::Model;
 use anyhow::{anyhow, bail, Result};
+use termusicplayback::SharedSettings;
 use tui_realm_stdlib::{Input, Table};
 use tui_realm_treeview::TREE_INITIAL_NODE;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
@@ -171,7 +172,7 @@ impl Component<Msg, NoUserEvent> for GSInputPopup {
 pub struct GSTablePopup {
     component: Table,
     source: Source,
-    keys: Keys,
+    config: SharedSettings,
 }
 pub enum Source {
     Library,
@@ -182,275 +183,268 @@ pub enum Source {
 }
 impl GSTablePopup {
     #[allow(clippy::too_many_lines)]
-    pub fn new(source: Source, config: &Settings) -> Self {
+    pub fn new(source: Source, config: SharedSettings) -> Self {
+        let config_r = config.read();
         let title_library = format!(
             "Results:(Enter: locate/{}: load to playlist)",
-            config.keys.global_right
+            config_r.keys.global_right
         );
         let title_playlist = format!(
             "Results:(Enter: locate/{}: play selected)",
-            config.keys.global_right
+            config_r.keys.global_right
         );
-        let title_database = format!("Results:( {}: load to playlist)", config.keys.global_right);
+        let title_database = format!(
+            "Results:( {}: load to playlist)",
+            config_r.keys.global_right
+        );
         let title_episode = format!(
             "Results:(Enter: locate/{}: load to playlist)",
-            config.keys.global_right
+            config_r.keys.global_right
         );
 
         let title_podcast = "Results:(Enter: locate)";
-        match source {
-            Source::Library => Self {
-                component: Table::default()
-                    .borders(
-                        Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .library_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
-                            .modifiers(BorderType::Rounded),
-                    )
-                    .background(
-                        config
-                            .style_color_symbol
-                            .library_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
-                    .title(title_library, Alignment::Left)
-                    .scroll(true)
-                    .highlighted_color(
-                        config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::LightBlue),
-                    )
-                    .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
-                    .rewind(false)
-                    .step(4)
-                    .row_height(1)
-                    .headers(&["idx", "File name"])
-                    .column_spacing(3)
-                    .widths(&[5, 95])
-                    .table(
-                        TableBuilder::default()
-                            .add_col(TextSpan::from("Empty result."))
-                            .add_col(TextSpan::from("Loading..."))
-                            .build(),
-                    ),
-                source,
-                keys: config.keys.clone(),
-            },
+        let component = match source {
+            Source::Library => Table::default()
+                .borders(
+                    Borders::default()
+                        .color(
+                            config_r
+                                .style_color_symbol
+                                .library_border()
+                                .unwrap_or(Color::Magenta),
+                        )
+                        .modifiers(BorderType::Rounded),
+                )
+                .background(
+                    config_r
+                        .style_color_symbol
+                        .library_background()
+                        .unwrap_or(Color::Reset),
+                )
+                .foreground(
+                    config_r
+                        .style_color_symbol
+                        .library_foreground()
+                        .unwrap_or(Color::Magenta),
+                )
+                .title(title_library, Alignment::Left)
+                .scroll(true)
+                .highlighted_color(
+                    config_r
+                        .style_color_symbol
+                        .library_highlight()
+                        .unwrap_or(Color::LightBlue),
+                )
+                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .rewind(false)
+                .step(4)
+                .row_height(1)
+                .headers(&["idx", "File name"])
+                .column_spacing(3)
+                .widths(&[5, 95])
+                .table(
+                    TableBuilder::default()
+                        .add_col(TextSpan::from("Empty result."))
+                        .add_col(TextSpan::from("Loading..."))
+                        .build(),
+                ),
 
-            Source::Playlist => Self {
-                component: Table::default()
-                    .borders(
-                        Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .library_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
-                            .modifiers(BorderType::Rounded),
-                    )
-                    .background(
-                        config
-                            .style_color_symbol
-                            .library_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
-                    .title(title_playlist, Alignment::Left)
-                    .scroll(true)
-                    .highlighted_color(
-                        config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::LightBlue),
-                    )
-                    .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
-                    .rewind(false)
-                    .step(4)
-                    .row_height(1)
-                    .headers(&["Duration", "Artist", "Title"])
-                    .column_spacing(3)
-                    .widths(&[14, 30, 56])
-                    .table(
-                        TableBuilder::default()
-                            .add_col(TextSpan::from("Empty result."))
-                            .add_col(TextSpan::from("Loading..."))
-                            .build(),
-                    ),
-                source,
-                keys: config.keys.clone(),
-            },
-            Source::Database => Self {
-                component: Table::default()
-                    .borders(
-                        Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .library_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
-                            .modifiers(BorderType::Rounded),
-                    )
-                    .background(
-                        config
-                            .style_color_symbol
-                            .library_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
-                    .title(title_database, Alignment::Left)
-                    .scroll(true)
-                    .highlighted_color(
-                        config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::LightBlue),
-                    )
-                    .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
-                    .rewind(false)
-                    .step(4)
-                    .row_height(1)
-                    .headers(&["Duration", "Artist", "Title"])
-                    .column_spacing(3)
-                    .widths(&[14, 30, 56])
-                    .table(
-                        TableBuilder::default()
-                            .add_col(TextSpan::from("Empty result."))
-                            .add_col(TextSpan::from("Loading..."))
-                            .build(),
-                    ),
-                source,
-                keys: config.keys.clone(),
-            },
-            Source::Episode => Self {
-                component: Table::default()
-                    .borders(
-                        Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .library_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
-                            .modifiers(BorderType::Rounded),
-                    )
-                    .background(
-                        config
-                            .style_color_symbol
-                            .library_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
-                    .title(title_episode, Alignment::Left)
-                    .scroll(true)
-                    .highlighted_color(
-                        config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::LightBlue),
-                    )
-                    .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
-                    .rewind(false)
-                    .step(4)
-                    .row_height(1)
-                    .headers(&["idx", "Episode Title"])
-                    .column_spacing(3)
-                    .widths(&[5, 95])
-                    .table(
-                        TableBuilder::default()
-                            .add_col(TextSpan::from("Empty result."))
-                            .add_col(TextSpan::from("Loading..."))
-                            .build(),
-                    ),
-                source,
-                keys: config.keys.clone(),
-            },
-            Source::Podcast => Self {
-                component: Table::default()
-                    .borders(
-                        Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .library_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
-                            .modifiers(BorderType::Rounded),
-                    )
-                    .background(
-                        config
-                            .style_color_symbol
-                            .library_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
-                    .title(title_podcast, Alignment::Left)
-                    .scroll(true)
-                    .highlighted_color(
-                        config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::LightBlue),
-                    )
-                    .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
-                    .rewind(false)
-                    .step(4)
-                    .row_height(1)
-                    .headers(&["idx", "Podcast Title"])
-                    .column_spacing(3)
-                    .widths(&[5, 95])
-                    .table(
-                        TableBuilder::default()
-                            .add_col(TextSpan::from("Empty result."))
-                            .add_col(TextSpan::from("Loading..."))
-                            .build(),
-                    ),
-                source,
-                keys: config.keys.clone(),
-            },
+            Source::Playlist => Table::default()
+                .borders(
+                    Borders::default()
+                        .color(
+                            config_r
+                                .style_color_symbol
+                                .library_border()
+                                .unwrap_or(Color::Magenta),
+                        )
+                        .modifiers(BorderType::Rounded),
+                )
+                .background(
+                    config_r
+                        .style_color_symbol
+                        .library_background()
+                        .unwrap_or(Color::Reset),
+                )
+                .foreground(
+                    config_r
+                        .style_color_symbol
+                        .library_foreground()
+                        .unwrap_or(Color::Magenta),
+                )
+                .title(title_playlist, Alignment::Left)
+                .scroll(true)
+                .highlighted_color(
+                    config_r
+                        .style_color_symbol
+                        .library_highlight()
+                        .unwrap_or(Color::LightBlue),
+                )
+                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .rewind(false)
+                .step(4)
+                .row_height(1)
+                .headers(&["Duration", "Artist", "Title"])
+                .column_spacing(3)
+                .widths(&[14, 30, 56])
+                .table(
+                    TableBuilder::default()
+                        .add_col(TextSpan::from("Empty result."))
+                        .add_col(TextSpan::from("Loading..."))
+                        .build(),
+                ),
+            Source::Database => Table::default()
+                .borders(
+                    Borders::default()
+                        .color(
+                            config_r
+                                .style_color_symbol
+                                .library_border()
+                                .unwrap_or(Color::Magenta),
+                        )
+                        .modifiers(BorderType::Rounded),
+                )
+                .background(
+                    config_r
+                        .style_color_symbol
+                        .library_background()
+                        .unwrap_or(Color::Reset),
+                )
+                .foreground(
+                    config_r
+                        .style_color_symbol
+                        .library_foreground()
+                        .unwrap_or(Color::Magenta),
+                )
+                .title(title_database, Alignment::Left)
+                .scroll(true)
+                .highlighted_color(
+                    config_r
+                        .style_color_symbol
+                        .library_highlight()
+                        .unwrap_or(Color::LightBlue),
+                )
+                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .rewind(false)
+                .step(4)
+                .row_height(1)
+                .headers(&["Duration", "Artist", "Title"])
+                .column_spacing(3)
+                .widths(&[14, 30, 56])
+                .table(
+                    TableBuilder::default()
+                        .add_col(TextSpan::from("Empty result."))
+                        .add_col(TextSpan::from("Loading..."))
+                        .build(),
+                ),
+            Source::Episode => Table::default()
+                .borders(
+                    Borders::default()
+                        .color(
+                            config_r
+                                .style_color_symbol
+                                .library_border()
+                                .unwrap_or(Color::Magenta),
+                        )
+                        .modifiers(BorderType::Rounded),
+                )
+                .background(
+                    config_r
+                        .style_color_symbol
+                        .library_background()
+                        .unwrap_or(Color::Reset),
+                )
+                .foreground(
+                    config_r
+                        .style_color_symbol
+                        .library_foreground()
+                        .unwrap_or(Color::Magenta),
+                )
+                .title(title_episode, Alignment::Left)
+                .scroll(true)
+                .highlighted_color(
+                    config_r
+                        .style_color_symbol
+                        .library_highlight()
+                        .unwrap_or(Color::LightBlue),
+                )
+                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .rewind(false)
+                .step(4)
+                .row_height(1)
+                .headers(&["idx", "Episode Title"])
+                .column_spacing(3)
+                .widths(&[5, 95])
+                .table(
+                    TableBuilder::default()
+                        .add_col(TextSpan::from("Empty result."))
+                        .add_col(TextSpan::from("Loading..."))
+                        .build(),
+                ),
+            Source::Podcast => Table::default()
+                .borders(
+                    Borders::default()
+                        .color(
+                            config_r
+                                .style_color_symbol
+                                .library_border()
+                                .unwrap_or(Color::Magenta),
+                        )
+                        .modifiers(BorderType::Rounded),
+                )
+                .background(
+                    config_r
+                        .style_color_symbol
+                        .library_background()
+                        .unwrap_or(Color::Reset),
+                )
+                .foreground(
+                    config_r
+                        .style_color_symbol
+                        .library_foreground()
+                        .unwrap_or(Color::Magenta),
+                )
+                .title(title_podcast, Alignment::Left)
+                .scroll(true)
+                .highlighted_color(
+                    config_r
+                        .style_color_symbol
+                        .library_highlight()
+                        .unwrap_or(Color::LightBlue),
+                )
+                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .rewind(false)
+                .step(4)
+                .row_height(1)
+                .headers(&["idx", "Podcast Title"])
+                .column_spacing(3)
+                .widths(&[5, 95])
+                .table(
+                    TableBuilder::default()
+                        .add_col(TextSpan::from("Empty result."))
+                        .add_col(TextSpan::from("Loading..."))
+                        .build(),
+                ),
+        };
+
+        drop(config_r);
+        Self {
+            component,
+            source,
+            config,
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for GSTablePopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let config = self.config.clone();
+        let keys = &config.read().keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupCloseCancel))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_quit.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupCloseCancel))
             }
 
@@ -461,11 +455,11 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
                 code: Key::Down, ..
             }) => self.perform(Cmd::Move(Direction::Down)),
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -475,10 +469,10 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
             Event::Keyboard(KeyEvent {
                 code: Key::PageUp, ..
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_goto_top.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_goto_top.key_event() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_goto_bottom.key_event() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
@@ -488,7 +482,7 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
                 return Some(Msg::GeneralSearch(GSMsg::TableBlur))
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_right.key_event() => {
                 match self.source {
                     Source::Library => {
                         return Some(Msg::GeneralSearch(GSMsg::PopupCloseLibraryAddPlaylist))

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -58,6 +58,7 @@ pub use popups::{
 };
 pub use progress::Progress;
 pub use tag_editor::*;
+use termusicplayback::SharedSettings;
 pub use youtube_search::{YSInputPopup, YSTablePopup};
 
 use crate::config::Keys;
@@ -71,14 +72,14 @@ use tuirealm::{Component, Event, MockComponent, Sub, SubClause, SubEventClause};
 #[derive(MockComponent)]
 pub struct GlobalListener {
     component: Phantom,
-    keys: Keys,
+    config: SharedSettings,
 }
 
 impl GlobalListener {
-    pub fn new(keys: &Keys) -> Self {
+    pub fn new(config: SharedSettings) -> Self {
         Self {
             component: Phantom::default(),
-            keys: keys.clone(),
+            config,
         }
     }
 }
@@ -86,141 +87,124 @@ impl GlobalListener {
 impl Component<Msg, NoUserEvent> for GlobalListener {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let keys = &self.config.read().keys;
         match ev {
             Event::WindowResize(..) => Some(Msg::UpdatePhoto),
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_esc.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
                 Some(Msg::QuitPopupShow)
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_quit.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
                 Some(Msg::QuitPopupShow)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_toggle_pause.key_event() =>
+                if keyevent == keys.global_player_toggle_pause.key_event() =>
             {
                 Some(Msg::PlayerTogglePause)
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_player_next.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_player_next.key_event() => {
                 Some(Msg::Playlist(PLMsg::NextSong))
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_previous.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_player_previous.key_event() => {
                 Some(Msg::Playlist(PLMsg::PrevSong))
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_volume_minus_1.key_event() =>
+                if keyevent == keys.global_player_volume_minus_1.key_event() =>
             {
                 Some(Msg::PlayerVolumeDown)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_volume_minus_2.key_event() =>
+                if keyevent == keys.global_player_volume_minus_2.key_event() =>
             {
                 Some(Msg::PlayerVolumeDown)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_volume_plus_1.key_event() =>
+                if keyevent == keys.global_player_volume_plus_1.key_event() =>
             {
                 Some(Msg::PlayerVolumeUp)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_volume_plus_2.key_event() =>
+                if keyevent == keys.global_player_volume_plus_2.key_event() =>
             {
                 Some(Msg::PlayerVolumeUp)
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_help.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_help.key_event() => {
                 Some(Msg::HelpPopupShow)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_seek_forward.key_event() =>
+                if keyevent == keys.global_player_seek_forward.key_event() =>
             {
                 Some(Msg::PlayerSeekForward)
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_seek_backward.key_event() =>
+                if keyevent == keys.global_player_seek_backward.key_event() =>
             {
                 Some(Msg::PlayerSeekBackward)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_speed_up.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_player_speed_up.key_event() => {
                 Some(Msg::PlayerSpeedUp)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_speed_down.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_player_speed_down.key_event() => {
                 Some(Msg::PlayerSpeedDown)
             }
 
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_lyric_adjust_forward.key_event() =>
+                if keyevent == keys.global_lyric_adjust_forward.key_event() =>
             {
                 Some(Msg::LyricAdjustDelay(1000))
             }
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_lyric_adjust_backward.key_event() =>
+                if keyevent == keys.global_lyric_adjust_backward.key_event() =>
             {
                 Some(Msg::LyricAdjustDelay(-1000))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_lyric_cycle.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_lyric_cycle.key_event() => {
                 Some(Msg::LyricCycle)
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_layout_treeview.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_layout_treeview.key_event() => {
                 Some(Msg::LayoutTreeView)
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_layout_database.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_layout_database.key_event() => {
                 Some(Msg::LayoutDataBase)
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_layout_podcast.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_layout_podcast.key_event() => {
                 Some(Msg::LayoutPodCast)
             }
 
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_player_toggle_gapless.key_event() =>
+                if keyevent == keys.global_player_toggle_gapless.key_event() =>
             {
                 Some(Msg::PlayerToggleGapless)
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_config_open.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_config_open.key_event() => {
                 Some(Msg::ConfigEditor(ConfigEditorMsg::Open))
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_save_playlist.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_save_playlist.key_event() => {
                 Some(Msg::SavePlaylistPopupShow)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_xywh_move_left.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_left.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::MoveLeft))
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_xywh_move_right.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_right.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::MoveRight))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_xywh_move_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_up.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::MoveUp))
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.global_xywh_move_down.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_down.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::MoveDown))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_xywh_zoom_in.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_zoom_in.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::ZoomIn))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_xywh_zoom_out.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_zoom_out.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::ZoomOut))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_xywh_hide.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_hide.key_event() => {
                 Some(Msg::Xywh(XYWHMsg::Hide))
             }
             _ => None,

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -1,10 +1,9 @@
-use crate::config::{Keys, Settings};
 use crate::ui::{Id, LIMsg, Model, Msg, TEMsg, YSMsg};
 use crate::utils::get_pin_yin;
 use anyhow::{bail, Context, Result};
 use std::fs::{remove_dir_all, remove_file, rename};
 use std::path::{Path, PathBuf};
-use termusicplayback::PlayerCmd;
+use termusicplayback::{PlayerCmd, SharedSettings};
 use tui_realm_treeview::{Node, Tree, TreeView, TREE_CMD_CLOSE, TREE_CMD_OPEN, TREE_INITIAL_NODE};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -15,19 +14,20 @@ use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, Sta
 #[derive(MockComponent)]
 pub struct MusicLibrary {
     component: TreeView,
-    keys: Keys,
+    config: SharedSettings,
     pub init: bool,
 }
 
 impl MusicLibrary {
-    pub fn new(tree: &Tree, initial_node: Option<String>, config: &Settings) -> Self {
+    pub fn new(tree: &Tree, initial_node: Option<String>, config: SharedSettings) -> Self {
         // Preserve initial node if exists
         let initial_node = match initial_node {
             Some(id) if tree.root().query(&id).is_some() => id,
             _ => tree.root().id().to_string(),
         };
-        Self {
-            component: TreeView::default()
+        let component = {
+            let config = config.read();
+            TreeView::default()
                 .background(
                     config
                         .style_color_symbol
@@ -64,8 +64,12 @@ impl MusicLibrary {
                 .preserve_state(true)
                 // .highlight_symbol("🦄")
                 .with_tree(tree.clone())
-                .initial_node(initial_node),
-            keys: config.keys.clone(),
+                .initial_node(initial_node)
+        };
+
+        Self {
+            component,
+            config,
             init: true,
         }
     }
@@ -103,8 +107,10 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                 self.init = false;
             }
         }
+        let config = self.config.clone();
+        let keys = &config.read().keys;
         let result = match ev {
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_left.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_left.key_event() => {
                 self.handle_left_key()
             }
             Event::Keyboard(KeyEvent {
@@ -125,7 +131,7 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                     )));
                 }
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_right.key_event() => {
                 let current_node = self.component.tree_state().selected().unwrap();
                 let p: &Path = Path::new(current_node);
                 if p.is_dir() {
@@ -136,10 +142,10 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                     )));
                 }
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -151,7 +157,7 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Move(Direction::Up)),
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_load_dir.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_load_dir.key_event() => {
                 let current_node = self.component.tree_state().selected().unwrap();
                 let p: &Path = Path::new(current_node);
                 if p.is_dir() {
@@ -169,10 +175,10 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_goto_top.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_goto_top.key_event() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_goto_bottom.key_event() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -193,37 +199,33 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
                     modifiers: KeyModifiers::SHIFT,
                 },
             ) => return Some(Msg::Library(LIMsg::TreeBlur)),
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_delete.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_delete.key_event() => {
                 return Some(Msg::DeleteConfirmShow)
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_yank.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_yank.key_event() => {
                 return Some(Msg::Library(LIMsg::Yank))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_paste.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_paste.key_event() => {
                 return Some(Msg::Library(LIMsg::Paste))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_switch_root.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_switch_root.key_event() => {
                 return Some(Msg::Library(LIMsg::SwitchRoot))
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_add_root.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_add_root.key_event() => {
                 return Some(Msg::Library(LIMsg::AddRoot))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_remove_root.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_remove_root.key_event() => {
                 return Some(Msg::Library(LIMsg::RemoveRoot))
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowLibrary))
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.library_search_youtube.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.library_search_youtube.key_event() => {
                 return Some(Msg::YoutubeSearch(YSMsg::InputPopupShow))
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.library_tag_editor_open.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.library_tag_editor_open.key_event() => {
                 let current_node = self.component.tree_state().selected().unwrap();
                 return Some(Msg::TagEditor(TEMsg::TagEditorRun(
                     current_node.to_string(),
@@ -244,7 +246,7 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
 impl Model {
     pub fn library_scan_dir(&mut self, p: &Path) {
         self.path = p.to_path_buf();
-        self.tree = Tree::new(Self::library_dir_tree(p, self.config.max_depth_cli));
+        self.tree = Tree::new(Self::library_dir_tree(p, self.config.read().max_depth_cli));
     }
 
     pub fn library_upper_dir(&self) -> Option<PathBuf> {
@@ -308,7 +310,7 @@ impl Model {
     pub fn library_reload_tree(&mut self) {
         self.tree = Tree::new(Self::library_dir_tree(
             self.path.as_ref(),
-            self.config.max_depth_cli,
+            self.config.read().max_depth_cli,
         ));
         let current_node = match self.app.state(&Id::Library).ok().unwrap() {
             State::One(StateValue::String(id)) => Some(id),
@@ -331,7 +333,7 @@ impl Model {
                     Box::new(MusicLibrary::new(
                         &self.tree.clone(),
                         current_node,
-                        &self.config,
+                        self.config.clone(),
                     ),),
                     Vec::new()
                 )
@@ -347,7 +349,7 @@ impl Model {
                 Box::new(MusicLibrary::new(
                     &self.tree.clone(),
                     current_node,
-                    &self.config,
+                    self.config.clone(),
                 ),),
                 Vec::new()
             )
@@ -479,17 +481,19 @@ impl Model {
 
     pub fn library_switch_root(&mut self) {
         let mut vec = Vec::new();
-        for dir in &self.config.music_dir {
+        let config = self.config.read();
+        for dir in &config.music_dir {
             let absolute_dir = shellexpand::tilde(dir).to_string();
             vec.push(absolute_dir);
         }
-        if let Some(dir) = &self.config.music_dir_from_cli {
+        if let Some(dir) = &config.music_dir_from_cli {
             let absolute_dir = shellexpand::tilde(&dir).to_string();
             vec.push(absolute_dir);
         }
         if vec.is_empty() {
             return;
         }
+        drop(config);
 
         let mut index = 0;
         let current_path_str = self.path.to_string_lossy().to_string();
@@ -512,14 +516,18 @@ impl Model {
     pub fn library_add_root(&mut self) -> Result<()> {
         let current_path_string = self.path.to_string_lossy().to_string();
 
-        for dir in &self.config.music_dir {
+        let mut config = self.config.write();
+
+        for dir in &config.music_dir {
             let absolute_dir = shellexpand::tilde(dir).to_string();
             if absolute_dir == current_path_string {
                 bail!("Add root failed, same root already exists");
             }
         }
-        self.config.music_dir.push(current_path_string);
-        match self.config.save() {
+        config.music_dir.push(current_path_string);
+        let res = config.save();
+        drop(config);
+        match res {
             Ok(()) => {
                 self.command(&PlayerCmd::ReloadConfig);
             }
@@ -532,9 +540,10 @@ impl Model {
 
     pub fn library_remove_root(&mut self) -> Result<()> {
         let current_path_string = self.path.to_string_lossy().to_string();
+        let mut config = self.config.write();
 
         let mut vec = Vec::new();
-        for dir in &self.config.music_dir {
+        for dir in &config.music_dir {
             let absolute_dir = shellexpand::tilde(dir).to_string();
             if absolute_dir == current_path_string {
                 continue;
@@ -545,7 +554,8 @@ impl Model {
             bail!("At least 1 root music directory should be kept");
         }
 
-        self.config.music_dir = vec;
+        config.music_dir = vec;
+        drop(config);
         self.library_switch_root();
         Ok(())
     }

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -6,13 +6,11 @@ use std::borrow::Cow;
 use std::path::Path;
 use termusiclib::sqlite::SearchCriteria;
 use termusiclib::sqlite::TrackForDB;
+use termusiclib::track::Track;
 use termusiclib::types::{GSMsg, Id, Msg, PLMsg};
 use termusiclib::utils::{filetype_supported, get_parent_folder, is_playlist, playlist_get_vec};
-use termusiclib::{
-    config::{Keys, Settings},
-    track::Track,
-};
 use termusicplayback::PlayerCmd;
+use termusicplayback::SharedSettings;
 
 use tui_realm_stdlib::Table;
 use tuirealm::props::{Alignment, BorderType, PropPayload, PropValue, TableBuilder, TextSpan};
@@ -29,13 +27,14 @@ use tuirealm::{
 #[derive(MockComponent)]
 pub struct Playlist {
     component: Table,
-    keys: Keys,
+    config: SharedSettings,
 }
 
 impl Playlist {
-    pub fn new(config: &Settings) -> Self {
-        Self {
-            component: Table::default()
+    pub fn new(config: SharedSettings) -> Self {
+        let component = {
+            let config = config.read();
+            Table::default()
                 .borders(
                     Borders::default().modifiers(BorderType::Rounded).color(
                         config
@@ -77,15 +76,18 @@ impl Playlist {
                         .add_col(TextSpan::from("Empty Queue"))
                         .add_col(TextSpan::from("Empty"))
                         .build(),
-                ),
-            keys: config.keys.clone(),
-        }
+                )
+        };
+
+        Self { component, config }
     }
 }
 
 impl Component<Msg, NoUserEvent> for Playlist {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let config = self.config.clone();
+        let keys = &config.read().keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -95,10 +97,10 @@ impl Component<Msg, NoUserEvent> for Playlist {
                 code: Key::Up,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Move(Direction::Up)),
-            Event::Keyboard(key) if key == self.keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.global_down.key_event() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(key) if key == self.keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.global_up.key_event() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -109,10 +111,10 @@ impl Component<Msg, NoUserEvent> for Playlist {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == self.keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == self.keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -131,7 +133,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
                 code: Key::BackTab,
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(Msg::Playlist(PLMsg::PlaylistTableBlurUp)),
-            Event::Keyboard(key) if key == self.keys.playlist_delete.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_delete.key_event() => {
                 match self.component.state() {
                     State::One(StateValue::Usize(index_selected)) => {
                         return Some(Msg::Playlist(PLMsg::Delete(index_selected)))
@@ -139,16 +141,16 @@ impl Component<Msg, NoUserEvent> for Playlist {
                     _ => return Some(Msg::None),
                 }
             }
-            Event::Keyboard(key) if key == self.keys.playlist_delete_all.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_delete_all.key_event() => {
                 return Some(Msg::Playlist(PLMsg::DeleteAll))
             }
-            Event::Keyboard(key) if key == self.keys.playlist_shuffle.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_shuffle.key_event() => {
                 return Some(Msg::Playlist(PLMsg::Shuffle))
             }
-            Event::Keyboard(key) if key == self.keys.playlist_mode_cycle.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_mode_cycle.key_event() => {
                 return Some(Msg::Playlist(PLMsg::LoopModeCycle))
             }
-            Event::Keyboard(key) if key == self.keys.playlist_play_selected.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_play_selected.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Playlist(PLMsg::PlaySelected(index)));
                 }
@@ -164,10 +166,10 @@ impl Component<Msg, NoUserEvent> for Playlist {
                 }
                 CmdResult::None
             }
-            Event::Keyboard(key) if key == self.keys.playlist_search.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_search.key_event() => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupShowPlaylist))
             }
-            Event::Keyboard(key) if key == self.keys.playlist_swap_down.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_swap_down.key_event() => {
                 match self.component.state() {
                     State::One(StateValue::Usize(index_selected)) => {
                         self.perform(Cmd::Move(Direction::Down));
@@ -176,7 +178,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
                     _ => return Some(Msg::None),
                 }
             }
-            Event::Keyboard(key) if key == self.keys.playlist_swap_up.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_swap_up.key_event() => {
                 match self.component.state() {
                     State::One(StateValue::Usize(index_selected)) => {
                         self.perform(Cmd::Move(Direction::Up));
@@ -185,10 +187,10 @@ impl Component<Msg, NoUserEvent> for Playlist {
                     _ => return Some(Msg::None),
                 }
             }
-            Event::Keyboard(key) if key == self.keys.playlist_cmus_lqueue.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_cmus_lqueue.key_event() => {
                 return Some(Msg::Playlist(PLMsg::CmusLQueue));
             }
-            Event::Keyboard(key) if key == self.keys.playlist_cmus_tqueue.key_event() => {
+            Event::Keyboard(key) if key == keys.playlist_cmus_tqueue.key_event() => {
                 return Some(Msg::Playlist(PLMsg::CmusTQueue));
             }
             _ => CmdResult::None,
@@ -203,7 +205,7 @@ impl Model {
             .app
             .remount(
                 Id::Playlist,
-                Box::new(Playlist::new(&self.config)),
+                Box::new(Playlist::new(self.config.clone())),
                 Vec::new()
             )
             .is_ok());
@@ -342,16 +344,16 @@ impl Model {
     }
 
     pub fn playlist_add_cmus_lqueue(&mut self) {
-        let vec = self.playlist_get_records_for_cmus_lqueue(
-            self.config.playlist_select_random_album_quantity,
-        );
+        let playlist_select_random_album_quantity =
+            self.config.read().playlist_select_random_album_quantity;
+        let vec = self.playlist_get_records_for_cmus_lqueue(playlist_select_random_album_quantity);
         self.playlist_add_all_from_db(&vec);
     }
 
     pub fn playlist_add_cmus_tqueue(&mut self) {
-        let vec = self.playlist_get_records_for_cmus_tqueue(
-            self.config.playlist_select_random_track_quantity,
-        );
+        let playlist_select_random_album_quantity =
+            self.config.read().playlist_select_random_album_quantity;
+        let vec = self.playlist_get_records_for_cmus_tqueue(playlist_select_random_album_quantity);
         self.playlist_add_all_from_db(&vec);
     }
 
@@ -490,11 +492,12 @@ impl Model {
 
     pub fn playlist_update_title(&mut self) {
         let duration = self.playlist.tracks().iter().map(Track::duration).sum();
+        let config = self.config.read();
         let title = format!(
             "\u{2500} Playlist \u{2500}\u{2500}\u{2524} Total {} tracks | {} | Mode: {} \u{251c}\u{2500}",
             self.playlist.len(),
             Track::duration_formatted_short(&duration),
-            self.config.player_loop_mode.display(self.config.playlist_display_symbol),
+            config.player_loop_mode.display(config.playlist_display_symbol),
         );
         self.app
             .attr(

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -4,10 +4,10 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use sanitize_filename::{sanitize_with_options, Options};
 use serde_json::Value;
 use std::time::Duration;
-use termusiclib::config::{Keys, Settings};
 use termusiclib::podcast::{download_list, EpData, PodcastFeed, PodcastNoId};
 use termusiclib::track::MediaType;
 use termusiclib::types::{Id, Msg, PCMsg};
+use termusicplayback::SharedSettings;
 use tui_realm_stdlib::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{Alignment, BorderType, TableBuilder, TextSpan};
@@ -24,13 +24,14 @@ pub struct FeedsList {
     component: List,
     on_key_tab: Msg,
     on_key_backtab: Msg,
-    keys: Keys,
+    config: SharedSettings,
 }
 
 impl FeedsList {
-    pub fn new(config: &Settings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
-        Self {
-            component: List::default()
+    pub fn new(config: SharedSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
+        let component = {
+            let config = config.read();
+            List::default()
                 .borders(
                     Borders::default().modifiers(BorderType::Rounded).color(
                         config
@@ -67,10 +68,14 @@ impl FeedsList {
                     TableBuilder::default()
                         .add_col(TextSpan::from("Empty"))
                         .build(),
-                ),
+                )
+        };
+
+        Self {
+            component,
             on_key_tab,
             on_key_backtab,
-            keys: config.keys.clone(),
+            config,
         }
     }
 }
@@ -78,6 +83,8 @@ impl FeedsList {
 impl Component<Msg, NoUserEvent> for FeedsList {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let config = self.config.clone();
+        let keys = &config.read().keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -96,7 +103,7 @@ impl Component<Msg, NoUserEvent> for FeedsList {
                 code: Key::Up,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Move(Direction::Up)),
-            Event::Keyboard(key) if key == self.keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.global_down.key_event() => {
                 if let Some(AttrValue::Table(t)) = self.query(Attribute::Content) {
                     if let State::One(StateValue::Usize(index)) = self.state() {
                         if index >= t.len() - 1 {
@@ -106,7 +113,7 @@ impl Component<Msg, NoUserEvent> for FeedsList {
                 }
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(key) if key == self.keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.global_up.key_event() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -117,10 +124,10 @@ impl Component<Msg, NoUserEvent> for FeedsList {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == self.keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == self.keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -138,7 +145,7 @@ impl Component<Msg, NoUserEvent> for FeedsList {
                 CmdResult::None
             }
 
-            Event::Keyboard(key) if key == self.keys.global_right.key_event() => {
+            Event::Keyboard(key) if key == keys.global_right.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::PodcastSelected(index)));
                 }
@@ -159,35 +166,29 @@ impl Component<Msg, NoUserEvent> for FeedsList {
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(self.on_key_backtab.clone()),
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_search_add_feed.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_search_add_feed.key_event() => {
                 return Some(Msg::Podcast(PCMsg::PodcastAddPopupShow));
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.podcast_refresh_feed.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_refresh_feed.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::PodcastRefreshOne(index)));
                 }
                 CmdResult::None
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_refresh_all_feeds.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_refresh_all_feeds.key_event() => {
                 return Some(Msg::Podcast(PCMsg::PodcastRefreshAll));
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.podcast_delete_feed.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_delete_feed.key_event() => {
                 return Some(Msg::Podcast(PCMsg::FeedDeleteShow));
             }
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_delete_all_feeds.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_delete_all_feeds.key_event() => {
                 return Some(Msg::Podcast(PCMsg::FeedsDeleteShow));
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowPodcast))
             }
             _ => CmdResult::None,
@@ -201,13 +202,14 @@ pub struct EpisodeList {
     component: List,
     on_key_tab: Msg,
     on_key_backtab: Msg,
-    keys: Keys,
+    config: SharedSettings,
 }
 
 impl EpisodeList {
-    pub fn new(config: &Settings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
-        Self {
-            component: List::default()
+    pub fn new(config: SharedSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
+        let component = {
+            let config = config.read();
+            List::default()
                 .borders(
                     Borders::default().modifiers(BorderType::Rounded).color(
                         config
@@ -244,10 +246,14 @@ impl EpisodeList {
                     TableBuilder::default()
                         .add_col(TextSpan::from("Empty"))
                         .build(),
-                ),
+                )
+        };
+
+        Self {
+            component,
             on_key_tab,
             on_key_backtab,
-            keys: config.keys.clone(),
+            config,
         }
     }
 }
@@ -255,6 +261,8 @@ impl EpisodeList {
 impl Component<Msg, NoUserEvent> for EpisodeList {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let config = self.config.clone();
+        let keys = &config.read().keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -275,11 +283,11 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
                 self.perform(Cmd::Move(Direction::Up));
                 return Some(Msg::Podcast(PCMsg::DescriptionUpdate));
             }
-            Event::Keyboard(key) if key == self.keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.global_down.key_event() => {
                 self.perform(Cmd::Move(Direction::Down));
                 return Some(Msg::Podcast(PCMsg::DescriptionUpdate));
             }
-            Event::Keyboard(key) if key == self.keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.global_up.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     if index == 0 {
                         return Some(self.on_key_backtab.clone());
@@ -296,10 +304,10 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == self.keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == self.keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -330,29 +338,25 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
                 CmdResult::None
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.global_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_right.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::EpisodeAdd(index)));
                 }
                 CmdResult::None
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.keys.podcast_mark_played.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_mark_played.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::EpisodeMarkPlayed(index)));
                 }
                 CmdResult::None
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_mark_all_played.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_mark_all_played.key_event() => {
                 return Some(Msg::Podcast(PCMsg::EpisodeMarkAllPlayed));
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_episode_download.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.podcast_episode_download.key_event() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::EpisodeDownload(index)));
                 }
@@ -360,14 +364,14 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
             }
 
             Event::Keyboard(keyevent)
-                if keyevent == self.keys.podcast_episode_delete_file.key_event() =>
+                if keyevent == keys.podcast_episode_delete_file.key_event() =>
             {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::Podcast(PCMsg::EpisodeDeleteFile(index)));
                 }
                 CmdResult::None
             }
-            Event::Keyboard(keyevent) if keyevent == self.keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowEpisode))
             }
             _ => CmdResult::None,
@@ -387,7 +391,7 @@ impl Model {
             .expect("error build client");
         // let result = agent.get(&url).call()?;
 
-        let mut max_retries = self.config.podcast_max_retries;
+        let mut max_retries = self.config.read().podcast_max_retries;
 
         let tx = self.tx_to_main.clone();
 
@@ -446,7 +450,7 @@ impl Model {
 
         crate::podcast::check_feed(
             feed,
-            self.config.podcast_max_retries,
+            self.config.read().podcast_max_retries,
             &self.threadpool,
             self.tx_to_main.clone(),
         );
@@ -708,7 +712,7 @@ impl Model {
         for feed in pod_data {
             crate::podcast::check_feed(
                 feed,
-                self.config.podcast_max_retries,
+                self.config.read().podcast_max_retries,
                 &self.threadpool,
                 self.tx_to_main.clone(),
             );
@@ -792,7 +796,7 @@ impl Model {
                     replacement: "",
                 },
             );
-            match crate::utils::create_podcast_dir(&self.config, dir_name) {
+            match crate::utils::create_podcast_dir(&self.config.read(), dir_name) {
                 Ok(path) => {
                     // for ep in ep_data.iter() {
                     //     self.download_tracker.insert(ep.id);
@@ -800,7 +804,7 @@ impl Model {
                     download_list(
                         ep_data,
                         &path,
-                        self.config.podcast_max_retries,
+                        self.config.read().podcast_max_retries,
                         &self.threadpool,
                         &self.tx_to_main,
                     );

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -66,7 +66,7 @@ impl Model {
             .app
             .remount(
                 Id::Progress,
-                Box::new(Progress::new(&self.config)),
+                Box::new(Progress::new(&self.config.read())),
                 Vec::new()
             )
             .is_ok());
@@ -75,7 +75,8 @@ impl Model {
 
     #[allow(clippy::cast_precision_loss)]
     pub fn progress_update_title(&mut self) {
-        let gapless = if self.config.player_gapless {
+        let config = self.config.read();
+        let gapless = if config.player_gapless {
             "True"
         } else {
             "False"
@@ -87,8 +88,8 @@ impl Model {
                     progress_title = format!(
                         " Status: {} | Volume: {} | Speed: {:^.1} | Gapless: {} ",
                         self.playlist.status(),
-                        self.config.player_volume,
-                        self.config.player_speed as f32 / 10.0,
+                        config.player_volume,
+                        config.player_speed as f32 / 10.0,
                         gapless,
                     );
                 }
@@ -97,14 +98,15 @@ impl Model {
                         " Status: {} {:^.20} | Volume: {} | Speed: {:^.1} | Gapless: {} ",
                         self.playlist.status(),
                         track.title().unwrap_or("Unknown title"),
-                        self.config.player_volume,
-                        self.config.player_speed as f32 / 10.0,
+                        config.player_volume,
+                        config.player_speed as f32 / 10.0,
                         gapless,
                     );
                 }
             }
         }
 
+        drop(config);
         self.app
             .attr(
                 &Id::Progress,

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -22,6 +22,7 @@
  * SOFTWARE.
  */
 // use crate::utils::get_block;
+use termusicplayback::SharedSettings;
 use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -32,7 +33,6 @@ use tuirealm::{
     AttrValue, Attribute, Component, Event, Frame, MockComponent, Props, State, StateValue,
 };
 
-use crate::config::Settings;
 use crate::ui::{Model, Msg, TEMsg, TFMsg};
 /// ## Counter
 ///
@@ -197,13 +197,14 @@ impl OwnStates {
 #[derive(MockComponent)]
 pub struct TECounterDelete {
     component: Counter,
-    config: Settings,
+    config: SharedSettings,
 }
 
 impl TECounterDelete {
-    pub fn new(initial_value: isize, config: &Settings) -> Self {
-        Self {
-            component: Counter::default()
+    pub fn new(initial_value: isize, config: SharedSettings) -> Self {
+        let component = {
+            let config = config.read();
+            Counter::default()
                 .alignment(Alignment::Center)
                 .background(
                     config
@@ -229,17 +230,19 @@ impl TECounterDelete {
                     Color::Red,
                 )
                 .modifiers(TextModifiers::BOLD)
-                .value(initial_value),
-            config: config.clone(),
-        }
+                .value(initial_value)
+        };
+
+        Self { component, config }
     }
 }
 
 impl Component<Msg, NoUserEvent> for TECounterDelete {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        let keys = &self.config.read().keys;
         // Get command
         let _cmd = match ev {
-            Event::Keyboard(keyevent) if keyevent == self.config.keys.config_save.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
@@ -256,17 +259,17 @@ impl Component<Msg, NoUserEvent> for TECounterDelete {
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurUp)))
             }
-            Event::Keyboard(keyevent) if keyevent == self.config.keys.global_quit.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(keyevent) if keyevent == self.config.keys.global_esc.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(keyevent) if keyevent == self.config.keys.global_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurUp)))
             }
 
-            Event::Keyboard(keyevent) if keyevent == self.config.keys.global_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurDown)))
             }
 

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -30,14 +30,16 @@ use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{Alignment, BorderType, Borders, Color, InputType};
 use tuirealm::{Component, Event, MockComponent};
 
+/// Common Field Properties and event handling
 #[derive(MockComponent)]
-pub struct TEInputArtist {
+struct EditField {
     component: Input,
     config: Settings,
 }
 
-impl TEInputArtist {
-    pub fn new(config: &Settings) -> Self {
+impl EditField {
+    #[inline]
+    pub fn new(config: Settings, title: &'static str) -> Self {
         Self {
             component: Input::default()
                 .foreground(
@@ -63,19 +65,36 @@ impl TEInputArtist {
                         .modifiers(BorderType::Rounded),
                 )
                 .input_type(InputType::Text)
-                .title(" Search artist ", Alignment::Left),
-            config: config.clone(),
+                .title(title, Alignment::Left),
+            config,
+        }
+    }
+
+    /// Basically [`Component::on`] but with custom extra parameters
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn on(&mut self, ev: Event<NoUserEvent>, on_key_down: Msg, on_key_up: Msg) -> Option<Msg> {
+        let keys = self.config.keys.clone();
+        handle_input_ev(self, ev, &keys, on_key_down, on_key_up)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct TEInputArtist {
+    component: EditField,
+}
+
+impl TEInputArtist {
+    pub fn new(config: Settings) -> Self {
+        Self {
+            component: EditField::new(config, " Search artist "),
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for TEInputArtist {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
-        handle_input_ev(
-            self,
+        self.component.on(
             ev,
-            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputArtistBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputArtistBlurUp)),
         )
@@ -84,50 +103,21 @@ impl Component<Msg, NoUserEvent> for TEInputArtist {
 
 #[derive(MockComponent)]
 pub struct TEInputTitle {
-    component: Input,
-    config: Settings,
+    component: EditField,
 }
 
 impl TEInputTitle {
-    pub fn new(config: &Settings) -> Self {
+    pub fn new(config: Settings) -> Self {
         Self {
-            component: Input::default()
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Cyan),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Black),
-                )
-                .borders(
-                    Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightYellow),
-                        )
-                        .modifiers(BorderType::Rounded),
-                )
-                .input_type(InputType::Text)
-                .title(" Search track name ", Alignment::Left),
-            config: config.clone(),
+            component: EditField::new(config, " Search track name "),
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for TEInputTitle {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
-        handle_input_ev(
-            self,
+        self.component.on(
             ev,
-            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputTitleBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputTitleBlurUp)),
         )
@@ -136,7 +126,7 @@ impl Component<Msg, NoUserEvent> for TEInputTitle {
 
 #[allow(clippy::needless_pass_by_value)]
 fn handle_input_ev(
-    component: &mut dyn Component<Msg, NoUserEvent>,
+    component: &mut dyn MockComponent,
     ev: Event<NoUserEvent>,
     keys: &Keys,
     on_key_down: Msg,
@@ -216,50 +206,21 @@ fn handle_input_ev(
 
 #[derive(MockComponent)]
 pub struct TEInputAlbum {
-    component: Input,
-    config: Settings,
+    component: EditField,
 }
 
 impl TEInputAlbum {
-    pub fn new(config: &Settings) -> Self {
+    pub fn new(config: Settings) -> Self {
         Self {
-            component: Input::default()
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Cyan),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Black),
-                )
-                .borders(
-                    Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightYellow),
-                        )
-                        .modifiers(BorderType::Rounded),
-                )
-                .input_type(InputType::Text)
-                .title(" Album ", Alignment::Left),
-            config: config.clone(),
+            component: EditField::new(config, " Album "),
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for TEInputAlbum {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
-        handle_input_ev(
-            self,
+        self.component.on(
             ev,
-            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputAlbumBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputAlbumBlurUp)),
         )
@@ -268,50 +229,21 @@ impl Component<Msg, NoUserEvent> for TEInputAlbum {
 
 #[derive(MockComponent)]
 pub struct TEInputGenre {
-    component: Input,
-    config: Settings,
+    component: EditField,
 }
 
 impl TEInputGenre {
-    pub fn new(config: &Settings) -> Self {
+    pub fn new(config: Settings) -> Self {
         Self {
-            component: Input::default()
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Cyan),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Black),
-                )
-                .borders(
-                    Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightYellow),
-                        )
-                        .modifiers(BorderType::Rounded),
-                )
-                .input_type(InputType::Text)
-                .title(" Genre ", Alignment::Left),
-            config: config.clone(),
+            component: EditField::new(config, " Genre "),
         }
     }
 }
 
 impl Component<Msg, NoUserEvent> for TEInputGenre {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = self.config.keys.clone();
-        handle_input_ev(
-            self,
+        self.component.on(
             ev,
-            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputGenreBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputGenreBlurUp)),
         )

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -23,6 +23,7 @@
  */
 use crate::config::Settings;
 use crate::ui::{Msg, TEMsg, TFMsg};
+use termusiclib::config::Keys;
 use tui_realm_stdlib::Input;
 use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -70,11 +71,11 @@ impl TEInputArtist {
 
 impl Component<Msg, NoUserEvent> for TEInputArtist {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputArtistBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputArtistBlurUp)),
         )
@@ -122,11 +123,11 @@ impl TEInputTitle {
 
 impl Component<Msg, NoUserEvent> for TEInputTitle {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputTitleBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputTitleBlurUp)),
         )
@@ -137,13 +138,13 @@ impl Component<Msg, NoUserEvent> for TEInputTitle {
 fn handle_input_ev(
     component: &mut dyn Component<Msg, NoUserEvent>,
     ev: Event<NoUserEvent>,
-    config: &Settings,
+    keys: &Keys,
     on_key_down: Msg,
     on_key_up: Msg,
 ) -> Option<Msg> {
     match ev {
         // Global Hotkeys
-        Event::Keyboard(keyevent) if keyevent == config.keys.config_save.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
             Some(Msg::TagEditor(TEMsg::TERename))
         }
         Event::Keyboard(KeyEvent {
@@ -157,7 +158,7 @@ fn handle_input_ev(
                 modifiers: KeyModifiers::SHIFT,
             },
         ) => Some(on_key_up),
-        Event::Keyboard(keyevent) if keyevent == config.keys.global_esc.key_event() => {
+        Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
             Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
         }
 
@@ -254,11 +255,11 @@ impl TEInputAlbum {
 
 impl Component<Msg, NoUserEvent> for TEInputAlbum {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputAlbumBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputAlbumBlurUp)),
         )
@@ -306,11 +307,11 @@ impl TEInputGenre {
 
 impl Component<Msg, NoUserEvent> for TEInputGenre {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let config = self.config.clone();
+        let keys = self.config.keys.clone();
         handle_input_ev(
             self,
             ev,
-            &config,
+            &keys,
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputGenreBlurDown)),
             Msg::TagEditor(TEMsg::TEFocus(TFMsg::InputGenreBlurUp)),
         )

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -194,7 +194,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputArtist),
-                        Box::new(TEInputArtist::new(&self.config)),
+                        Box::new(TEInputArtist::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -202,7 +202,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputTitle),
-                        Box::new(TEInputTitle::new(&self.config)),
+                        Box::new(TEInputTitle::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -210,7 +210,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputAlbum),
-                        Box::new(TEInputAlbum::new(&self.config)),
+                        Box::new(TEInputAlbum::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -218,7 +218,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputGenre),
-                        Box::new(TEInputGenre::new(&self.config)),
+                        Box::new(TEInputGenre::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -186,7 +186,10 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::LabelHint),
-                        Box::new(LabelGeneric::new(&self.config, "Press <ENTER> to search:")),
+                        Box::new(LabelGeneric::new(
+                            &self.config.read(),
+                            "Press <ENTER> to search:"
+                        )),
                         vec![]
                     )
                     .is_ok());
@@ -226,7 +229,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::TableLyricOptions),
-                        Box::new(TETableLyricOptions::new(&self.config)),
+                        Box::new(TETableLyricOptions::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -234,7 +237,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::SelectLyric),
-                        Box::new(TESelectLyric::new(&self.config)),
+                        Box::new(TESelectLyric::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -242,7 +245,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::CounterDelete),
-                        Box::new(TECounterDelete::new(5, &self.config)),
+                        Box::new(TECounterDelete::new(5, self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -250,7 +253,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::TextareaLyric),
-                        Box::new(TETextareaLyric::new(&self.config)),
+                        Box::new(TETextareaLyric::new(self.config.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -459,66 +462,57 @@ impl Model {
     }
 
     pub fn remount_tag_editor_label_help(&mut self) {
+        let config = self.config.read();
         assert!(self
             .app
             .remount(
                 Id::Label,
                 Box::new(LabelSpan::new(
-                    &self.config,
+                    &config,
                     &[
-                        TextSpan::new(format!("<{}>", self.config.keys.config_save))
+                        TextSpan::new(format!("<{}>", config.keys.config_save))
                             .bold()
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Save tag ").fg(self
-                            .config
+                        TextSpan::new(" Save tag ").fg(config
                             .style_color_symbol
                             .library_foreground()
                             .unwrap_or(Color::White)),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_esc))
+                        TextSpan::new(format!("<{}>", config.keys.global_esc))
                             .bold()
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Exit ").fg(self
-                            .config
+                        TextSpan::new(" Exit ").fg(config
                             .style_color_symbol
                             .library_foreground()
                             .unwrap_or(Color::White)),
-                        TextSpan::new("<Tab/ShiftTab>").bold().fg(self
-                            .config
+                        TextSpan::new("<Tab/ShiftTab>").bold().fg(config
                             .style_color_symbol
                             .library_highlight()
                             .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Change field ").fg(self
-                            .config
+                        TextSpan::new(" Change field ").fg(config
                             .style_color_symbol
                             .library_foreground()
                             .unwrap_or(Color::White)),
-                        TextSpan::new("<ENTER>").bold().fg(self
-                            .config
+                        TextSpan::new("<ENTER>").bold().fg(config
                             .style_color_symbol
                             .library_highlight()
                             .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Search/Embed tag ").fg(self
-                            .config
+                        TextSpan::new(" Search/Embed tag ").fg(config
                             .style_color_symbol
                             .library_foreground()
                             .unwrap_or(Color::White)),
-                        TextSpan::new(format!("<{}>", self.config.keys.library_search_youtube))
+                        TextSpan::new(format!("<{}>", config.keys.library_search_youtube))
                             .bold()
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" download ").fg(self
-                            .config
+                        TextSpan::new(" download ").fg(config
                             .style_color_symbol
                             .library_foreground()
                             .unwrap_or(Color::White)),

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -33,35 +33,37 @@ use termusiclib::types::{DLMsg, Id, IdConfigEditor, IdTagEditor, ImageWrapper, M
 
 impl Model {
     pub fn xywh_move_left(&mut self) {
-        self.config.album_photo_xywh.move_left();
+        self.config.write().album_photo_xywh.move_left();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_right(&mut self) {
-        self.config.album_photo_xywh.move_right();
+        self.config.write().album_photo_xywh.move_right();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_up(&mut self) {
-        self.config.album_photo_xywh.move_up();
+        self.config.write().album_photo_xywh.move_up();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_down(&mut self) {
-        self.config.album_photo_xywh.move_down();
+        self.config.write().album_photo_xywh.move_down();
         self.update_photo().ok();
     }
     pub fn xywh_zoom_in(&mut self) {
-        self.config.album_photo_xywh.zoom_in();
+        self.config.write().album_photo_xywh.zoom_in();
         self.update_photo().ok();
     }
     pub fn xywh_zoom_out(&mut self) {
-        self.config.album_photo_xywh.zoom_out();
+        self.config.write().album_photo_xywh.zoom_out();
         self.update_photo().ok();
     }
     pub fn xywh_toggle_hide(&mut self) {
         self.clear_photo().ok();
-        self.config.disable_album_art_from_cli = !self.config.disable_album_art_from_cli;
+        let mut config = self.config.write();
+        config.disable_album_art_from_cli = !config.disable_album_art_from_cli;
+        drop(config);
         self.update_photo().ok();
     }
     fn should_not_show_photo(&self) -> bool {
@@ -98,7 +100,7 @@ impl Model {
     #[allow(clippy::cast_possible_truncation)]
     pub fn update_photo(&mut self) -> Result<()> {
         #[cfg(feature = "cover")]
-        if self.config.disable_album_art_from_cli {
+        if self.config.read().disable_album_art_from_cli {
             return Ok(());
         }
         self.clear_photo()?;
@@ -183,7 +185,8 @@ impl Model {
 
     #[allow(clippy::cast_possible_truncation)]
     pub fn show_image(&mut self, img: &DynamicImage) -> Result<()> {
-        match self.config.album_photo_xywh.update_size(img) {
+        let res = self.config.read().album_photo_xywh.update_size(img);
+        match res {
             Err(e) => self.mount_error_popup(e),
             Ok(xywh) => {
                 // error!("{:?}", self.viuer_supported);

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -61,7 +61,7 @@ impl UI {
         // }
     }
     /// Instantiates a new Ui
-    pub async fn new(config: &Settings, client: MusicPlayerClient<Channel>) -> Result<Self> {
+    pub async fn new(config: Settings, client: MusicPlayerClient<Channel>) -> Result<Self> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let mut model = Model::new(config, cmd_tx).await;
         model.init_config();
@@ -137,7 +137,7 @@ impl UI {
         // if let Err(e) = self.model.config.save() {
         //     error!("error when saving config: {e}");
         // };
-        if self.model.config.kill_daemon_when_quit {
+        if self.model.config.read().kill_daemon_when_quit {
             let mut system = System::new();
             system.refresh_all();
             for proc in system.processes().values() {
@@ -266,25 +266,26 @@ impl UI {
                     self.model.force_redraw();
                 }
                 PlayerCmd::SpeedDown => {
-                    self.model.config.player_speed = self.playback.speed_down().await?;
+                    self.model.config.write().player_speed = self.playback.speed_down().await?;
                     self.model.progress_update_title();
                 }
                 PlayerCmd::SpeedUp => {
-                    self.model.config.player_speed = self.playback.speed_up().await?;
+                    self.model.config.write().player_speed = self.playback.speed_up().await?;
                     self.model.progress_update_title();
                 }
                 PlayerCmd::ToggleGapless => {
-                    self.model.config.player_gapless = self.playback.toggle_gapless().await?;
+                    self.model.config.write().player_gapless =
+                        self.playback.toggle_gapless().await?;
                     self.model.progress_update_title();
                 }
                 PlayerCmd::VolumeDown => {
                     let volume = self.playback.volume_down().await?;
-                    self.model.config.player_volume = volume;
+                    self.model.config.write().player_volume = volume;
                     self.model.progress_update_title();
                 }
                 PlayerCmd::VolumeUp => {
                     let volume = self.playback.volume_up().await?;
-                    self.model.config.player_volume = volume;
+                    self.model.config.write().player_volume = volume;
                     self.model.progress_update_title();
                 }
                 _ => {}

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -151,7 +151,10 @@ impl Model {
         let threadpool = Threadpool::new(config.podcast_simultanious_download);
         let (tx_to_main, rx_to_main) = mpsc::channel();
 
-        let playlist = Playlist::new(config).unwrap_or_default();
+        // TODO: refactor this for TUI
+        let config_a_rwl = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+
+        let playlist = Playlist::new(config_a_rwl).unwrap_or_default();
         // This line is required, in order to show the playing message for the first track
         // playlist.set_current_track_index(0);
 

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -44,7 +44,7 @@ use termusiclib::podcast::{db::Database as DBPod, Podcast, PodcastFeed, Threadpo
 use termusiclib::songtag::SongTag;
 use termusiclib::sqlite::TrackForDB;
 use termusiclib::utils::{get_app_config_path, DownloadTracker};
-use termusicplayback::{PlayerCmd, Playlist};
+use termusicplayback::{PlayerCmd, Playlist, SharedSettings};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
@@ -76,7 +76,7 @@ pub struct Model {
     pub terminal: TerminalBridge,
     pub path: PathBuf,
     pub tree: Tree,
-    pub config: Settings,
+    pub config: SharedSettings,
     pub yanked_node_id: Option<String>,
     pub current_song: Option<Track>,
     pub tageditor_song: Option<Track>,
@@ -120,8 +120,8 @@ pub enum ViuerSupported {
 }
 
 impl Model {
-    pub async fn new(config: &Settings, cmd_tx: UnboundedSender<PlayerCmd>) -> Self {
-        let path = Self::get_full_path_from_config(config);
+    pub async fn new(config: Settings, cmd_tx: UnboundedSender<PlayerCmd>) -> Self {
+        let path = Self::get_full_path_from_config(&config);
         let tree = Tree::new(Self::library_dir_tree(&path, config.max_depth_cli));
 
         let (tx3, rx3): (Sender<SearchLyricState>, Receiver<SearchLyricState>) = mpsc::channel();
@@ -132,9 +132,8 @@ impl Model {
         } else if viuer::is_iterm_supported() {
             viuer_supported = ViuerSupported::ITerm;
         }
-        let db = DataBase::new(config);
+        let db = DataBase::new(&config);
         let db_criteria = SearchCriteria::Artist;
-        let app = Self::init_app(&tree, config);
         let terminal = TerminalBridge::new().expect("Could not initialize terminal");
         // let viuer_supported =
         //     viuer::KittySupport::None != viuer::get_kitty_support() || viuer::is_iterm_supported();
@@ -151,10 +150,11 @@ impl Model {
         let threadpool = Threadpool::new(config.podcast_simultanious_download);
         let (tx_to_main, rx_to_main) = mpsc::channel();
 
-        // TODO: refactor this for TUI
-        let config_a_rwl = std::sync::Arc::new(parking_lot::RwLock::new(config.clone()));
+        let config = std::sync::Arc::new(parking_lot::RwLock::new(config));
 
-        let playlist = Playlist::new(config_a_rwl).unwrap_or_default();
+        let playlist = Playlist::new(config.clone()).unwrap_or_default();
+        let app = Self::init_app(&tree, &config);
+
         // This line is required, in order to show the playing message for the first track
         // playlist.set_current_track_index(0);
 
@@ -166,7 +166,7 @@ impl Model {
             tree,
             path,
             terminal,
-            config: config.clone(),
+            config,
             yanked_node_id: None,
             // current_song: None,
             tageditor_song: None,

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -58,7 +58,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::QuitPopupShow => {
-                    if self.config.enable_exit_confirmation {
+                    if self.config.read().enable_exit_confirmation {
                         self.mount_quit_popup();
                     } else {
                         self.quit = true;
@@ -829,7 +829,7 @@ impl Model {
             }
             PLMsg::LoopModeCycle => {
                 self.command(&PlayerCmd::CycleLoop);
-                self.config.player_loop_mode = self.playlist.cycle_loop_mode();
+                self.config.write().player_loop_mode = self.playlist.cycle_loop_mode();
                 self.playlist_update_title();
             }
             PLMsg::PlaylistTableBlurDown => match self.layout {

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -31,11 +31,11 @@ use std::time::{Duration, Instant};
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use termusiclib::config::Settings;
 use termusiclib::types::{DBMsg, Id, IdConfigEditor, IdTagEditor, Msg, PCMsg};
 use termusiclib::utils::{
     draw_area_in_absolute, draw_area_in_relative, draw_area_top_right_absolute, get_parent_folder,
 };
+use termusicplayback::SharedSettings;
 use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{AttrValue, Attribute, Color, PropPayload, PropValue, TextSpan};
@@ -45,7 +45,8 @@ use tuirealm::EventListenerCfg;
 use tuirealm::{Frame, State, StateValue};
 
 impl Model {
-    pub fn init_app(tree: &Tree, config: &Settings) -> Application<Id, Msg, NoUserEvent> {
+    #[allow(clippy::too_many_lines)]
+    pub fn init_app(tree: &Tree, config: &SharedSettings) -> Application<Id, Msg, NoUserEvent> {
         // Setup application
         // NOTE: NoUserEvent is a shorthand to tell tui-realm we're not going to use any custom user event
         // NOTE: the event listener is configured to use the default crossterm input listener and to raise a Tick event each second
@@ -60,7 +61,7 @@ impl Model {
         assert!(app
             .mount(
                 Id::Library,
-                Box::new(MusicLibrary::new(tree, None, config)),
+                Box::new(MusicLibrary::new(tree, None, config.clone())),
                 vec![]
             )
             .is_ok());
@@ -68,7 +69,7 @@ impl Model {
             .mount(
                 Id::DBListCriteria,
                 Box::new(DBListCriteria::new(
-                    config,
+                    config.clone(),
                     Msg::DataBase(DBMsg::CriteriaBlurDown),
                     Msg::DataBase(DBMsg::CriteriaBlurUp)
                 )),
@@ -80,7 +81,7 @@ impl Model {
             .mount(
                 Id::DBListSearchResult,
                 Box::new(DBListSearchResult::new(
-                    config,
+                    config.clone(),
                     Msg::DataBase(DBMsg::SearchResultBlurDown),
                     Msg::DataBase(DBMsg::SearchResultBlurUp)
                 )),
@@ -91,7 +92,7 @@ impl Model {
             .mount(
                 Id::DBListSearchTracks,
                 Box::new(DBListSearchTracks::new(
-                    config,
+                    config.clone(),
                     Msg::DataBase(DBMsg::SearchTracksBlurDown),
                     Msg::DataBase(DBMsg::SearchTracksBlurUp)
                 )),
@@ -99,20 +100,28 @@ impl Model {
             )
             .is_ok());
         assert!(app
-            .mount(Id::Playlist, Box::new(Playlist::new(config)), vec![])
+            .mount(
+                Id::Playlist,
+                Box::new(Playlist::new(config.clone())),
+                vec![]
+            )
             .is_ok());
         assert!(app
-            .mount(Id::Progress, Box::new(Progress::new(config)), vec![])
+            .mount(
+                Id::Progress,
+                Box::new(Progress::new(&config.read())),
+                vec![]
+            )
             .is_ok());
         assert!(app
-            .mount(Id::Lyric, Box::new(Lyric::new(config)), vec![])
+            .mount(Id::Lyric, Box::new(Lyric::new(config.clone())), vec![])
             .is_ok());
 
         assert!(app
             .mount(
                 Id::Podcast,
                 Box::new(FeedsList::new(
-                    config,
+                    config.clone(),
                     Msg::Podcast(PCMsg::PodcastBlurDown),
                     Msg::Podcast(PCMsg::PodcastBlurUp)
                 )),
@@ -124,7 +133,7 @@ impl Model {
             .mount(
                 Id::Episode,
                 Box::new(EpisodeList::new(
-                    config,
+                    config.clone(),
                     Msg::Podcast(PCMsg::EpisodeBlurDown),
                     Msg::Podcast(PCMsg::EpisodeBlurUp)
                 )),
@@ -134,7 +143,7 @@ impl Model {
         assert!(app
             .mount(
                 Id::DownloadSpinner,
-                Box::new(DownloadSpinner::new(config)),
+                Box::new(DownloadSpinner::new(&config.read())),
                 vec![]
             )
             .is_ok());
@@ -143,8 +152,8 @@ impl Model {
         assert!(app
             .mount(
                 Id::GlobalListener,
-                Box::new(GlobalListener::new(&config.keys)),
-                Self::subscribe(&config.keys),
+                Box::new(GlobalListener::new(config.clone())),
+                Self::subscribe(&config.read().keys),
             )
             .is_ok());
         // Active library
@@ -450,7 +459,7 @@ impl Model {
             .app
             .remount(
                 Id::QuitPopup,
-                Box::new(QuitPopup::new(&self.config)),
+                Box::new(QuitPopup::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -462,7 +471,7 @@ impl Model {
             .app
             .remount(
                 Id::HelpPopup,
-                Box::new(HelpPopup::new(&self.config)),
+                Box::new(HelpPopup::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -475,7 +484,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(Source::Library, &self.config)),
+                Box::new(GSInputPopup::new(Source::Library, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -483,7 +492,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(Source::Library, &self.config)),
+                Box::new(GSTablePopup::new(Source::Library, self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -499,7 +508,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(Source::Playlist, &self.config)),
+                Box::new(GSInputPopup::new(Source::Playlist, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -507,7 +516,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(Source::Playlist, &self.config)),
+                Box::new(GSTablePopup::new(Source::Playlist, self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -522,7 +531,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(Source::Database, &self.config)),
+                Box::new(GSInputPopup::new(Source::Database, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -530,7 +539,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(Source::Database, &self.config)),
+                Box::new(GSTablePopup::new(Source::Database, self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -545,7 +554,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(Source::Episode, &self.config)),
+                Box::new(GSInputPopup::new(Source::Episode, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -553,7 +562,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(Source::Episode, &self.config)),
+                Box::new(GSTablePopup::new(Source::Episode, self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -569,7 +578,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(Source::Podcast, &self.config)),
+                Box::new(GSInputPopup::new(Source::Podcast, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -577,7 +586,7 @@ impl Model {
             .app
             .remount(
                 Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(Source::Podcast, &self.config)),
+                Box::new(GSTablePopup::new(Source::Podcast, self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -593,7 +602,7 @@ impl Model {
             .app
             .remount(
                 Id::YoutubeSearchInputPopup,
-                Box::new(YSInputPopup::new(&self.config)),
+                Box::new(YSInputPopup::new(&self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -605,7 +614,7 @@ impl Model {
             .app
             .remount(
                 Id::YoutubeSearchTablePopup,
-                Box::new(YSTablePopup::new(&self.config)),
+                Box::new(YSTablePopup::new(self.config.clone())),
                 vec![]
             )
             .is_ok());
@@ -642,93 +651,82 @@ impl Model {
     }
 
     pub fn mount_label_help(&mut self) {
+        let config = self.config.read();
         self.app
             .remount(
                 Id::Label,
                 Box::new(LabelSpan::new(
-                    &self.config,
+                    &config,
                     &[
                         TextSpan::new(" Version: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         // maybe consider moving version into Help or Config or its own popup (like a About)
                         TextSpan::new(env!("TERMUSIC_VERSION"))
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Help: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_help))
-                            .fg(self
-                                .config
+                        TextSpan::new(format!("<{}>", config.keys.global_help))
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Config: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_config_open))
-                            .fg(self
-                                .config
+                        TextSpan::new(format!("<{}>", config.keys.global_config_open))
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Library: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_layout_treeview))
-                            .fg(self
-                                .config
+                        TextSpan::new(format!("<{}>", config.keys.global_layout_treeview))
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Database: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_layout_database))
-                            .fg(self
-                                .config
+                        TextSpan::new(format!("<{}>", config.keys.global_layout_database))
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Podcasts: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
-                        TextSpan::new(format!("<{}>", self.config.keys.global_layout_podcast))
-                            .fg(self
-                                .config
+                        TextSpan::new(format!("<{}>", config.keys.global_layout_podcast))
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
@@ -758,7 +756,9 @@ impl Model {
             .app
             .remount(
                 Id::SavePlaylistPopup,
-                Box::new(SavePlaylistPopup::new(&self.config.style_color_symbol)),
+                Box::new(SavePlaylistPopup::new(
+                    &self.config.read().style_color_symbol
+                )),
                 vec![]
             )
             .is_ok());
@@ -784,30 +784,29 @@ impl Model {
         let mut path_string = get_parent_folder(&current_node);
         path_string.push('/');
 
+        let config = self.config.read();
+
         self.app
             .remount(
                 Id::SavePlaylistLabel,
                 Box::new(LabelSpan::new(
-                    &self.config,
+                    &config,
                     &[
                         TextSpan::new("Full name: ")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(path_string)
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Red))
                             .bold(),
                         TextSpan::new(filename).fg(Color::Cyan).bold(),
                         TextSpan::new(".m3u")
-                            .fg(self
-                                .config
+                            .fg(config
                                 .style_color_symbol
                                 .library_foreground()
                                 .unwrap_or(Color::Cyan))
@@ -825,7 +824,7 @@ impl Model {
             .app
             .remount(
                 Id::SavePlaylistConfirm,
-                Box::new(SavePlaylistConfirm::new(&self.config, filename)),
+                Box::new(SavePlaylistConfirm::new(self.config.clone(), filename)),
                 vec![]
             )
             .is_ok());
@@ -843,7 +842,7 @@ impl Model {
             .app
             .remount(
                 Id::PodcastAddPopup,
-                Box::new(PodcastAddPopup::new(&self.config.style_color_symbol)),
+                Box::new(PodcastAddPopup::new(&self.config.read().style_color_symbol)),
                 vec![]
             )
             .is_ok());
@@ -864,16 +863,17 @@ impl Model {
         background: Option<Color>,
         timeout: Option<isize>,
     ) {
+        let config = self.config.read();
         let textspan = &[TextSpan::new(active_msg)
             .fg(foreground.unwrap_or_else(|| {
-                self.config
+                config
                     .style_color_symbol
                     .library_highlight()
                     .unwrap_or(Color::Cyan)
             }))
             .bold()
             .bg(background.unwrap_or_else(|| {
-                self.config
+                config
                     .style_color_symbol
                     .library_background()
                     .unwrap_or(Color::Reset)


### PR DESCRIPTION
This PR refactors all code handling `Settings` which previously cloned everything, now there is only ever 1 instance active in each binary (except while in the tui config editor), in more details:
- refactor all handling of `Settings` to not clone the whole instances anymore and use shared access
- update `playback::PlayerTrait`'s `volume*` and `speed*` function to always return the new value
- `tui::ui::components::tag_editor::te_input` & `tui::ui::components::config_editor::general` refactor to be easier handle-able (and remove some duplicate code)

for whats it worth, some stats:

Memory changes (i dont know if i collected it correctly, collected from the debug builds):
(master(008aae4e8dff7e451281ac164e9f0b1dc06c371e) -> PR(7993fa63c9b2defd9b47e23449c5d7d76a2cf8d5))
`termusic-server` VSZ `2191644 KB` -> `2191632 KB` [`-12 KB`]
`termusic-server` RSS `85056 KB` -> `86200 KB` [`+1144 KB`]
`termusic` VSZ `2768932 KB` -> `2768656 KB` [`-276 KB`]
`termusic` RSS `71692 KB` -> `71412 KB` [`-280 KB`]

Binary size:
debug `termusic-server` `292697872 Bytes` -> `292756224 Bytes` [`+58352 Bytes` (~57KB)]
release `termusic-server` `23586664 Bytes`  -> `23556736 Bytes` [`-29928 Bytes` (~29KB)]
debug `termusic` `312275448 Bytes` -> `312431664 Bytes` [`+156216 KB`(~153KB)]
release `termusic` `30627376 Bytes` -> `30579824 Bytes` [`-47552 KB`(~46KB)]

even if the sizes are not much different (even getting bigger in debug), this way we wont have stale data or duplicate data in memory

re #214