### PR TITLE
Log to file by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,45 @@
+---
+name: Bug
+about: Create a bug report
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
+-->
+
+## Environment & Versions
+
+<!--Please confirm you are running the latest versions-->
+
+- System: <!--linux / macos / windows--> <!--Also include system version, and if on linux the distro-->
+- Termusic version: <!--termusic --version-->
+<!--If custom compile-->
+- Rust version:
+
+Logs:
+
+<!--
+Logs can be found by default in your temporary directory; in linux its /tmp/termusic-{tui,server}.log
+Log location can also be manually set via TM_LOGFILE=/path/to/tui.log or TMS_LOGFILE=/path/to/server.log
+And Log-level can be set via RUST_LOG, see the following for all levels: https://docs.rs/flexi_logger/latest/flexi_logger/enum.Level.html
+-->
+
+<!--When only doing a small section of the logs, please use a code-block inside "details"(or also known as spoiler)-->
+<!--
+<details>
+<summary>Logs</summary>
+
+```txt
+```
+
+</details>
+-->
+
+<!--Otherwise please upload the log file-->
+
+## Description of the Problem
+
+<!--Please add an description of what the problem is-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Have a question?
+    url: https://github.com/tramhao/termusic/discussions/new
+    about: We use Discussions for questions

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,19 @@
+---
+name: Feature
+about: Request a feature
+title: ''
+labels: feature
+assignees: ''
+---
+
+<!--
+Make sure you read [Mastering-Markdown](https://guides.github.com/features/mastering-markdown/)
+-->
+
+## Describe what you want
+
+<!--Add a description of the feature here-->
+
+## Do you have already an idea for the implementation?
+
+<!--If you have a idea of how to implement it, please provide it here-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog
 
+### next
+- Unreleased
+- Change: enable `log-to-file` by default.
+
 ### [v0.9.0]
 - Released on: March 24, 2024.
 - Big thanks to the contribution of hasezoey. A lot of improvements and refactors in this release. Especially now you can change backends without recompile.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 /**
  * MIT License
  *
@@ -23,7 +21,8 @@ use std::path::PathBuf;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
 use termusicplayback::BackendSelect;
 
 #[derive(Parser, Debug)]
@@ -126,7 +125,11 @@ pub struct LogOptions {
     /// automatically enabled if "log-file" is manually set
     #[arg(
         long = "log-to-file",
-        default_value_if("log_file", ArgPredicate::IsPresent, "true")
+        // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
+        default_value_if("log_file", ArgPredicate::IsPresent, "true"),
+        default_value_t = true,
+        // explicit arg action is required, otherwise it will not take any arguments like "=false" to disable file logging
+        action = ArgAction::Set
     )]
     pub log_to_file: bool,
 

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 /**
  * MIT License
  *
@@ -23,7 +21,8 @@ use std::path::PathBuf;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 // mostly read from `Cargo.toml`
@@ -105,7 +104,11 @@ pub struct LogOptions {
     /// automatically enabled if "log-file" is manually set
     #[arg(
         long = "log-to-file",
-        default_value_if("log_file", ArgPredicate::IsPresent, "true")
+        // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
+        default_value_if("log_file", ArgPredicate::IsPresent, "true"),
+        default_value_t = true,
+        // explicit arg action is required, otherwise it will not take any arguments like "=false" to disable file logging
+        action = ArgAction::Set
     )]
     pub log_to_file: bool,
 


### PR DESCRIPTION
This PR does:
- change `log-to-file` to default to `true`
- change `log-to-file` to be set-able (`=false` to disable)
- add issue templates