### PR TITLE
Refactor `PlayerTrait` to combine `_up` and `_down` function into `add_`

### DIFF
--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -39,8 +39,6 @@ use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
 
-static VOLUME_STEP: u16 = 5;
-
 /// This trait allows for easy conversion of a path to a URI
 pub trait PathToURI {
     fn to_uri(&self) -> String;
@@ -354,14 +352,6 @@ impl PlayerTrait for GStreamerBackend {
         self.playbin
             .set_state(gst::State::Playing)
             .expect("set gst state playing error");
-    }
-
-    fn volume_up(&mut self) -> Volume {
-        self.set_volume(self.volume.saturating_add(VOLUME_STEP))
-    }
-
-    fn volume_down(&mut self) -> Volume {
-        self.set_volume(self.volume.saturating_sub(VOLUME_STEP))
     }
 
     fn volume(&self) -> Volume {

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -443,21 +443,6 @@ impl PlayerTrait for GStreamerBackend {
         self.speed
     }
 
-    fn speed_up(&mut self) -> Speed {
-        let mut speed = self.speed + 1;
-        if speed > 30 {
-            speed = 30;
-        }
-        self.set_speed(speed)
-    }
-
-    fn speed_down(&mut self) -> Speed {
-        let mut speed = self.speed - 1;
-        if speed < 1 {
-            speed = 1;
-        }
-        self.set_speed(speed)
-    }
     fn stop(&mut self) {
         self.playbin.set_state(gst::State::Null).ok();
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -574,11 +574,8 @@ impl PlayerTrait for GeneralPlayer {
     fn volume(&self) -> Volume {
         self.get_player().volume()
     }
-    fn volume_up(&mut self) -> Volume {
-        self.get_player_mut().volume_up()
-    }
-    fn volume_down(&mut self) -> Volume {
-        self.get_player_mut().volume_down()
+    fn add_volume(&mut self, volume: VolumeSigned) -> Volume {
+        self.get_player_mut().add_volume(volume)
     }
     fn set_volume(&mut self, volume: Volume) -> Volume {
         self.get_player_mut().set_volume(volume)
@@ -692,6 +689,8 @@ pub struct MediaInfo {
 }
 
 pub type Volume = u16;
+/// The type of [`Volume::saturating_add_signed`]
+pub type VolumeSigned = i16;
 pub type Speed = i32;
 
 #[allow(clippy::module_name_repetitions)]
@@ -701,14 +700,13 @@ pub trait PlayerTrait {
     async fn add_and_play(&mut self, track: &Track);
     /// Get the currently set volume
     fn volume(&self) -> Volume;
-    /// Step the volume up by a backend-set step amount
+    /// Add a relative amount to the current volume
     ///
     /// Returns the new volume
-    fn volume_up(&mut self) -> Volume;
-    /// Step the volume down by a backend-set step amount
-    ///
-    /// Returns the new volume
-    fn volume_down(&mut self) -> Volume;
+    fn add_volume(&mut self, volume: VolumeSigned) -> Volume {
+        let volume = self.volume().saturating_add_signed(volume);
+        self.set_volume(volume)
+    }
     /// Set the volume to a specific amount.
     ///
     /// Returns the new volume

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -602,12 +602,8 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player_mut().set_speed(speed)
     }
 
-    fn speed_up(&mut self) -> Speed {
-        self.get_player_mut().speed_up()
-    }
-
-    fn speed_down(&mut self) -> Speed {
-        self.get_player_mut().speed_down()
+    fn add_speed(&mut self, speed: SpeedSigned) -> Speed {
+        self.get_player_mut().add_speed(speed)
     }
 
     fn speed(&self) -> Speed {
@@ -692,6 +688,11 @@ pub type Volume = u16;
 /// The type of [`Volume::saturating_add_signed`]
 pub type VolumeSigned = i16;
 pub type Speed = i32;
+// yes this is currently the same as speed, but for consistentcy with VolumeSigned (and maybe other types)
+pub type SpeedSigned = Speed;
+
+pub const MIN_SPEED: Speed = 1;
+pub const MAX_SPEED: Speed = 30;
 
 #[allow(clippy::module_name_repetitions)]
 #[async_trait]
@@ -729,14 +730,14 @@ pub trait PlayerTrait {
     ///
     /// Returns the new speed
     fn set_speed(&mut self, speed: Speed) -> Speed;
-    /// Step the speed up by a backend-set step amount
+    /// Add a relative amount to the current speed
     ///
     /// Returns the new speed
-    fn speed_up(&mut self) -> Speed;
-    /// Step the speed down by a backend-set step amount
-    ///
-    /// Returns the new speed
-    fn speed_down(&mut self) -> Speed;
+    fn add_speed(&mut self, speed: SpeedSigned) -> Speed {
+        // NOTE: the clamping should likely be done in `set_speed` instead of here
+        let speed = (self.speed() + speed).clamp(MIN_SPEED, MAX_SPEED);
+        self.set_speed(speed)
+    }
     /// Get the currently set speed
     fn speed(&self) -> Speed;
     fn stop(&mut self);

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -335,21 +335,6 @@ impl PlayerTrait for MpvBackend {
         self.speed
     }
 
-    fn speed_up(&mut self) -> Speed {
-        let mut speed = self.speed + 1;
-        if speed > 30 {
-            speed = 30;
-        }
-        self.set_speed(speed)
-    }
-
-    fn speed_down(&mut self) -> Speed {
-        let mut speed = self.speed - 1;
-        if speed < 1 {
-            speed = 1;
-        }
-        self.set_speed(speed)
-    }
     fn stop(&mut self) {
         self.command_tx.send(PlayerInternalCmd::Stop).ok();
     }

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -38,8 +38,6 @@ use std::time::Duration;
 use termusiclib::config::Settings;
 use termusiclib::track::Track;
 
-static VOLUME_STEP: u16 = 5;
-
 pub struct MpvBackend {
     // player: Mpv,
     volume: u16,
@@ -290,14 +288,6 @@ impl PlayerTrait for MpvBackend {
 
     fn volume(&self) -> Volume {
         self.volume
-    }
-
-    fn volume_up(&mut self) -> Volume {
-        self.set_volume(self.volume.saturating_add(VOLUME_STEP))
-    }
-
-    fn volume_down(&mut self) -> Volume {
-        self.set_volume(self.volume.saturating_sub(VOLUME_STEP))
     }
 
     fn set_volume(&mut self, volume: Volume) -> Volume {

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -202,22 +202,6 @@ impl PlayerTrait for RustyBackend {
         self.command(PlayerInternalCmd::SeekAbsolute(position));
     }
 
-    fn speed_up(&mut self) -> Speed {
-        let mut speed = self.speed + 1;
-        if speed > 30 {
-            speed = 30;
-        }
-        self.set_speed(speed)
-    }
-
-    fn speed_down(&mut self) -> Speed {
-        let mut speed = self.speed - 1;
-        if speed < 1 {
-            speed = 1;
-        }
-        self.set_speed(speed)
-    }
-
     fn set_speed(&mut self, speed: Speed) -> Speed {
         self.speed = speed;
         self.command(PlayerInternalCmd::Speed(speed));

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -51,8 +51,6 @@ use symphonia::core::io::{
 use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
 
-static VOLUME_STEP: u16 = 5;
-
 pub type TotalDuration = Option<Duration>;
 pub type ArcTotalDuration = Arc<Mutex<TotalDuration>>;
 
@@ -171,22 +169,6 @@ impl PlayerTrait for RustyBackend {
 
     fn volume(&self) -> Volume {
         self.volume.load(Ordering::SeqCst)
-    }
-
-    fn volume_up(&mut self) -> Volume {
-        let volume = self
-            .volume
-            .load(Ordering::SeqCst)
-            .saturating_add(VOLUME_STEP);
-        self.set_volume(volume)
-    }
-
-    fn volume_down(&mut self) -> Volume {
-        let volume = self
-            .volume
-            .load(Ordering::SeqCst)
-            .saturating_sub(VOLUME_STEP);
-        self.set_volume(volume)
     }
 
     fn set_volume(&mut self, volume: Volume) -> Volume {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -17,7 +17,7 @@ use termusicplayback::player::music_player_server::MusicPlayerServer;
 use termusicplayback::player::{GetProgressResponse, PlayerTime};
 use termusicplayback::{
     Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
-    PlayerProgress, PlayerTrait, Status, VolumeSigned,
+    PlayerProgress, PlayerTrait, SpeedSigned, Status, VolumeSigned,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -29,6 +29,7 @@ extern crate log;
 
 pub const MAX_DEPTH: usize = 4;
 pub const VOLUME_STEP: VolumeSigned = 5;
+pub const SPEED_STEP: SpeedSigned = 1;
 
 /// Stats for the music player responses
 #[derive(Debug, Clone, PartialEq)]
@@ -239,7 +240,7 @@ fn player_loop(
                 player.next();
             }
             PlayerCmd::SpeedDown => {
-                let new_speed = player.speed_down();
+                let new_speed = player.add_speed(-SPEED_STEP);
                 info!("after speed down: {}", new_speed);
                 player.config.write().player_speed = new_speed;
                 let mut p_tick = playerstats.lock();
@@ -247,7 +248,7 @@ fn player_loop(
             }
 
             PlayerCmd::SpeedUp => {
-                let new_speed = player.speed_up();
+                let new_speed = player.add_speed(SPEED_STEP);
                 info!("after speed up: {}", new_speed);
                 player.config.write().player_speed = new_speed;
                 let mut p_tick = playerstats.lock();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -17,7 +17,7 @@ use termusicplayback::player::music_player_server::MusicPlayerServer;
 use termusicplayback::player::{GetProgressResponse, PlayerTime};
 use termusicplayback::{
     Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
-    PlayerProgress, PlayerTrait, Status,
+    PlayerProgress, PlayerTrait, Status, VolumeSigned,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -28,6 +28,7 @@ use tonic::transport::Server;
 extern crate log;
 
 pub const MAX_DEPTH: usize = 4;
+pub const VOLUME_STEP: VolumeSigned = 5;
 
 /// Stats for the music player responses
 #[derive(Debug, Clone, PartialEq)]
@@ -324,7 +325,7 @@ fn player_loop(
             }
             PlayerCmd::VolumeDown => {
                 info!("before volumedown: {}", player.volume());
-                let new_volume = player.volume_down();
+                let new_volume = player.add_volume(-VOLUME_STEP);
                 player.config.write().player_volume = new_volume;
                 info!("after volumedown: {}", new_volume);
                 let mut p_tick = playerstats.lock();
@@ -332,7 +333,7 @@ fn player_loop(
             }
             PlayerCmd::VolumeUp => {
                 info!("before volumeup: {}", player.volume());
-                let new_volume = player.volume_up();
+                let new_volume = player.add_volume(VOLUME_STEP);
                 player.config.write().player_volume = new_volume;
                 info!("after volumeup: {}", new_volume);
                 let mut p_tick = playerstats.lock();


### PR DESCRIPTION
This PR adds a new function for volume & speed prefixed with `add_` to do signed operations, and replaces (and removes) the old `_up` and `_down` functions.
Also the new function(s) provide a default implementation, as it would be the same in all backends.

For now the `PlayerCmd` enum is un-touched, but i plan to also replace the `Up` and `Down` events there with a relative and value.