### PR TITLE
Use more async reqwest instead of blocking

### DIFF
--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -437,10 +437,10 @@ impl Model {
                             .ok();
                         }
                     },
-                    _ => {
-                        tx.send(Msg::Podcast(PCMsg::SearchError(
-                            "Error result status code".to_string(),
-                        )))
+                    code => {
+                        tx.send(Msg::Podcast(PCMsg::SearchError(format!(
+                            "Error result status code: {code}"
+                        ))))
                         .ok();
                     }
                 },


### PR DESCRIPTION
This PR refactors some places in the tui where `reqwest::blocking` was used to use the async versions instead.
In addition to that, some slight other changes:
- in `podcast_search_itunes` report the status code on non-OK status
- in `xywh` also check the status code
- in `xywh` send a error if `result.bytes()` fails instead of ignoring

fixes #209 