### PR TITLE
fix(playback::rusty): clear already decoded sample buffer after seek

### DIFF
--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -280,10 +280,15 @@ impl Source for Symphonia {
                 track_id: Some(self.track_id),
             },
         ) {
-            Ok(seeked_to) => self
-                .time_base
-                .as_ref()
-                .map(|v| v.calc_time(seeked_to.actual_ts).into()),
+            Ok(seeked_to) => {
+                // clear sample buffer after seek
+                self.current_frame_offset = 0;
+                self.buffer.clear();
+
+                self.time_base
+                    .as_ref()
+                    .map(|v| v.calc_time(seeked_to.actual_ts).into())
+            }
             Err(_) => None,
         }
     }


### PR DESCRIPTION
This PR changes the rusty backend to clear its sample buffer after a seek.

I dont actually hear a audible difference, but i think it is actually more correct to not play the samples from before the seek.

@tramhao what do you think?