### PR TITLE
disable `log-to-file` again for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### next
 - Unreleased
-- Change: enable `log-to-file` by default.
 
 ### [v0.9.0]
 - Released on: March 24, 2024.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 use termusicplayback::BackendSelect;
 
@@ -127,9 +127,12 @@ pub struct LogOptions {
         long = "log-to-file",
         // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
         default_value_if("log_file", ArgPredicate::IsPresent, "true"),
-        default_value_t = true,
-        // explicit arg action is required, otherwise it will not take any arguments like "=false" to disable file logging
-        action = ArgAction::Set
+        // disabled, see https://github.com/clap-rs/clap/issues/5421
+        // default_value_t = true,
+        // // somehow clap has this option not properly supported in derive, so it needs to be a string
+        // default_missing_value = "true",
+        // num_args = 0..=1,
+        // require_equals = true,
     )]
     pub log_to_file: bool,
 

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -106,9 +106,12 @@ pub struct LogOptions {
         long = "log-to-file",
         // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
         default_value_if("log_file", ArgPredicate::IsPresent, "true"),
-        default_value_t = true,
-        // explicit arg action is required, otherwise it will not take any arguments like "=false" to disable file logging
-        action = ArgAction::Set
+        // disabled, see https://github.com/clap-rs/clap/issues/5421
+        // default_value_t = true,
+        // // somehow clap has this option not properly supported in derive, so it needs to be a string
+        // default_missing_value = "true",
+        // num_args = 0..=1,
+        // require_equals = true,
     )]
     pub log_to_file: bool,
 


### PR DESCRIPTION
This PR basically reverts functional changes from #264 again, because of https://github.com/clap-rs/clap/issues/5421