### PR TITLE
Fix server / playback feature Backend problems

### DIFF
--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -58,7 +58,7 @@ features = [
 
 [features]
 # NOTE: do NOT enable any backends here, enable them in crate "server"!
-# otherwise you will get compile errors in server about not handling branches
+# otherwise you will not be able to start that backend
 default = []
 # cover = []
 gst = ["dep:gstreamer", "dep:glib"]

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -183,6 +183,9 @@ impl GStreamerBackend {
                         main_tx.send_blocking(PlayerCmd::Eos)
                             .expect("Unable to send message to main()");
                         eos_watcher.store(true, std::sync::atomic::Ordering::SeqCst);
+
+                        // clear stored title on end
+                        media_title_internal.lock().clear();
                     },
                     gst::MessageView::StreamStart(_e) => {
                         if !eos_watcher.load(std::sync::atomic::Ordering::SeqCst) {
@@ -192,6 +195,9 @@ impl GStreamerBackend {
                         }
 
                         eos_watcher.store(false, std::sync::atomic::Ordering::SeqCst);
+
+                        // clear stored title on stream start (should work without conflicting in ::Tag)
+                        media_title_internal.lock().clear();
                     }
                     gst::MessageView::Error(e) =>
                         error!("GStreamer Error: {}", e.error()),

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -204,7 +204,7 @@ impl GStreamerBackend {
                     gst::MessageView::Tag(tag) => {
                         if let Some(title) = tag.tags().get::<gst::tags::Title>() {
                             info!("  Title: {}", title.get());
-                            *media_title_internal.lock() = format!("Current Playing: {}",title.get()).to_string();
+                            *media_title_internal.lock() = title.get().into();
                         }
                         // if let Some(artist) = tag.tags().get::<gst::tags::Artist>() {
                         //     info!("  Artist: {}", artist.get());

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
-use crate::{Speed, Volume};
+use crate::{MediaInfo, Speed, Volume};
 use anyhow::Result;
 use async_trait::async_trait;
 use glib::FlagsClass;
@@ -61,7 +61,7 @@ pub struct GStreamerBackend {
     speed: i32,
     gapless: bool,
     message_tx: async_channel::Sender<PlayerCmd>,
-    pub radio_title: Arc<Mutex<String>>,
+    radio_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }
 
@@ -480,6 +480,17 @@ impl PlayerTrait for GStreamerBackend {
 
     fn enqueue_next(&mut self, track: &Track) {
         set_uri_from_track(&self.playbin, track);
+    }
+
+    fn media_info(&self) -> MediaInfo {
+        let radio_title_r = self.radio_title.lock();
+        if radio_title_r.is_empty() {
+            MediaInfo::default()
+        } else {
+            MediaInfo {
+                media_title: Some(radio_title_r.clone()),
+            }
+        }
     }
 }
 

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -61,7 +61,7 @@ pub struct GStreamerBackend {
     speed: i32,
     gapless: bool,
     message_tx: async_channel::Sender<PlayerCmd>,
-    radio_title: Arc<Mutex<String>>,
+    media_title: Arc<Mutex<String>>,
     _bus_watch_guard: BusWatchGuard,
 }
 
@@ -170,8 +170,8 @@ impl GStreamerBackend {
 
         // Handle messages from GStreamer bus
 
-        let radio_title = Arc::new(Mutex::new(String::new()));
-        let radio_title_internal = radio_title.clone();
+        let media_title = Arc::new(Mutex::new(String::new()));
+        let media_title_internal = media_title.clone();
         let bus_watch = playbin
             .bus()
             .expect("Failed to get GStreamer message bus")
@@ -198,15 +198,15 @@ impl GStreamerBackend {
                     gst::MessageView::Tag(tag) => {
                         if let Some(title) = tag.tags().get::<gst::tags::Title>() {
                             info!("  Title: {}", title.get());
-                            *radio_title_internal.lock() = format!("Current Playing: {}",title.get()).to_string();
+                            *media_title_internal.lock() = format!("Current Playing: {}",title.get()).to_string();
                         }
                         // if let Some(artist) = tag.tags().get::<gst::tags::Artist>() {
                         //     info!("  Artist: {}", artist.get());
-                        //     // *radio_title_internal.lock() = artist.get().to_string();
+                        //     // *media_title_internal.lock() = artist.get().to_string();
                         // }
                         // if let Some(album) = tag.tags().get::<gst::tags::Album>() {
                         //     info!("  Album: {}", album.get());
-                        //     // *radio_title_internal.lock() = album.get().to_string();
+                        //     // *media_title_internal.lock() = album.get().to_string();
                         // }
                     }
                     gst::MessageView::Buffering(buffering) => {
@@ -253,7 +253,7 @@ impl GStreamerBackend {
             speed,
             gapless,
             message_tx,
-            radio_title,
+            media_title,
             _bus_watch_guard: bus_watch,
         };
 
@@ -483,12 +483,12 @@ impl PlayerTrait for GStreamerBackend {
     }
 
     fn media_info(&self) -> MediaInfo {
-        let radio_title_r = self.radio_title.lock();
-        if radio_title_r.is_empty() {
+        let media_title_r = self.media_title.lock();
+        if media_title_r.is_empty() {
             MediaInfo::default()
         } else {
             MediaInfo {
-                media_title: Some(radio_title_r.clone()),
+                media_title: Some(media_title_r.clone()),
             }
         }
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -97,6 +97,7 @@ pub enum BackendSelect {
 }
 
 /// Enum to choose backend at runtime
+#[non_exhaustive]
 pub enum Backend {
     #[cfg(feature = "mpv")]
     Mpv(mpv_backend::MpvBackend),

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -646,6 +646,10 @@ impl PlayerTrait for GeneralPlayer {
     fn enqueue_next(&mut self, track: &Track) {
         self.get_player_mut().enqueue_next(track);
     }
+
+    fn media_info(&self) -> MediaInfo {
+        self.get_player().media_info()
+    }
 }
 
 /// The primitive in which time (current position / total duration) will be stored as
@@ -675,6 +679,15 @@ impl From<PlayerProgress> for crate::player::PlayerTime {
             total_duration: value.total_duration.map(std::convert::Into::into),
         }
     }
+}
+
+/// Some information that may be available from the backend
+/// This is different from [`Track`] as this is everything parsed from the decoder's metadata
+/// and [`Track`] stores some different extra stuff
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct MediaInfo {
+    /// The title of the current media playing (if present)
+    pub media_title: Option<String>,
 }
 
 pub type Volume = u16;
@@ -739,4 +752,6 @@ pub trait PlayerTrait {
     }
     /// Add the given URI to be played, but do not skip currently playing track
     fn enqueue_next(&mut self, track: &Track);
+    /// Get info of the current media
+    fn media_info(&self) -> MediaInfo;
 }

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -124,6 +124,9 @@ impl MpvBackend {
                                 if e == 0 {
                                     cmd_tx_inside.send(PlayerInternalCmd::Eos).ok();
                                 }
+
+                                // clear stored title on end
+                                media_title_inside.lock().clear();
                             }
                             Ok(Event::StartFile) => {
                                 // message_tx.send(PlayerMsg::CurrentTrackUpdated).ok();

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 use super::{PlayerCmd, PlayerProgress, PlayerTrait};
-use crate::{Speed, Volume};
+use crate::{MediaInfo, Speed, Volume};
 use anyhow::Result;
 use async_trait::async_trait;
 use libmpv::Mpv;
@@ -49,7 +49,7 @@ pub struct MpvBackend {
     position: Arc<Mutex<Duration>>,
     // TODO: this should likely be a Option
     duration: Arc<Mutex<Duration>>,
-    pub media_title: Arc<Mutex<String>>,
+    media_title: Arc<Mutex<String>>,
     // cmd_tx: crate::PlayerCmdSender,
 }
 
@@ -389,5 +389,16 @@ impl PlayerTrait for MpvBackend {
         self.command_tx
             .send(PlayerInternalCmd::QueueNext(file.to_string()))
             .expect("failed to queue next");
+    }
+
+    fn media_info(&self) -> MediaInfo {
+        let media_title_r = self.media_title.lock();
+        if media_title_r.is_empty() {
+            MediaInfo::default()
+        } else {
+            MediaInfo {
+                media_title: Some(media_title_r.clone()),
+            }
+        }
     }
 }

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -23,7 +23,7 @@ use std::num::{NonZeroU16, NonZeroUsize};
 pub use stream::OutputStream;
 use tokio::runtime::Handle;
 
-use crate::{Speed, Volume};
+use crate::{MediaInfo, Speed, Volume};
 
 use self::decoder::buffered_source::BufferedSource;
 use self::decoder::read_seek_source::ReadSeekSource;
@@ -84,7 +84,7 @@ pub struct RustyBackend {
     command_tx: Sender<PlayerInternalCmd>,
     position: Arc<Mutex<Duration>>,
     total_duration: ArcTotalDuration,
-    pub radio_title: Arc<Mutex<String>>,
+    radio_title: Arc<Mutex<String>>,
     pub radio_downloaded: Arc<Mutex<u64>>,
     // cmd_tx_outside: crate::PlayerCmdSender,
 }
@@ -277,6 +277,17 @@ impl PlayerTrait for RustyBackend {
             Box::new(track.clone()),
             self.gapless,
         ));
+    }
+
+    fn media_info(&self) -> MediaInfo {
+        let radio_title_r = self.radio_title.lock();
+        if radio_title_r.is_empty() {
+            MediaInfo::default()
+        } else {
+            MediaInfo {
+                media_title: Some(radio_title_r.clone()),
+            }
+        }
     }
 }
 

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -698,7 +698,7 @@ async fn queue_next(
                 let new_title = if title.is_empty() {
                     "<no title>".to_string()
                 } else {
-                    format!("Current playing: {title}")
+                    title.to_string()
                 };
 
                 *radio_title_clone.lock() = new_title;

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -296,14 +296,14 @@ impl Model {
         }
     }
 
-    pub fn lyric_update_for_radio<T: Into<String>>(&mut self, radio_title: T) {
+    pub fn lyric_update_for_radio<T: AsRef<str>>(&mut self, radio_title: T) {
         if let Some(song) = self.playlist.current_track() {
             if MediaType::LiveRadio == song.media_type {
-                let radio_title = radio_title.into();
+                let radio_title = radio_title.as_ref();
                 if radio_title.is_empty() {
                     return;
                 }
-                self.lyric_set_lyric(radio_title);
+                self.lyric_set_lyric(format!("Currently Playing: {radio_title}"));
             }
         }
     }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -302,9 +302,6 @@ impl Model {
                 if radio_title.is_empty() {
                     return;
                 }
-                if self.lyric_line == radio_title {
-                    return;
-                }
                 self.lyric_set_lyric(&radio_title);
             }
         }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -299,14 +299,13 @@ impl Model {
     pub fn lyric_update_for_radio(&mut self, radio_title: &str) {
         if let Some(song) = self.playlist.current_track() {
             if MediaType::LiveRadio == song.media_type {
-                let line = radio_title.to_string();
-                if line.is_empty() {
+                if radio_title.is_empty() {
                     return;
                 }
-                if self.lyric_line == line {
+                if self.lyric_line == radio_title {
                     return;
                 }
-                self.lyric_set_lyric(&line);
+                self.lyric_set_lyric(&radio_title);
             }
         }
     }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -296,18 +296,20 @@ impl Model {
         }
     }
 
-    pub fn lyric_update_for_radio(&mut self, radio_title: &str) {
+    pub fn lyric_update_for_radio<T: Into<String>>(&mut self, radio_title: T) {
         if let Some(song) = self.playlist.current_track() {
             if MediaType::LiveRadio == song.media_type {
+                let radio_title = radio_title.into();
                 if radio_title.is_empty() {
                     return;
                 }
-                self.lyric_set_lyric(&radio_title);
+                self.lyric_set_lyric(radio_title);
             }
         }
     }
 
-    fn lyric_set_lyric(&mut self, text: &str) {
+    fn lyric_set_lyric<T: Into<String>>(&mut self, text: T) {
+        let text = text.into();
         if self.lyric_line == *text {
             return;
         }
@@ -316,11 +318,11 @@ impl Model {
                 &Id::Lyric,
                 Attribute::Text,
                 AttrValue::Payload(PropPayload::Vec(vec![PropValue::TextSpan(TextSpan::from(
-                    text,
+                    &text,
                 ))])),
             )
             .ok();
-        self.lyric_line = text.to_string();
+        self.lyric_line = text;
     }
 
     pub fn lyric_cycle(&mut self) {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -234,7 +234,7 @@ impl UI {
                         self.handle_current_track_index(response.current_track_index as usize);
                     }
 
-                    self.model.lyric_update_for_radio(&response.radio_title);
+                    self.model.lyric_update_for_radio(response.radio_title);
 
                     self.handle_status(Status::from_u32(response.status));
                 }


### PR DESCRIPTION
This PR addresses the issues mentioned in #259 regarding the Backend features. Now server can be compiled with less or same features as playback. Some more details:
- Add new `PlayerTrait` function `media_info` to get the current media's title (works on mpv and gst for both radio and normal music, in rusty for now only in radio)
- mark the `Backend` enum as `non_exhaustive`, meaning any case where a `match` against a backend is done, now it needs to be handled if a backend has not been accounted for in the downstream crate
- gst & mpv: clear media_title in-between source changes
- move applying the prefix `Current Playing: ` from backend-specific to TUI where used (fixes mpv not having the prefix)
- tui lyric: avoid some clones / allocations if possible

note the new `playback::MediaInfo` struct and method `playback::PlayerTrait::media_info` has been designed so that we can add new fields without having to add a new function every time (for example if we should start parsing & storing the artist metadata or other metadata from the backend / decoder).

also note that the compile error for no backend being compiled-in (in playback) has *not* been removed.