### PR TITLE
Some lib::songtag Refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ dependencies = [
  "dirs",
  "escaper",
  "figment",
+ "futures",
  "hex",
  "id3",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ yaml-rust = "^0.4.5"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }
 # winit = "0.27.0"
 # windows = "0.52"
+futures = "0.3"
 
 [profile.release]
 # lto = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -66,6 +66,7 @@ viuer.workspace = true #   = "0.6"
 walkdir.workspace = true #   = "2"
 wildmatch.workspace = true #   = "2"
 ytd-rs.workspace = true #   = { version = "0.1", features = ["yt-dlp"]}
+futures.workspace = true
 
 
 [features]

--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -31,10 +31,10 @@ use model::{to_lyric, to_lyric_id_accesskey, to_pic_url, to_song_info, to_song_u
 use reqwest::blocking::{Client, ClientBuilder};
 use std::time::Duration;
 
-static URL_SEARCH_KUGOU: &str = "http://mobilecdn.kugou.com/api/v3/search/song";
-static URL_LYRIC_SEARCH_KUGOU: &str = "http://krcs.kugou.com/search";
-static URL_LYRIC_DOWNLOAD_KUGOU: &str = "http://lyrics.kugou.com/download";
-static URL_SONG_DOWNLOAD_KUGOU: &str = "http://www.kugou.com/yy/index.php?r=play/getdata";
+const URL_SEARCH_KUGOU: &str = "http://mobilecdn.kugou.com/api/v3/search/song";
+const URL_LYRIC_SEARCH_KUGOU: &str = "http://krcs.kugou.com/search";
+const URL_LYRIC_DOWNLOAD_KUGOU: &str = "http://lyrics.kugou.com/download";
+const URL_SONG_DOWNLOAD_KUGOU: &str = "http://www.kugou.com/yy/index.php?r=play/getdata";
 
 #[derive(Debug, Clone, Copy)]
 pub enum SearchRequestType {

--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -24,7 +24,7 @@
 mod model;
 
 use super::{encrypt::Crypto, SongTag};
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use bytes::Buf;
 use lofty::Picture;
 use model::{to_lyric, to_lyric_id_accesskey, to_pic_url, to_song_info, to_song_url};
@@ -35,6 +35,11 @@ static URL_SEARCH_KUGOU: &str = "http://mobilecdn.kugou.com/api/v3/search/song";
 static URL_LYRIC_SEARCH_KUGOU: &str = "http://krcs.kugou.com/search";
 static URL_LYRIC_DOWNLOAD_KUGOU: &str = "http://lyrics.kugou.com/download";
 static URL_SONG_DOWNLOAD_KUGOU: &str = "http://www.kugou.com/yy/index.php?r=play/getdata";
+
+#[derive(Debug, Clone, Copy)]
+pub enum SearchRequestType {
+    Song = 1,
+}
 
 pub struct Api {
     client: Client,
@@ -53,7 +58,7 @@ impl Api {
     pub fn search(
         &self,
         keywords: &str,
-        types: u32,
+        types: SearchRequestType,
         offset: u16,
         limit: u16,
     ) -> Result<Vec<SongTag>> {
@@ -82,11 +87,10 @@ impl Api {
         // file.write_all(result.as_bytes()).expect("write failed");
 
         match types {
-            1 => {
+            SearchRequestType::Song => {
                 let song_info = to_song_info(&result).ok_or_else(|| anyhow!("Search Error"))?;
                 Ok(song_info)
             }
-            _ => bail!("None Error"),
         }
     }
 

--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -23,7 +23,7 @@
  */
 mod model;
 
-use super::encrypt::Crypto;
+use super::{encrypt::Crypto, SongTag};
 use anyhow::{anyhow, bail, Result};
 use bytes::Buf;
 use lofty::Picture;
@@ -50,7 +50,13 @@ impl Api {
         Self { client }
     }
 
-    pub fn search(&self, keywords: &str, types: u32, offset: u16, limit: u16) -> Result<String> {
+    pub fn search(
+        &self,
+        keywords: &str,
+        types: u32,
+        offset: u16,
+        limit: u16,
+    ) -> Result<Vec<SongTag>> {
         let q_1 = 1.to_string();
         let q_page = offset.to_string();
         let q_pagesize = limit.to_string();
@@ -78,8 +84,7 @@ impl Api {
         match types {
             1 => {
                 let song_info = to_song_info(&result).ok_or_else(|| anyhow!("Search Error"))?;
-                let song_info_string = serde_json::to_string(&song_info)?;
-                Ok(song_info_string)
+                Ok(song_info)
             }
             _ => bail!("None Error"),
         }

--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -28,7 +28,7 @@ use anyhow::{anyhow, Result};
 use bytes::Buf;
 use lofty::Picture;
 use model::{to_lyric, to_lyric_id_accesskey, to_pic_url, to_song_info, to_song_url};
-use reqwest::blocking::{Client, ClientBuilder};
+use reqwest::{Client, ClientBuilder};
 use std::time::Duration;
 
 const URL_SEARCH_KUGOU: &str = "http://mobilecdn.kugou.com/api/v3/search/song";
@@ -55,7 +55,7 @@ impl Api {
         Self { client }
     }
 
-    pub fn search(
+    pub async fn search(
         &self,
         keywords: &str,
         types: SearchRequestType,
@@ -80,8 +80,10 @@ impl Api {
             .post(URL_SEARCH_KUGOU)
             .header("Referer", "https://m.music.migu.cn")
             .query(&query_vec)
-            .send()?
-            .text()?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         // let mut file = std::fs::File::create("data.txt").expect("create failed");
         // file.write_all(result.as_bytes()).expect("write failed");
@@ -96,7 +98,7 @@ impl Api {
 
     // search and download lyrics
     // music_id: 歌曲id
-    pub fn song_lyric(&self, music_id: &str) -> Result<String> {
+    pub async fn song_lyric(&self, music_id: &str) -> Result<String> {
         let query_vec = vec![
             ("keyword", "%20-%20"),
             ("ver", "1"),
@@ -109,8 +111,10 @@ impl Api {
             .client
             .get(URL_LYRIC_SEARCH_KUGOU)
             .query(&query_vec)
-            .send()?
-            .text()?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let (accesskey, id) =
             to_lyric_id_accesskey(&result).ok_or_else(|| anyhow!("Search Error"))?;
@@ -127,15 +131,17 @@ impl Api {
             .client
             .get(URL_LYRIC_DOWNLOAD_KUGOU)
             .query(&query_vec)
-            .send()?
-            .text()?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         to_lyric(&result).ok_or_else(|| anyhow!("Search Error"))
     }
 
     // 歌曲 URL
     // ids: 歌曲列表
-    pub fn song_url(&self, id: &str, album_id: &str) -> Result<String> {
+    pub async fn song_url(&self, id: &str, album_id: &str) -> Result<String> {
         let kg_mid = Crypto::alpha_lowercase_random_bytes(32);
 
         let query_vec = vec![("hash", id), ("album_id", album_id)];
@@ -144,8 +150,10 @@ impl Api {
             .get(URL_SONG_DOWNLOAD_KUGOU)
             .header("Cookie", format!("kg_mid={kg_mid}").as_str())
             .query(&query_vec)
-            .send()?
-            .text()?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         // let mut file = std::fs::File::create("data.txt").expect("create failed");
         // file.write_all(result.as_bytes()).expect("write failed");
@@ -154,7 +162,7 @@ impl Api {
     }
 
     // download picture
-    pub fn pic(&self, id: &str, album_id: &str) -> Result<Picture> {
+    pub async fn pic(&self, id: &str, album_id: &str) -> Result<Picture> {
         let kg_mid = Crypto::alpha_lowercase_random_bytes(32);
         let query_vec = vec![("hash", id), ("album_id", album_id)];
         let result = self
@@ -162,12 +170,14 @@ impl Api {
             .get(URL_SONG_DOWNLOAD_KUGOU)
             .header("Cookie", format!("kg_mid={kg_mid}").as_str())
             .query(&query_vec)
-            .send()?
-            .text()?;
+            .send()
+            .await?
+            .text()
+            .await?;
 
         let url = to_pic_url(&result).ok_or_else(|| anyhow!("Search Error"))?;
 
-        let result = self.client.get(url).send()?;
+        let result = self.client.get(url).send().await?;
 
         // let mut bytes: Vec<u8> = Vec::new();
         // result.into_reader().read_to_end(&mut bytes)?;
@@ -176,7 +186,7 @@ impl Api {
         // let mut bytes = Vec::new();
         // result.read_to_end(&mut bytes)?;
 
-        let mut reader = result.bytes()?.reader();
+        let mut reader = result.bytes().await?.reader();
         let picture = Picture::from_reader(&mut reader)?;
         Ok(picture)
     }

--- a/lib/src/songtag/kugou/model.rs
+++ b/lib/src/songtag/kugou/model.rs
@@ -143,3 +143,35 @@ fn parse_song_info(v: &Value) -> Option<SongTag> {
         album_id: Some(v.get("album_id")?.as_str()?.to_owned()),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO: get some actual test data like migu or netease
+    #[test]
+    fn should_parse_songinfo() {
+        let sample_data = r#"{
+            "status": 1,
+            "errcode": 0,
+            "data": {
+              "timestamp": 1111111111,
+              "tab": "",
+              "forcecorrection": 0,
+              "correctiontype": 0,
+              "total": 0,
+              "istag": 0,
+              "allowerr": 0,
+              "info": [],
+              "aggregation": [],
+              "correctiontip": "",
+              "istagresult": 0
+            },
+            "error": ""
+          }"#;
+
+        let res = to_song_info(sample_data).unwrap();
+
+        assert_eq!(res.len(), 0);
+    }
+}

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -37,6 +37,11 @@ static URL_SEARCH_MIGU: &str = "https://m.music.migu.cn/migu/remoting/scr_search
 static URL_LYRIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getLyric";
 static URL_PIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getSongPic";
 
+#[derive(Debug, Clone, Copy)]
+pub enum SearchRequestType {
+    Song = 1,
+}
+
 pub struct Api {
     client: Client,
 }
@@ -54,7 +59,7 @@ impl Api {
     pub fn search(
         &self,
         keywords: &str,
-        types: u32,
+        types: SearchRequestType,
         offset: u16,
         limit: u16,
     ) -> Result<Vec<SongTag>> {
@@ -79,11 +84,10 @@ impl Api {
         // file.write_all(result.as_bytes()).expect("write failed");
 
         match types {
-            1 => {
+            SearchRequestType::Song => {
                 let songtag_vec = to_song_info(&result).ok_or_else(|| anyhow!("Search Error"))?;
                 Ok(songtag_vec)
             }
-            _ => Err(anyhow!("None Error")),
         }
     }
 

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -31,6 +31,8 @@ use model::{to_lyric, to_pic_url, to_song_info};
 use reqwest::blocking::{Client, ClientBuilder};
 use std::time::Duration;
 
+use super::SongTag;
+
 static URL_SEARCH_MIGU: &str = "https://m.music.migu.cn/migu/remoting/scr_search_tag";
 static URL_LYRIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getLyric";
 static URL_PIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getSongPic";
@@ -49,7 +51,13 @@ impl Api {
         Self { client }
     }
 
-    pub fn search(&self, keywords: &str, types: u32, offset: u16, limit: u16) -> Result<String> {
+    pub fn search(
+        &self,
+        keywords: &str,
+        types: u32,
+        offset: u16,
+        limit: u16,
+    ) -> Result<Vec<SongTag>> {
         let q_pgc = offset.to_string();
         let q_rows = limit.to_string();
         let q_type = 2.to_string();
@@ -73,8 +81,7 @@ impl Api {
         match types {
             1 => {
                 let songtag_vec = to_song_info(&result).ok_or_else(|| anyhow!("Search Error"))?;
-                let songtag_string = serde_json::to_string(&songtag_vec)?;
-                Ok(songtag_string)
+                Ok(songtag_vec)
             }
             _ => Err(anyhow!("None Error")),
         }

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -33,9 +33,9 @@ use std::time::Duration;
 
 use super::SongTag;
 
-static URL_SEARCH_MIGU: &str = "https://m.music.migu.cn/migu/remoting/scr_search_tag";
-static URL_LYRIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getLyric";
-static URL_PIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getSongPic";
+const URL_SEARCH_MIGU: &str = "https://m.music.migu.cn/migu/remoting/scr_search_tag";
+const URL_LYRIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getLyric";
+const URL_PIC_MIGU: &str = "https://music.migu.cn/v3/api/music/audioPlayer/getSongPic";
 
 #[derive(Debug, Clone, Copy)]
 pub enum SearchRequestType {

--- a/lib/src/songtag/migu/model.rs
+++ b/lib/src/songtag/migu/model.rs
@@ -106,3 +106,108 @@ fn parse_song_info(v: &Value) -> Option<SongTag> {
         album_id: Some(album_id),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_songinfo() {
+        let sample_data = r#"{
+            "musics": [
+              {
+                "songName": "Track A",
+                "isHdCrbt": null,
+                "albumName": "Some Album 1",
+                "has24Bitqq": null,
+                "hasMv": null,
+                "artist": "Some Artist",
+                "hasHQqq": "1",
+                "albumId": "0000000000",
+                "title": "Track A",
+                "singerName": "Some Artist",
+                "cover": "https://mcontent.migu.cn/newlv2/new/album/20230810/0000000000/someRandomCode.jpg",
+                "mp3": "https://freetyst.nf.migu.cn/SomeLongPercentFilename.mp3?Key=AAAAAAAAAAAAAAAA&Tim=1111111111111&channelid=01&msisdn=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "hasSQqq": null,
+                "has3Dqq": null,
+                "singerId": "0000000001",
+                "mvCopyrightId": null,
+                "copyrightId": "0000000AAAA",
+                "unuseFlag": null,
+                "auditionsFlag": null,
+                "auditionsLength": null,
+                "mvId": "",
+                "id": "0000000002",
+                "lyrics": "https://tyqk.migu.cn/files/lyric/2018-04-20/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC.lrc"
+              },
+              {
+                "songName": "Track B",
+                "isHdCrbt": null,
+                "albumName": "Some Album 2",
+                "has24Bitqq": null,
+                "hasMv": null,
+                "artist": "Some Artist",
+                "hasHQqq": "1",
+                "albumId": "1111111111",
+                "title": "Track B",
+                "singerName": "Some Artist",
+                "cover": "https://tyqk.migu.cn/files/resize/album/2023-12-19/someOtherRandomCode.jpg?200x200",
+                "mp3": "https://freetyst.nf.migu.cn/SomeOtherLongPercentFilename.mp3?Key=AAAAAAAAAAAAAAAA&Tim=1111111111111&channelid=01&msisdn=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "hasSQqq": null,
+                "has3Dqq": null,
+                "singerId": "0000000001",
+                "mvCopyrightId": null,
+                "copyrightId": "1111111BBBB",
+                "unuseFlag": null,
+                "auditionsFlag": null,
+                "auditionsLength": null,
+                "mvId": "",
+                "id": "1111111112",
+                "lyrics": "https://tyqk.migu.cn/files/lyric/2018-12-22/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD.lrc"
+              }
+            ],
+            "pgt": 100,
+            "keyword": "Some Artist Track A",
+            "pageNo": "0",
+            "success": true
+        }"#;
+
+        let res = to_song_info(sample_data).unwrap();
+
+        assert_eq!(res.len(), 2);
+
+        const ARTIST: &str = "Some Artist";
+
+        assert_eq!(
+            res[0],
+            SongTag {
+                artist: Some(ARTIST.to_owned()),
+                title: Some("Track A".to_owned()),
+                album: Some("Some Album 1".to_owned()),
+                lang_ext: Some("migu".to_string()),
+                service_provider: Some(ServiceProvider::Migu),
+                song_id: Some("0000000002".to_owned()),
+                lyric_id: Some("0000000AAAA".to_owned()),
+                url: Some("https://freetyst.nf.migu.cn/SomeLongPercentFilename.mp3?Key=AAAAAAAAAAAAAAAA&Tim=1111111111111&channelid=01&msisdn=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned()),
+                pic_id: Some("https://mcontent.migu.cn/newlv2/new/album/20230810/0000000000/someRandomCode.jpg".to_owned()),
+                album_id: Some("0000000000".to_owned())
+            }
+        );
+
+        assert_eq!(
+            res[1],
+            SongTag {
+                artist: Some(ARTIST.to_owned()),
+                title: Some("Track B".to_owned()),
+                album: Some("Some Album 2".to_owned()),
+                lang_ext: Some("migu".to_string()),
+                service_provider: Some(ServiceProvider::Migu),
+                song_id: Some("1111111112".to_owned()),
+                lyric_id: Some("1111111BBBB".to_owned()),
+                url: Some("https://freetyst.nf.migu.cn/SomeOtherLongPercentFilename.mp3?Key=AAAAAAAAAAAAAAAA&Tim=1111111111111&channelid=01&msisdn=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_owned()),
+                pic_id: Some("https://tyqk.migu.cn/files/resize/album/2023-12-19/someOtherRandomCode.jpg?200x200".to_owned()),
+                album_id: Some("1111111111".to_owned())
+            }
+        );
+    }
+}

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -83,8 +83,7 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let handle_netease = thread::spawn(move || -> Result<()> {
         let mut netease_api = netease::Api::new();
         if let Ok(results) = netease_api.search(&search_str_netease, 1, 0, 30) {
-            let result_new: Vec<SongTag> = serde_json::from_str(&results)?;
-            tx1.send(result_new).ok();
+            tx1.send(results).ok();
         }
         Ok(())
     });
@@ -94,8 +93,7 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let handle_migu = thread::spawn(move || -> Result<()> {
         let migu_api = migu::Api::new();
         if let Ok(results) = migu_api.search(&search_str_migu, 1, 0, 30) {
-            let result_new: Vec<SongTag> = serde_json::from_str(&results)?;
-            tx2.send(result_new).ok();
+            tx2.send(results).ok();
         }
         Ok(())
     });
@@ -103,9 +101,8 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let kugou_api = kugou::Api::new();
     let search_str_kugou = search_str.to_string();
     let handle_kugou = thread::spawn(move || -> Result<()> {
-        if let Ok(r) = kugou_api.search(&search_str_kugou, 1, 0, 30) {
-            let result_new: Vec<SongTag> = serde_json::from_str(&r)?;
-            tx.send(result_new).ok();
+        if let Ok(results) = kugou_api.search(&search_str_kugou, 1, 0, 30) {
+            tx.send(results).ok();
         }
         Ok(())
     });

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -39,7 +39,7 @@ use std::thread::{self, sleep};
 use std::time::Duration;
 use ytd_rs::{Arg, YoutubeDL};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SongTag {
     artist: Option<String>,
     title: Option<String>,
@@ -54,8 +54,7 @@ pub struct SongTag {
     // genre: Option<String>,
 }
 
-#[derive(Deserialize, Serialize)]
-#[allow(clippy::use_self)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum ServiceProvider {
     Netease,
     Kugou,

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -39,7 +39,7 @@ use std::thread::{self, sleep};
 use std::time::Duration;
 use ytd_rs::{Arg, YoutubeDL};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct SongTag {
     artist: Option<String>,
     title: Option<String>,
@@ -54,7 +54,7 @@ pub struct SongTag {
     // genre: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub enum ServiceProvider {
     Netease,
     Kugou,

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -34,7 +34,7 @@ use lofty::id3::v2::{Frame, FrameFlags, FrameValue, Id3v2Tag, UnsynchronizedText
 use lofty::{Accessor, Picture, TagExt, TextEncoding};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::mpsc::{self, Sender};
 use std::thread::{self, sleep};
 use std::time::Duration;
 use ytd_rs::{Arg, YoutubeDL};
@@ -76,7 +76,7 @@ impl std::fmt::Display for ServiceProvider {
 // Search function of 3 servers. Run in parallel to get results faster.
 pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let mut results: Vec<SongTag> = Vec::new();
-    let (tx, rx): (Sender<Vec<SongTag>>, Receiver<Vec<SongTag>>) = mpsc::channel();
+    let (tx, rx) = mpsc::channel::<Vec<SongTag>>();
 
     let tx1 = tx.clone();
     let search_str_netease = search_str.to_string();

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -107,7 +107,9 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let kugou_api = kugou::Api::new();
     let search_str_kugou = search_str.to_string();
     let handle_kugou = thread::spawn(move || -> Result<()> {
-        if let Ok(results) = kugou_api.search(&search_str_kugou, 1, 0, 30) {
+        if let Ok(results) =
+            kugou_api.search(&search_str_kugou, kugou::SearchRequestType::Song, 0, 30)
+        {
             tx.send(results).ok();
         }
         Ok(())

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -82,7 +82,12 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let search_str_netease = search_str.to_string();
     let handle_netease = thread::spawn(move || -> Result<()> {
         let mut netease_api = netease::Api::new();
-        if let Ok(results) = netease_api.search(&search_str_netease, 1, 0, 30) {
+        if let Ok(results) = netease_api.search(
+            &search_str_netease,
+            netease::SearchRequestType::Single,
+            0,
+            30,
+        ) {
             tx1.send(results).ok();
         }
         Ok(())

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -97,7 +97,8 @@ pub fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let search_str_migu = search_str.to_string();
     let handle_migu = thread::spawn(move || -> Result<()> {
         let migu_api = migu::Api::new();
-        if let Ok(results) = migu_api.search(&search_str_migu, 1, 0, 30) {
+        if let Ok(results) = migu_api.search(&search_str_migu, migu::SearchRequestType::Song, 0, 30)
+        {
             tx2.send(results).ok();
         }
         Ok(())

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -76,32 +76,24 @@ impl std::fmt::Display for ServiceProvider {
 pub async fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
     let mut results: Vec<SongTag> = Vec::new();
 
-    let search_str_netease = search_str.to_string();
     let handle_netease = async {
         let mut netease_api = netease::Api::new();
         netease_api
-            .search(
-                &search_str_netease,
-                netease::SearchRequestType::Single,
-                0,
-                30,
-            )
+            .search(search_str, netease::SearchRequestType::Single, 0, 30)
             .await
     };
 
-    let search_str_migu = search_str.to_string();
     let handle_migu = async {
         let migu_api = migu::Api::new();
         migu_api
-            .search(&search_str_migu, migu::SearchRequestType::Song, 0, 30)
+            .search(search_str, migu::SearchRequestType::Song, 0, 30)
             .await
     };
 
-    let search_str_kugou = search_str.to_string();
     let handle_kugou = async {
         let kugou_api = kugou::Api::new();
         kugou_api
-            .search(&search_str_kugou, kugou::SearchRequestType::Song, 0, 30)
+            .search(search_str, kugou::SearchRequestType::Song, 0, 30)
             .await
     };
 

--- a/lib/src/songtag/netease/mod.rs
+++ b/lib/src/songtag/netease/mod.rs
@@ -20,7 +20,7 @@ lazy_static! {
     static ref _CSRF: Regex = Regex::new(r"_csrf=(?P<csrf>[^(;|$)]+)").unwrap();
 }
 
-static BASE_URL_NETEASE: &str = "https://music.163.com";
+const BASE_URL_NETEASE: &str = "https://music.163.com";
 
 const LINUX_USER_AGENT: &str =
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36";

--- a/lib/src/songtag/netease/mod.rs
+++ b/lib/src/songtag/netease/mod.rs
@@ -54,6 +54,18 @@ enum CryptoApi {
     Linuxapi,
 }
 
+// types: 单曲(1)，歌手(100)，专辑(10)，歌单(1000)，用户(1002) *(type)*
+// types: single (1), singer (100), album (10), playlist (1000), user (1002) *(type)*
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub enum SearchRequestType {
+    Single = 1,
+    Singer = 100,
+    Album = 10,
+    Playlist = 1000,
+    User = 1002,
+}
+
 impl Api {
     #[allow(unused)]
     pub fn new() -> Self {
@@ -150,23 +162,22 @@ impl Api {
 
     // 搜索
     // keywords: 关键词
-    // types: 单曲(1)，歌手(100)，专辑(10)，歌单(1000)，用户(1002) *(type)*
     // offset: 起始点
     // limit: 数量
     pub fn search(
         &mut self,
         keywords: &str,
-        types: u32,
+        types: SearchRequestType,
         offset: u16,
         limit: u16,
     ) -> Result<Vec<SongTag>> {
         let path = "/weapi/search/get";
         let mut params = HashMap::new();
-        let types_str = &types.to_string();
+        let types_str = (types as usize).to_string();
         let offset = &offset.to_string();
         let limit = &limit.to_string();
         params.insert("s", keywords);
-        params.insert("type", types_str);
+        params.insert("type", types_str.as_str());
         params.insert("offset", offset);
         params.insert("limit", limit);
         let result = self.request(Method::Post, path, params, CryptoApi::Weapi, "")?;
@@ -176,7 +187,7 @@ impl Api {
         // file.write_all(result.as_bytes()).expect("write failed");
 
         match types {
-            1 => {
+            SearchRequestType::Single => {
                 let songtag_vec =
                     to_song_info(&result, Parse::Search).ok_or_else(|| anyhow!("Search Error"))?;
                 Ok(songtag_vec)

--- a/lib/src/songtag/netease/mod.rs
+++ b/lib/src/songtag/netease/mod.rs
@@ -5,7 +5,7 @@
  */
 mod model;
 
-use super::encrypt::Crypto;
+use super::{encrypt::Crypto, SongTag};
 use anyhow::{anyhow, bail, Result};
 use lazy_static::lazy_static;
 use lofty::Picture;
@@ -159,7 +159,7 @@ impl Api {
         types: u32,
         offset: u16,
         limit: u16,
-    ) -> Result<String> {
+    ) -> Result<Vec<SongTag>> {
         let path = "/weapi/search/get";
         let mut params = HashMap::new();
         let types_str = &types.to_string();
@@ -179,8 +179,7 @@ impl Api {
             1 => {
                 let songtag_vec =
                     to_song_info(&result, Parse::Search).ok_or_else(|| anyhow!("Search Error"))?;
-                let songtag_string = serde_json::to_string(&songtag_vec)?;
-                Ok(songtag_string)
+                Ok(songtag_vec)
             }
             _ => bail!("None Error"),
         }

--- a/lib/src/songtag/netease/model.rs
+++ b/lib/src/songtag/netease/model.rs
@@ -241,3 +241,159 @@ pub enum Parse {
     Search,
     Usl,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_songinfo() {
+        let sample_data = r#"{
+            "result": {
+              "songs": [
+                {
+                  "id": 1000000000,
+                  "name": "Track A",
+                  "artists": [
+                    {
+                      "id": 3333333,
+                      "name": "Some Artist",
+                      "picUrl": null,
+                      "alias": [],
+                      "albumSize": 0,
+                      "picId": 0,
+                      "fansGroup": null,
+                      "img1v1Url": "https://p3.music.126.net/AAAAAAAAAAAAAAAAAAAAAAAA/0000000000000000.jpg",
+                      "img1v1": 0,
+                      "trans": null
+                    }
+                  ],
+                  "album": {
+                    "id": 100000001,
+                    "name": "Some Album 1",
+                    "artist": {
+                      "id": 0,
+                      "name": "",
+                      "picUrl": null,
+                      "alias": [],
+                      "albumSize": 0,
+                      "picId": 0,
+                      "fansGroup": null,
+                      "img1v1Url": "https://p3.music.126.net/AAAAAAAAAAAAAAAAAAAAAAAA/0000000000000000.jpg",
+                      "img1v1": 0,
+                      "trans": null
+                    },
+                    "publishTime": 1111111111111,
+                    "size": 6,
+                    "copyrightId": 1111,
+                    "status": 1,
+                    "picId": 444444444444444444,
+                    "mark": 0
+                  },
+                  "duration": 89595,
+                  "copyrightId": 1111,
+                  "status": 0,
+                  "alias": [],
+                  "rtype": 0,
+                  "ftype": 0,
+                  "mvid": 0,
+                  "fee": 1,
+                  "rUrl": null,
+                  "mark": 66666666666
+                },
+                {
+                  "id": 1111111111,
+                  "name": "Track B",
+                  "artists": [
+                    {
+                      "id": 3333333,
+                      "name": "Some Artist",
+                      "picUrl": null,
+                      "alias": [],
+                      "albumSize": 0,
+                      "picId": 0,
+                      "fansGroup": null,
+                      "img1v1Url": "https://p4.music.126.net/AAAAAAAAAAAAAAAAAAAAAAAA/0000000000000000.jpg",
+                      "img1v1": 0,
+                      "trans": null
+                    }
+                  ],
+                  "album": {
+                    "id": 11111112,
+                    "name": "Some Album 2",
+                    "artist": {
+                      "id": 0,
+                      "name": "",
+                      "picUrl": null,
+                      "alias": [],
+                      "albumSize": 0,
+                      "picId": 0,
+                      "fansGroup": null,
+                      "img1v1Url": "https://p3.music.126.net/AAAAAAAAAAAAAAAAAAAAAAAA/0000000000000000.jpg",
+                      "img1v1": 0,
+                      "trans": null
+                    },
+                    "publishTime": 2222222222222,
+                    "size": 4,
+                    "copyrightId": 1111,
+                    "status": 1,
+                    "picId": 555555555555555555,
+                    "mark": 0
+                  },
+                  "duration": 158143,
+                  "copyrightId": 1111,
+                  "status": 0,
+                  "alias": [],
+                  "rtype": 0,
+                  "ftype": 0,
+                  "mvid": 8888888,
+                  "fee": 1,
+                  "rUrl": null,
+                  "mark": 77777777777
+                }
+              ],
+              "hasMore": false,
+              "songCount": 20
+            },
+            "code": 200
+          }"#;
+
+        let res = to_song_info(sample_data, Parse::Search).unwrap();
+
+        assert_eq!(res.len(), 2);
+
+        const ARTIST: &str = "Some Artist";
+
+        assert_eq!(
+            res[0],
+            SongTag {
+                artist: Some(ARTIST.to_owned()),
+                title: Some("Track A".to_owned()),
+                album: Some("Some Album 1".to_owned()),
+                lang_ext: Some("netease".to_string()),
+                service_provider: Some(ServiceProvider::Netease),
+                song_id: Some("1000000000".to_owned()),
+                lyric_id: Some("1000000000".to_owned()),
+                url: Some("Copyright protected".to_owned()),
+                pic_id: Some("444444444444444444".to_owned()),
+                album_id: Some("444444444444444444".to_owned())
+            }
+        );
+
+        assert_eq!(
+            res[1],
+            SongTag {
+                artist: Some(ARTIST.to_owned()),
+                title: Some("Track B".to_owned()),
+                album: Some("Some Album 2".to_owned()),
+                lang_ext: Some("netease".to_string()),
+                service_provider: Some(ServiceProvider::Netease),
+                song_id: Some("1111111111".to_owned()),
+                lyric_id: Some("1111111111".to_owned()),
+                url: Some("Copyright protected".to_owned()),
+                pic_id: Some("555555555555555555".to_owned()),
+                album_id: Some("555555555555555555".to_owned())
+            }
+        );
+    }
+}


### PR DESCRIPTION
This PR refactors some parts in lib::songtag, most notably changing to use async-reqwest instead of blocking, other changes:
- change `Service*::search`'s parameter `types` to be a enum instead of magic numbers
- add some derives to `SongTag` (and dependencies) for logging and comparing
- add tests for the `to_song_info` for each service (except kugou, because of empty response)
- dont serialize and then immediately deserialize the return vectors
- convert `static: &str` to `const: &str`

Now there is only 1 usage of `reqwest::blocking` anymore, that being `lib::podcast` (and a unreferenced module in `playback::rusty::source::http`)