### PR TITLE
refactor(lib::podcast::db::update_episodes): avoid clone if not necessary

### DIFF
--- a/lib/src/podcast/db.rs
+++ b/lib/src/podcast/db.rs
@@ -376,7 +376,7 @@ impl Database {
         let mut old_ep_map = AHashMap::new();
         for ep in &old_episodes {
             if !ep.guid.is_empty() {
-                old_ep_map.insert(ep.guid.clone(), ep.clone());
+                old_ep_map.insert(&ep.guid, ep);
             }
         }
 


### PR DESCRIPTION
This PR avoids 2 clones when they are actually not necessary thanks to `old_episodes` not being `mut`