### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [stable, "1.74"]
+        rust: [stable, "1.75"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### next
 - Unreleased
 - Change: enable `log-to-file` by default.
+- Change: updated MSRV to 1.75.
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
 
 ### [v0.9.0]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,16 +1828,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.28",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3153,49 +3156,6 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.25",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-rustls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
@@ -3214,6 +3174,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3224,7 +3185,9 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.2",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3232,6 +3195,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3239,7 +3203,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.52.0",
+ "webpki-roots",
+ "winreg",
 ]
 
 [[package]]
@@ -3330,23 +3295,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3367,11 +3325,12 @@ checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3426,16 +3385,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sctk-adwaita"
@@ -3696,17 +3645,16 @@ dependencies = [
 
 [[package]]
 name = "stream-download"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809ed111dc3f00305dcbbce2172e0834b3a291d62e2d20c20d01e23907462126"
+checksum = "85fa761723d640532a18f46b7f429fc181fc8d2b5b37721fad5cd48bd95098a5"
 dependencies = [
- "async-trait",
  "bytes",
  "futures",
  "mediatype",
  "parking_lot",
  "rangemap",
- "reqwest 0.11.26",
+ "reqwest",
  "tap",
  "tempfile",
  "tokio",
@@ -3731,6 +3679,12 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "symphonia"
@@ -4047,7 +4001,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "reqwest 0.12.3",
+ "reqwest",
  "sanitize-filename",
  "serde_json",
  "shellexpand",
@@ -4099,7 +4053,7 @@ dependencies = [
  "quick-xml 0.31.0",
  "rand",
  "regex",
- "reqwest 0.12.3",
+ "reqwest",
  "rfc822_sanitizer",
  "rss",
  "rusqlite",
@@ -4141,7 +4095,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "rand",
- "reqwest 0.12.3",
+ "reqwest",
  "serde",
  "soundtouch",
  "souvlaki",
@@ -4349,11 +4303,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -4959,9 +4914,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "weezl"
@@ -5341,16 +5299,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -5466,6 +5414,12 @@ dependencies = [
  "quote",
  "syn 2.0.53",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -338,8 +338,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -1594,7 +1594,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -1707,13 +1726,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1739,9 +1792,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1754,14 +1807,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -1773,7 +1846,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -1781,15 +1854,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3061,37 +3157,31 @@ version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
- "cookie",
- "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -3101,7 +3191,55 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "async-compression",
+ "base64 0.22.0",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3210,6 +3348,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -3552,7 +3706,7 @@ dependencies = [
  "mediatype",
  "parking_lot",
  "rangemap",
- "reqwest",
+ "reqwest 0.11.26",
  "tap",
  "tempfile",
  "tokio",
@@ -3893,7 +4047,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.12.3",
  "sanitize-filename",
  "serde_json",
  "shellexpand",
@@ -3945,7 +4099,7 @@ dependencies = [
  "quick-xml 0.31.0",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.12.3",
  "rfc822_sanitizer",
  "rss",
  "rusqlite",
@@ -3987,7 +4141,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "rand",
- "reqwest",
+ "reqwest 0.12.3",
  "serde",
  "soundtouch",
  "souvlaki",
@@ -4284,10 +4438,10 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.25",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -4351,6 +4505,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5189,6 +5344,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "calloop"
@@ -4147,9 +4147,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ termusic-lib = { path = "lib/", version = "0.9.0" }
 termusic-playback = { path = "playback/", version = "0.9.0", default-features = false }
 ahash = "^0.8"
 anyhow = { version = "1.0", features = ["backtrace"] }
-async-channel = "2"
+async-channel = "2.2"
 async-trait = "0.1"
 base64 = "0.22"
-bytes = "1"
+bytes = "1.6"
 chrono = "^0.4.23"
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 cpal = "^0.15"
-ctrlc = { version = "3", features = ["termination"] }
+ctrlc = { version = "3.4", features = ["termination"] }
 dirs = "5.0"
 discord-rich-presence = { version = "0.2" }
 escaper = "0.1.1"
@@ -43,7 +43,7 @@ futures-util = "0.3"
 glib = { version = "0.19" }
 gstreamer = { version = "0.22" }
 hex = "0.4"
-id3 = "1"
+id3 = "1.13"
 image = "0.24"
 include_dir = "0.7"
 lazy_static = "1.4"
@@ -55,16 +55,16 @@ flexi_logger = "0.28"
 colored = "2.0"
 md5 = "0.7"
 num-bigint = "0.4"
-opml = "1"
+opml = "1.1"
 parking_lot = "^0.12"
 pathdiff = { version = "0.2", features = ["camino"] }
 percent-encoding = "2.2"
 pinyin = "0.10"
-pretty_assertions = "1"
+pretty_assertions = "1.4"
 prost = "0.12"
 quick-xml = "0.31"
 rand = "0.8"
-rangemap = "1"
+rangemap = "1.5"
 regex = "^1.5.5"
 reqwest = { version = "0.11", features = [
     "blocking",
@@ -74,13 +74,13 @@ reqwest = { version = "0.11", features = [
     "stream",
 ] }
 rfc822_sanitizer = "0.3"
-rss = "2"
+rss = "2.0"
 rusqlite = { version = "0.31", features = ["bundled"] }
 sanitize-filename = "0.5"
-semver = "^1"
+semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shellexpand = "3"
+shellexpand = "3.1"
 soundtouch = "0.4"
 souvlaki = "0.7.2"
 stream-download = { version = "0.5", features = ["reqwest-rustls"] }
@@ -94,10 +94,10 @@ symphonia = { version = "0.5.1", features = [
     "mkv",
 ] }
 sysinfo = "^0.30"
-tap = "1"
-tempfile = "3"
+tap = "1.0"
+tempfile = "3.10"
 textwrap = "0.16"
-tokio = { version = "1", features = ["sync", "macros", "rt","rt-multi-thread"] }
+tokio = { version = "1.37", features = ["sync", "macros", "rt","rt-multi-thread"] }
 tokio-util = "0.7"
 # tokio-stream = "*"
 toml = "0.8"
@@ -109,11 +109,11 @@ tui-realm-stdlib = "~1.2"
 tui-realm-treeview = "~1.1"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
-urlencoding = "2"
+urlencoding = "2.1"
 # viuer = { version = "0.7", features = ["sixel"] }
 viuer = "0.7"
-walkdir = "2"
-wildmatch = "2"
+walkdir = "2.5"
+wildmatch = "2.3"
 yaml-rust = "^0.4.5"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }
 # winit = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 ]
 readme = "./README.md"
 version = "0.9.0"
-rust-version = "1.74"
+rust-version = "1.75"
 
 [workspace.dependencies]
 # "version" key is required, as per https://github.com/rust-lang/cargo/issues/11133

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ symphonia = { version = "0.5.1", features = [
     "mkv",
 ] }
 sysinfo = "^0.30"
-tap = "1.0"
 tempfile = "3.10"
 textwrap = "0.16"
 tokio = { version = "1.37", features = ["sync", "macros", "rt","rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ tokio-util = "0.7"
 toml = "0.8"
 tonic = "0.11"
 tonic-build = "0.11"
-tracing = "0.1"
 tuirealm = { version = "~1.8", features = ["serialize"] }
 tui-realm-stdlib = "~1.2"
 tui-realm-treeview = "~1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ pretty_assertions = "1.4"
 prost = "0.12"
 quick-xml = "0.31"
 rand = "0.8"
-rangemap = "1.5"
 regex = "^1.5.5"
 reqwest = { version = "0.12", features = [
     "blocking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ glib = { version = "0.19" }
 gstreamer = { version = "0.22" }
 hex = "0.4"
 id3 = "1.13"
+# image cannot be upgraded to 0.25 because of viuer, see https://github.com/atanunq/viuer/issues/56
 image = "0.24"
 include_dir = "0.7"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ serde_json = "1.0"
 shellexpand = "3.1"
 soundtouch = "0.4"
 souvlaki = "0.7.2"
-stream-download = { version = "0.5", features = ["reqwest-rustls"] }
+stream-download = { version = "0.5.2", features = ["reqwest-rustls"] }
 symphonia = { version = "0.5.1", features = [
     "default",
     "aac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,6 @@ dirs = "5.0"
 discord-rich-presence = { version = "0.2" }
 escaper = "0.1.1"
 figment = { version = "0.10", features = ["toml"] }
-futures = "0.3"
-futures-util = "0.3"
 glib = { version = "0.19" }
 gstreamer = { version = "0.22" }
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ quick-xml = "0.31"
 rand = "0.8"
 rangemap = "1.5"
 regex = "^1.5.5"
-reqwest = { version = "0.11", features = [
+reqwest = { version = "0.12", features = [
     "blocking",
     "cookies",
     "gzip",

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 pub use conversions::Sample;
 pub use cpal::{traits::StreamTrait, ChannelCount, SampleRate};
 pub use decoder::Symphonia;
-use reqwest::header::{HeaderMap, HeaderValue};
 pub use sink::Sink;
 pub use source::Source;
 use std::num::{NonZeroU16, NonZeroUsize};
@@ -39,7 +38,13 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::time::Duration;
-use stream_download::http::{reqwest::Client, HttpStream};
+use stream_download::http::{
+    reqwest::{
+        header::{HeaderMap, HeaderValue},
+        Client,
+    },
+    HttpStream,
+};
 use stream_download::source::SourceStream;
 use stream_download::storage::bounded::BoundedStorageProvider;
 use stream_download::storage::memory::MemoryStorageProvider;


### PR DESCRIPTION
This PR updates and removes some dependencies, in more details:
- remove unused dependencies
- update some dependencies
- use more specific versions instead of just the major version, see *1 and *2
- Update MSRV thanks to a dependency update

*1 to not accidentally rely on newer features added in newer minor releases

*2 re lib.rs text:

> Cargo does not always pick latest versions of dependencies! Specify the version as clap = "4.5.0". If Cargo.lock ends up having an unexpectedly old version of the dependency, you might get a dependency that lacks features/APIs or important bugfixes that you depend on. This is most likely to happen when using minimal-versions flag, used by users of old Rust versions.