### PR TITLE
Some Media-Controls(mpris) refactors

### DIFF
--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -273,6 +273,19 @@ impl GeneralPlayer {
         Self::new_backend(BackendSelect::Default, config, cmd_tx)
     }
 
+    /// Reload the config from file, on fail continue to use the old
+    ///
+    /// # Errors
+    ///
+    /// - if Config could not be parsed
+    pub fn reload_config(&self) -> Result<()> {
+        info!("Reloading config");
+        self.config.write().load()?;
+        info!("Config Reloaded");
+
+        Ok(())
+    }
+
     fn get_player(&self) -> &dyn PlayerTrait {
         self.backend.as_player()
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -220,7 +220,7 @@ pub struct GeneralPlayer {
     pub playlist: Playlist,
     pub config: SharedSettings,
     pub current_track_updated: bool,
-    pub mpris: mpris::Mpris,
+    pub mpris: Option<mpris::Mpris>,
     pub discord: discord::Rpc,
     pub db: DataBase,
     pub db_podcast: DBPod,
@@ -249,12 +249,17 @@ impl GeneralPlayer {
 
         let config = Arc::new(RwLock::new(config));
         let playlist = Playlist::new(config.clone()).unwrap_or_default();
+        let mpris = if config.read().player_use_mpris {
+            Some(mpris::Mpris::new(cmd_tx.clone()))
+        } else {
+            None
+        };
 
         Ok(Self {
             backend,
             playlist,
             config,
-            mpris: mpris::Mpris::new(cmd_tx.clone()),
+            mpris,
             discord: discord::Rpc::default(),
             db,
             db_podcast,
@@ -278,9 +283,26 @@ impl GeneralPlayer {
     /// # Errors
     ///
     /// - if Config could not be parsed
-    pub fn reload_config(&self) -> Result<()> {
+    pub fn reload_config(&mut self) -> Result<()> {
         info!("Reloading config");
-        self.config.write().load()?;
+        let mut config = self.config.write();
+        config.load()?;
+
+        if config.player_use_mpris && self.mpris.is_none() {
+            // start mpris if new config has it enabled, but is not active yet
+            let mut mpris = mpris::Mpris::new(self.cmd_tx.clone());
+            // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
+            if let Some(track) = self.playlist.current_track() {
+                mpris.add_and_play(track);
+            }
+            // the same for volume
+            mpris.update_volume(self.volume());
+            self.mpris.replace(mpris);
+        } else if !config.player_use_mpris && self.mpris.is_some() {
+            // stop mpris if new config does not have it enabled, but is currently active
+            self.mpris.take();
+        }
+
         info!("Config Reloaded");
 
         Ok(())
@@ -346,8 +368,8 @@ impl GeneralPlayer {
     fn add_and_play_mpris_discord(&mut self) {
         if let Some(track) = self.playlist.current_track() {
             let config = self.config.read();
-            if config.player_use_mpris {
-                self.mpris.add_and_play(track);
+            if let Some(ref mut mpris) = self.mpris {
+                mpris.add_and_play(track);
             }
 
             if config.player_use_discord {
@@ -394,8 +416,8 @@ impl GeneralPlayer {
             Status::Running => {
                 self.get_player_mut().pause();
                 let config = self.config.read();
-                if config.player_use_mpris {
-                    self.mpris.pause();
+                if let Some(ref mut mpris) = self.mpris {
+                    mpris.pause();
                 }
                 if config.player_use_discord {
                     self.discord.pause();
@@ -406,8 +428,8 @@ impl GeneralPlayer {
             Status::Paused => {
                 self.get_player_mut().resume();
                 let config = self.config.read();
-                if config.player_use_mpris {
-                    self.mpris.resume();
+                if let Some(ref mut mpris) = self.mpris {
+                    mpris.resume();
                 }
                 if config.player_use_discord {
                     let time_pos = self.get_player().position();
@@ -423,8 +445,8 @@ impl GeneralPlayer {
             Status::Running => {
                 self.get_player_mut().pause();
                 let config = self.config.read();
-                if config.player_use_mpris {
-                    self.mpris.pause();
+                if let Some(ref mut mpris) = self.mpris {
+                    mpris.pause();
                 }
                 if config.player_use_discord {
                     self.discord.pause();
@@ -441,8 +463,8 @@ impl GeneralPlayer {
             Status::Paused => {
                 self.get_player_mut().resume();
                 let config = self.config.read();
-                if config.player_use_mpris {
-                    self.mpris.resume();
+                if let Some(ref mut mpris) = self.mpris {
+                    mpris.resume();
                 }
                 if config.player_use_discord {
                     let time_pos = self.get_player().position();

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -227,11 +227,17 @@ impl GeneralPlayer {
             self.mpris_handler(m);
         }
 
-        self.mpris.update_volume(self.volume());
-
         if let Some(progress) = self.get_progress() {
             self.mpris
                 .update_progress(progress.position, self.playlist.status());
+        }
+    }
+
+    /// Update Media-Controls reported volume, if enabled to be reporting
+    #[inline]
+    pub fn mpris_volume_update(&mut self) {
+        if self.config.read().player_use_mpris {
+            self.mpris.update_volume(self.volume());
         }
     }
 }

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -3,7 +3,9 @@ use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, P
 use std::sync::mpsc::{self, Receiver};
 use termusiclib::track::Track;
 
-use crate::{GeneralPlayer, PlayerCmd, PlayerTimeUnit, PlayerTrait, Status, Volume};
+use crate::{
+    GeneralPlayer, PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait, Status, Volume,
+};
 
 pub struct Mpris {
     controls: MediaControls,
@@ -226,8 +228,12 @@ impl GeneralPlayer {
         if let Ok(m) = self.mpris.rx.try_recv() {
             self.mpris_handler(m);
         }
+    }
 
-        if let Some(progress) = self.get_progress() {
+    /// Update Media-Controls reported Position & Status, if enabled to be reporting
+    #[inline]
+    pub fn mpris_update_progress(&mut self, progress: &PlayerProgress) {
+        if self.config.read().player_use_mpris {
             self.mpris
                 .update_progress(progress.position, self.playlist.status());
         }

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -224,9 +224,12 @@ impl GeneralPlayer {
         }
     }
 
-    pub fn update_mpris(&mut self) {
-        if let Ok(m) = self.mpris.rx.try_recv() {
-            self.mpris_handler(m);
+    /// Handle Media-Controls events, if enabled to be used
+    pub fn mpris_handle_events(&mut self) {
+        if self.config.read().player_use_mpris {
+            if let Ok(m) = self.mpris.rx.try_recv() {
+                self.mpris_handler(m);
+            }
         }
     }
 

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -226,8 +226,8 @@ impl GeneralPlayer {
 
     /// Handle Media-Controls events, if enabled to be used
     pub fn mpris_handle_events(&mut self) {
-        if self.config.read().player_use_mpris {
-            if let Ok(m) = self.mpris.rx.try_recv() {
+        if let Some(ref mut mpris) = self.mpris {
+            if let Ok(m) = mpris.rx.try_recv() {
                 self.mpris_handler(m);
             }
         }
@@ -236,17 +236,17 @@ impl GeneralPlayer {
     /// Update Media-Controls reported Position & Status, if enabled to be reporting
     #[inline]
     pub fn mpris_update_progress(&mut self, progress: &PlayerProgress) {
-        if self.config.read().player_use_mpris {
-            self.mpris
-                .update_progress(progress.position, self.playlist.status());
+        if let Some(ref mut mpris) = self.mpris {
+            mpris.update_progress(progress.position, self.playlist.status());
         }
     }
 
     /// Update Media-Controls reported volume, if enabled to be reporting
     #[inline]
     pub fn mpris_volume_update(&mut self) {
-        if self.config.read().player_use_mpris {
-            self.mpris.update_volume(self.volume());
+        let volume = self.volume();
+        if let Some(ref mut mpris) = self.mpris {
+            mpris.update_volume(volume);
         }
     }
 }

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -128,6 +128,7 @@ impl Mpris {
     /// Update the Volume reported by Media-Controls
     ///
     /// currently only does something on linux (mpris)
+    #[allow(unused_variables)] // non-linux targets will complain about unused parameters
     pub fn update_volume(&mut self, volume: Volume) {
         // currently "set_volume" only exists for "linux"(mpris)
         #[cfg(target_os = "linux")]

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -128,7 +128,7 @@ impl Mpris {
     /// Update the Volume reported by Media-Controls
     ///
     /// currently only does something on linux (mpris)
-    #[allow(unused_variables)] // non-linux targets will complain about unused parameters
+    #[allow(unused_variables, clippy::unused_self)] // non-linux targets will complain about unused parameters
     pub fn update_volume(&mut self, volume: Volume) {
         // currently "set_volume" only exists for "linux"(mpris)
         #[cfg(target_os = "linux")]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -214,8 +214,9 @@ fn player_loop(
                 player.previous();
             }
             PlayerCmd::ReloadConfig => {
-                player.config.write().load()?;
-                info!("config reloaded");
+                if let Err(err) = player.reload_config() {
+                    error!("Reloading config failed, using old: {:#?}", err);
+                }
             }
             PlayerCmd::ReloadPlaylist => {
                 player.playlist.reload_tracks().ok();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -331,6 +331,7 @@ fn player_loop(
                 info!("after volumedown: {}", new_volume);
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
+                player.mpris_volume_update();
             }
             PlayerCmd::VolumeUp => {
                 info!("before volumeup: {}", player.volume());
@@ -339,6 +340,7 @@ fn player_loop(
                 info!("after volumeup: {}", new_volume);
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
+                player.mpris_volume_update();
             }
             PlayerCmd::Pause => {
                 player.pause();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -256,9 +256,7 @@ fn player_loop(
             }
             PlayerCmd::Tick => {
                 // info!("tick received");
-                if player.config.read().player_use_mpris {
-                    player.update_mpris();
-                }
+                player.mpris_handle_events();
                 let mut p_tick = playerstats.lock();
                 p_tick.status = player.playlist.status().as_u32();
                 // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -276,7 +276,8 @@ fn player_loop(
                     continue;
                 }
                 if let Some(progress) = player.get_progress() {
-                    p_tick.progress = progress
+                    p_tick.progress = progress;
+                    player.mpris_update_progress(&p_tick.progress);
                 }
                 if player.current_track_updated {
                     p_tick.current_track_index = player.playlist.get_current_track_index() as u32;


### PR DESCRIPTION
This PR refactor the Media-Controls(mpris) to be in a better shape and more responsive, which includes:
- set volume on volume events (instead of on every tick)
- set progress to actual new progress (instead of using the old / stale progress)
- dont start mpris if not wanted (and restart / stop on config change)
- move reloading config logic to a separate function
- general refactors to have some separate functions for mpris things (change volume, handle events, update progress)