### PR TITLE
Some rusty backend refactors

### DIFF
--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -189,7 +189,6 @@ impl Source for Symphonia {
     }
 
     #[inline]
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn seek(&mut self, time: Duration) -> Option<Duration> {
         match self.format.seek(
             SeekMode::Coarse,

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -111,7 +111,7 @@ impl Symphonia {
             }
         };
         let spec = *decode_result.spec();
-        let buffer = Self::get_buffer(decode_result, spec);
+        let buffer = Self::get_buffer(decode_result);
 
         Ok(Some(Self {
             decoder,
@@ -136,9 +136,9 @@ impl Symphonia {
     }
 
     #[inline]
-    fn get_buffer(decoded: AudioBufferRef<'_>, spec: SignalSpec) -> SampleBuffer<i16> {
+    fn get_buffer(decoded: AudioBufferRef<'_>) -> SampleBuffer<i16> {
         let duration = decoded.capacity() as u64;
-        let mut buffer = SampleBuffer::<i16>::new(duration, spec);
+        let mut buffer = SampleBuffer::<i16>::new(duration, *decoded.spec());
         buffer.copy_interleaved_ref(decoded);
         buffer
     }
@@ -221,7 +221,7 @@ impl Iterator for Symphonia {
                 }
             };
             self.spec = *decoded.spec();
-            self.buffer = Self::get_buffer(decoded, self.spec);
+            self.buffer = Self::get_buffer(decoded);
             self.current_frame_offset = 0;
         }
 

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -88,15 +88,15 @@ pub struct Symphonia {
 }
 
 impl Symphonia {
-    // /// Create a new instance, which also returns a [`MediaTitleRx`]
-    // #[inline]
-    // pub fn new_with_media_title(
-    //     mss: MediaSourceStream,
-    //     gapless: bool,
-    // ) -> Result<(Self, MediaTitleRx), SymphoniaDecoderError> {
-    //     // guaranteed if "media_title" is set to "true"
-    //     Self::common_new(mss, gapless, true).map(|v| (v.0, v.1.unwrap()))
-    // }
+    /// Create a new instance, which also returns a [`MediaTitleRx`]
+    #[inline]
+    pub fn new_with_media_title(
+        mss: MediaSourceStream,
+        gapless: bool,
+    ) -> Result<(Self, MediaTitleRx), SymphoniaDecoderError> {
+        // guaranteed if "media_title" is set to "true"
+        Self::common_new(mss, gapless, true).map(|v| (v.0, v.1.unwrap()))
+    }
 
     /// Create a new instance, without a [`MediaTitleRx`]
     #[inline]

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -195,7 +195,7 @@ impl Source for Symphonia {
             SeekMode::Coarse,
             SeekTo::Time {
                 time: time.into(),
-                track_id: None,
+                track_id: Some(self.track_id),
             },
         ) {
             Ok(seeked_to) => {

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -198,12 +198,10 @@ impl Source for Symphonia {
                 track_id: Some(self.track_id),
             },
         ) {
-            Ok(seeked_to) => {
-                let base = TimeBase::new(1, self.sample_rate());
-                let time = base.calc_time(seeked_to.actual_ts);
-
-                Some(time.into())
-            }
+            Ok(seeked_to) => self
+                .time_base
+                .as_ref()
+                .map(|v| v.calc_time(seeked_to.actual_ts).into()),
             Err(_) => None,
         }
     }

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -2,7 +2,6 @@ pub mod buffered_source;
 pub mod read_seek_source;
 
 use super::Source;
-// pub use read_seek_source::ReadSeekSource;
 use std::{fmt, time::Duration};
 use symphonia::{
     core::{

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -85,7 +85,7 @@ pub struct RustyBackend {
     command_tx: Sender<PlayerInternalCmd>,
     position: Arc<Mutex<Duration>>,
     total_duration: ArcTotalDuration,
-    radio_title: Arc<Mutex<String>>,
+    media_title: Arc<Mutex<String>>,
     pub radio_downloaded: Arc<Mutex<u64>>,
     // cmd_tx_outside: crate::PlayerCmdSender,
 }
@@ -111,8 +111,8 @@ impl RustyBackend {
         let total_duration_local = total_duration.clone();
         let position_local = position.clone();
         let pcmd_tx_local = cmd_tx;
-        let radio_title = Arc::new(Mutex::new(String::new()));
-        let radio_title_local = radio_title.clone();
+        let media_title = Arc::new(Mutex::new(String::new()));
+        let media_title_local = media_title.clone();
         let radio_downloaded = Arc::new(Mutex::new(100_u64));
         // let radio_downloaded_local = radio_downloaded.clone();
         // this should likely be a parameter, but works for now
@@ -126,7 +126,7 @@ impl RustyBackend {
                     pcmd_tx_local,
                     picmd_tx_local,
                     picmd_rx,
-                    radio_title_local,
+                    media_title_local,
                     // radio_downloaded_local,
                     position_local,
                     volume_local,
@@ -142,7 +142,7 @@ impl RustyBackend {
             gapless,
             command_tx: picmd_tx,
             position,
-            radio_title,
+            media_title,
             radio_downloaded,
             // cmd_tx_outside: cmd_tx,
         }
@@ -281,12 +281,12 @@ impl PlayerTrait for RustyBackend {
     }
 
     fn media_info(&self) -> MediaInfo {
-        let radio_title_r = self.radio_title.lock();
-        if radio_title_r.is_empty() {
+        let media_title_r = self.media_title.lock();
+        if media_title_r.is_empty() {
             MediaInfo::default()
         } else {
             MediaInfo {
-                media_title: Some(radio_title_r.clone()),
+                media_title: Some(media_title_r.clone()),
             }
         }
     }
@@ -451,7 +451,7 @@ async fn player_thread(
     pcmd_tx: crate::PlayerCmdSender,
     picmd_tx: Sender<PlayerInternalCmd>,
     picmd_rx: Receiver<PlayerInternalCmd>,
-    radio_title: Arc<Mutex<String>>,
+    media_title: Arc<Mutex<String>>,
     // radio_downloaded: Arc<Mutex<u64>>,
     position: Arc<Mutex<Duration>>,
     volume_inside: Arc<AtomicU16>,
@@ -482,7 +482,7 @@ async fn player_thread(
                     &mut is_radio,
                     &total_duration,
                     &mut next_duration_opt,
-                    &radio_title,
+                    &media_title,
                     // &radio_downloaded,
                     false,
                 )
@@ -502,7 +502,7 @@ async fn player_thread(
                     &mut is_radio,
                     &total_duration,
                     &mut next_duration_opt,
-                    &radio_title,
+                    &media_title,
                     // &radio_downloaded,
                     true,
                 )
@@ -606,7 +606,7 @@ async fn queue_next(
     is_radio: &mut bool,
     total_duration: &ArcTotalDuration,
     next_duration_opt: &mut Option<Duration>,
-    radio_title: &Arc<Mutex<String>>,
+    media_title: &Arc<Mutex<String>>,
     // _radio_downloaded: &Arc<Mutex<u64>>,
     enqueue: bool,
 ) -> Result<()> {
@@ -627,7 +627,7 @@ async fn queue_next(
                     sink,
                     gapless,
                     next_duration_opt,
-                    common_media_title_cb(radio_title.clone()),
+                    common_media_title_cb(media_title.clone()),
                 );
             } else {
                 append_to_sink(
@@ -636,7 +636,7 @@ async fn queue_next(
                     sink,
                     gapless,
                     total_duration,
-                    common_media_title_cb(radio_title.clone()),
+                    common_media_title_cb(media_title.clone()),
                 );
             }
 
@@ -656,7 +656,7 @@ async fn queue_next(
                         sink,
                         gapless,
                         next_duration_opt,
-                        common_media_title_cb(radio_title.clone()),
+                        common_media_title_cb(media_title.clone()),
                     );
                 } else {
                     append_to_sink(
@@ -665,7 +665,7 @@ async fn queue_next(
                         sink,
                         gapless,
                         total_duration,
-                        common_media_title_cb(radio_title.clone()),
+                        common_media_title_cb(media_title.clone()),
                     );
                 }
 
@@ -708,7 +708,7 @@ async fn queue_next(
                     sink,
                     gapless,
                     next_duration_opt,
-                    common_media_title_cb(radio_title.clone()),
+                    common_media_title_cb(media_title.clone()),
                 );
             } else {
                 append_to_sink(
@@ -717,7 +717,7 @@ async fn queue_next(
                     sink,
                     gapless,
                     total_duration,
-                    common_media_title_cb(radio_title.clone()),
+                    common_media_title_cb(media_title.clone()),
                 );
             }
 
@@ -759,7 +759,7 @@ async fn queue_next(
             // // Modify this to what the actual headers said
             // let meta_interval = 8192;
 
-            let radio_title_clone = radio_title.clone();
+            let media_title_clone = media_title.clone();
 
             let cb = move |title: &str| {
                 let new_title = if title.is_empty() {
@@ -768,7 +768,7 @@ async fn queue_next(
                     title.to_string()
                 };
 
-                *radio_title_clone.lock() = new_title;
+                *media_title_clone.lock() = new_title;
             };
 
             // set initial title to what the header says


### PR DESCRIPTION
This PR refactors some things for the rusty backend to bring it in-line with other backends, in more details:
- deduplicate the decoder loops (to not accidentally forget to change something in the other loop)
- avoid sample buffer allocations if possible
- parse title metadata for non-liveradio media, as the other backends already did it*1
- various small tweaks

*1 the metadata refactor should also make it easier to add new tags to be parsed