### PR TITLE
feat(cli): enable "log-to-file" by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 - Unreleased
+- Change: enable `log-to-file` by default.
+- Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
 
 ### [v0.9.0]
 - Released on: March 24, 2024.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 use termusicplayback::BackendSelect;
 
@@ -125,14 +125,15 @@ pub struct LogOptions {
     /// automatically enabled if "log-file" is manually set
     #[arg(
         long = "log-to-file",
+        env = "TMS_LOGTOFILE",
         // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
         default_value_if("log_file", ArgPredicate::IsPresent, "true"),
-        // disabled, see https://github.com/clap-rs/clap/issues/5421
-        // default_value_t = true,
-        // // somehow clap has this option not properly supported in derive, so it needs to be a string
-        // default_missing_value = "true",
-        // num_args = 0..=1,
-        // require_equals = true,
+        action = ArgAction::Set,
+        default_value_t = true,
+        // somehow clap has this option not properly supported in derive, so it needs to be a string
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
     )]
     pub log_to_file: bool,
 

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use clap::{builder::ArgPredicate, Parser, Subcommand, ValueEnum};
+use clap::{builder::ArgPredicate, ArgAction, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -104,14 +104,15 @@ pub struct LogOptions {
     /// automatically enabled if "log-file" is manually set
     #[arg(
         long = "log-to-file",
+        env = "TM_LOGTOFILE",
         // automatically enable "log-to-file" if "log-file" is set, unless explicitly told not to
         default_value_if("log_file", ArgPredicate::IsPresent, "true"),
-        // disabled, see https://github.com/clap-rs/clap/issues/5421
-        // default_value_t = true,
-        // // somehow clap has this option not properly supported in derive, so it needs to be a string
-        // default_missing_value = "true",
-        // num_args = 0..=1,
-        // require_equals = true,
+        action = ArgAction::Set,
+        default_value_t = true,
+        // somehow clap has this option not properly supported in derive, so it needs to be a string
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
     )]
     pub log_to_file: bool,
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -102,9 +102,13 @@ async fn actual_main() -> Result<()> {
     if launch_daemon {
         let mut server_args = vec![];
 
-        if args.log_options.log_to_file {
-            server_args.push("--log-to-file");
-        }
+        // dont clone over "log-to-file", because default is "true" now, and otherwise can be controlled via TMS_LOGTOFILE or TMS_LOGFILE
+        // server_args.push("--log-to-file");
+        // if args.log_options.log_to_file {
+        //     server_args.push("true");
+        // } else {
+        //     server_args.push("false");
+        // }
 
         if args.log_options.file_color_log {
             server_args.push("--log-filecolor");


### PR DESCRIPTION
This time for real, tested were:
- no argument -> true
- `--log-to-file` -> true
- `--log-to-file=false` -> false
- `--log-to-file=true` -> true
- `--log-to-file=false --log-file /dev/null` -> false

also:
- add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` from a environment variable (cli argument takes precedence)
- dont give the `--log-to-file` argument to the server from the tui (to still have the server log even if the tui does not, use `TMS_LOGTOFILE=false` instead)