### PR TITLE
fix(tui): ensure the QuitPopup has the top-most focus

### DIFF
--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -126,6 +126,9 @@ impl UI {
                 }
                 _ => {}
             }
+
+            self.model.ensure_quit_popup_top_most_focus();
+
             // Check whether to force redraw
             self.check_force_redraw();
             self.model.view();

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -179,6 +179,15 @@ impl Update<Msg> for Model {
 }
 
 impl Model {
+    /// Ensure the [`QuitPopup`](crate::ui::components::QuitPopup) always has the focus (top-most)
+    pub fn ensure_quit_popup_top_most_focus(&mut self) {
+        if self.app.mounted(&Id::QuitPopup)
+            && !self.app.focus().is_some_and(|v| *v == Id::QuitPopup)
+        {
+            self.app.active(&Id::QuitPopup).ok();
+        }
+    }
+
     fn update_xywh_msg(&mut self, msg: &XYWHMsg) -> Option<Msg> {
         match msg {
             XYWHMsg::MoveLeft => self.xywh_move_left(),


### PR DESCRIPTION
for example after showing the popup, but then switching to podcast view.

fixes #248