### PR TITLE
GStreamer fix initial speed not being applied

### DIFF
--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -315,9 +315,12 @@ impl GStreamerBackend {
 
         // If we have not done so, obtain the sink through which we will send the seek events
         if let Some(sink) = self.playbin.property::<Option<Element>>("audio-sink") {
-            // try_property::<Option<Element>>("audio-sink") {
             // Send the event
-            sink.send_event(seek_event)
+            let send_event = sink.send_event(seek_event);
+            if !send_event {
+                warn!("Speed event was *NOT* handled!");
+            }
+            send_event
         } else {
             false
         }

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -109,6 +109,11 @@ impl GStreamerBackend {
                                 error!("error in sending SkipNext: {e}");
                             }
                         }
+                        PlayerCmd::SpeedUp => {
+                            // HACK: currently gstreamer does not have any internal events to be send, and there is no global "re-apply speed property", this also means that if using max speed, it will not actually use full-speed
+                            let _ = cmd_tx.send(PlayerCmd::SpeedUp);
+                            let _ = cmd_tx.send(PlayerCmd::SpeedDown);
+                        }
                         _ => {}
                     }
                 }
@@ -198,6 +203,9 @@ impl GStreamerBackend {
 
                         // clear stored title on stream start (should work without conflicting in ::Tag)
                         media_title_internal.lock().clear();
+
+                        // HACK: gstreamer does not handle seek events before some undocumented time, see other note in main_rx handler
+                        let _ = main_tx.send_blocking(PlayerCmd::SpeedUp);
                     }
                     gst::MessageView::Error(e) =>
                         error!("GStreamer Error: {}", e.error()),
@@ -264,7 +272,7 @@ impl GStreamerBackend {
         };
 
         this.set_volume(volume);
-        this.set_speed(speed);
+        // this.set_speed(speed);
 
         // Send a signal to enqueue the next media before the current finished
         this.playbin.connect("about-to-finish", false, move |_| {


### PR DESCRIPTION
This PR adds a HACK to actually set the initial speed in a gst playback.
This needs to be done because gstreamer does not handle seek (speed) events before the pads are activated, which is at some undocumented time (at least from what i have found), so as a workaround it is set in `StreamStart`.

Additionally, because the gstreamer backend does not have any InternalCMD yet (unlike mpv and rusty), it needs to go through the entire server. In extra addition, we dont have a global "re-apply speed property" event, so i had to HACK it with `SpeedUp` & `SpeedDown`, which work, but result in not being able to use the full speed initially (== 30 in gst).
(I also didnt wanna add a event that is only useful to one backend, would like to refactor gst and main events at some point)

PS: in addition, i also added a log when the seek (speed) event was not handled.

fixes #279