### PR TITLE
Update terminal cover printing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Change: use more specific versions instead of just the major version (lib.rs suggestion).
 - Change: remove unused dependencies from all packages.
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
-- Change(tui): rename previous feature `cover` to `cover-uberzug`
+- Change(tui): rename previous feature `cover` to `cover-ueberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
 - Feat(tui): allow Sixel to be used for covers.
 - Feat(tui): allow all cover providers to not be compiled in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change: use more specific versions instead of just the major version (lib.rs suggestion).
 - Change: remove unused dependencies from all packages.
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
+- Change(tui): rename previous feature `cover` to `cover-uberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
 - Fix: allow backends to be compiled in for `termusic-playback` but not in `termusic-server`.
 - Fix: on backend mpv, clear media-title on EndOfFile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
 - Change(tui): rename previous feature `cover` to `cover-uberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
+- Feat(tui): allow Sixel to be used for covers.
+- Feat(tui): allow all cover providers to not be compiled in.
 - Fix: allow backends to be compiled in for `termusic-playback` but not in `termusic-server`.
 - Fix: on backend mpv, clear media-title on EndOfFile.
 - Fix: consistent media-title(/radio-title) handling across all backends.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,6 @@ dependencies = [
  "tui-realm-treeview",
  "tuirealm",
  "unicode-width",
- "urlencoding",
  "viuer",
  "walkdir",
  "wildmatch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "make-cmd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3544,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "sixel-rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa95c014543113a192d906e5971d0c8d1e8b4cc1e61026539687a7016644ce5"
+dependencies = [
+ "sixel-sys",
+]
+
+[[package]]
+name = "sixel-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb46e0cd5569bf910390844174a5a99d52dd40681fff92228d221d9f8bf87dea"
+dependencies = [
+ "make-cmd",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,6 +4716,7 @@ dependencies = [
  "crossterm 0.27.0",
  "image",
  "lazy_static",
+ "sixel-rs",
  "tempfile",
  "termcolor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ tui-realm-treeview = "~1.1"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2.1"
-viuer = { version = "0.7", features = ["sixel"] }
+viuer = "0.7"
 walkdir = "2.5"
 wildmatch = "2.3"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,8 +106,7 @@ tui-realm-treeview = "~1.1"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2.1"
-# viuer = { version = "0.7", features = ["sixel"] }
-viuer = "0.7"
+viuer = { version = "0.7", features = ["sixel"] }
 walkdir = "2.5"
 wildmatch = "2.3"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -59,9 +59,12 @@ parking_lot.workspace = true
 
 
 [features]
-default = ["cover-viuer"]
+# enable all cover features by default that do not require system interfaces / extra dependencies
+default = ["cover-viuer-iterm", "cover-viuer-kitty"]
+# enable all terminal cover printers
 cover = ["cover-uberzug", "cover-viuer"]
 cover-uberzug = []
+# enable all viuer protocols
 cover-viuer = ["cover-viuer-iterm", "cover-viuer-kitty", "cover-viuer-sixel"]
 cover-viuer-iterm = []
 cover-viuer-kitty = []

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -70,6 +70,7 @@ parking_lot.workspace = true
 
 
 [features]
+default = ["cover-viuer"]
 # left for debug
 # default = ["gst"]
 # default = ["mpv"]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -62,8 +62,8 @@ parking_lot.workspace = true
 # enable all cover features by default that do not require system interfaces / extra dependencies
 default = ["cover-viuer-iterm", "cover-viuer-kitty"]
 # enable all terminal cover printers
-cover = ["cover-uberzug", "cover-viuer"]
-cover-uberzug = []
+cover = ["cover-ueberzug", "cover-viuer"]
+cover-ueberzug = []
 # enable all viuer protocols
 cover-viuer = ["cover-viuer-iterm", "cover-viuer-kitty", "cover-viuer-sixel"]
 cover-viuer-iterm = []

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -49,23 +49,13 @@ viuer.workspace = true
 ytd-rs.workspace = true #   = { version = "0.1", features = ["yt-dlp"]}
 walkdir.workspace = true #   = "2"
 wildmatch.workspace = true #   = "2"
-# opml.workspace = true #   = "1"
-# chrono.workspace = true #   = "^0.4.23"
-# rss.workspace = true #   = "2"
-# rfc822_sanitizer.workspace = true #   = "0.3" 
-# ahash.workspace = true #   = "^0.8"
-# semver.workspace = true #   = "^1"
 escaper.workspace = true #   = "0.1.1"
 textwrap.workspace = true #   = "0.16"
-# bytes.workspace = true #   = "1"
-# unicode-segmentation.workspace = true #   = "1.10"
 sanitize-filename.workspace = true #   = "0.4"
 percent-encoding.workspace = true #   = "2.2"
 tonic.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
-# reqwest = { version="0.11", features = ["stream"] }
-# tokio = { version = "1", features = ["full"] }
 parking_lot.workspace = true
 
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -70,14 +70,13 @@ parking_lot.workspace = true
 
 
 [features]
-# default = ["cover"]
 # left for debug
 # default = ["gst"]
 # default = ["mpv"]
 # default = ["discord"]
 # mpris = ["souvlaki"]
 # cover = ["tempfile"]
-cover = []
+cover-uberzug = []
 # discord = ["discord-rich-presence"]
 
 [dev-dependencies]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -45,8 +45,7 @@ tui-realm-stdlib.workspace = true #   = "1"
 tui-realm-treeview.workspace = true #   = "1"
 unicode-width.workspace = true #   = "^0.1.8"
 urlencoding.workspace = true #   = "2"
-# viuer = { version = "0.6", features = ["sixel"] }
-viuer.workspace = true #   = "0.6"
+viuer.workspace = true
 ytd-rs.workspace = true #   = { version = "0.1", features = ["yt-dlp"]}
 walkdir.workspace = true #   = "2"
 wildmatch.workspace = true #   = "2"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -77,6 +77,10 @@ parking_lot.workspace = true
 # mpris = ["souvlaki"]
 # cover = ["tempfile"]
 cover-uberzug = []
+cover-viuer = ["cover-viuer-iterm", "cover-viuer-kitty", "cover-viuer-sixel"]
+cover-viuer-iterm = []
+cover-viuer-kitty = []
+cover-viuer-sixel = ["viuer/sixel"]
 # discord = ["discord-rich-presence"]
 
 [dev-dependencies]

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -71,18 +71,11 @@ parking_lot.workspace = true
 
 [features]
 default = ["cover-viuer"]
-# left for debug
-# default = ["gst"]
-# default = ["mpv"]
-# default = ["discord"]
-# mpris = ["souvlaki"]
-# cover = ["tempfile"]
 cover-uberzug = []
 cover-viuer = ["cover-viuer-iterm", "cover-viuer-kitty", "cover-viuer-sixel"]
 cover-viuer-iterm = []
 cover-viuer-kitty = []
 cover-viuer-sixel = ["viuer/sixel"]
-# discord = ["discord-rich-presence"]
 
 [dev-dependencies]
 pretty_assertions.workspace = true # = "1"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -44,7 +44,6 @@ tuirealm.workspace = true #   = { version = "1", features = ["serialize"] }
 tui-realm-stdlib.workspace = true #   = "1"
 tui-realm-treeview.workspace = true #   = "1"
 unicode-width.workspace = true #   = "^0.1.8"
-urlencoding.workspace = true #   = "2"
 viuer.workspace = true
 ytd-rs.workspace = true #   = { version = "0.1", features = ["yt-dlp"]}
 walkdir.workspace = true #   = "2"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -61,6 +61,7 @@ parking_lot.workspace = true
 
 [features]
 default = ["cover-viuer"]
+cover = ["cover-uberzug", "cover-viuer"]
 cover-uberzug = []
 cover-viuer = ["cover-viuer-iterm", "cover-viuer-kitty", "cover-viuer-sixel"]
 cover-viuer-iterm = []

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -103,7 +103,6 @@ impl Model {
     /// Requires that the current thread has a entered runtime
     #[allow(clippy::cast_possible_truncation)]
     pub fn update_photo(&mut self) -> Result<()> {
-        #[cfg(feature = "cover")]
         if self.config.read().disable_album_art_from_cli {
             return Ok(());
         }
@@ -231,7 +230,7 @@ impl Model {
                             .map_err(|e| anyhow!("viuer print error: {}", e))?;
                     }
                     ViuerSupported::NotSupported => {
-                        #[cfg(all(feature = "cover", not(target_os = "windows")))]
+                        #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
                         {
                             let mut cache_file =
                                 dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
@@ -275,7 +274,7 @@ impl Model {
             // }
             // ViuerSupported::NotSupported | ViuerSupported::Sixel => {
             ViuerSupported::NotSupported => {
-                #[cfg(all(feature = "cover", not(target_os = "windows")))]
+                #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
                 self.ueberzug_instance.clear_cover_ueberzug()?;
             }
         }

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -301,7 +301,6 @@ impl Model {
     ))]
     fn clear_image_viuer_kitty(&mut self) -> Result<()> {
         write!(self.terminal.raw_mut().backend_mut(), "\x1b_Ga=d\x1b\\")?;
-        // write!(self.terminal.raw_mut().backend_mut(), "\x1b_Ga=d\x1b\\")?;
         self.terminal.raw_mut().backend_mut().flush()?;
         Ok(())
     }

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -142,14 +142,18 @@ impl Model {
                 }
             }
             MediaType::Podcast => {
-                let mut url = String::new();
-                if let Some(episode_photo_url) = track.album_photo() {
-                    url = episode_photo_url.to_string();
-                } else if let Some(pod_photo_url) =
-                    self.podcast_get_album_photo_by_url(track.file().unwrap_or(""))
-                {
-                    url = pod_photo_url;
-                }
+                let url = {
+                    if let Some(episode_photo_url) = track.album_photo() {
+                        episode_photo_url.to_string()
+                    } else if let Some(pod_photo_url) = track
+                        .file()
+                        .and_then(|file| self.podcast_get_album_photo_by_url(file))
+                    {
+                        pod_photo_url
+                    } else {
+                        return Ok(());
+                    }
+                };
 
                 if url.is_empty() {
                     return Ok(());

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -122,7 +122,7 @@ impl Model {
         if self.should_not_show_photo() {
             return Ok(());
         }
-        let Some(track) = self.playlist.current_track().cloned() else {
+        let Some(track) = self.playlist.current_track() else {
             return Ok(());
         };
 

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -293,12 +293,6 @@ impl Model {
                     .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
                 // sixel does not use temp-files, so no cleaning necessary
             }
-            // ViuerSupported::ITerm => {
-            //     // FIXME: This is a total clear of the whole screen. I haven't found a better way to clear
-            //     // iterm images
-            //     self.terminal.raw_mut().clear()?;
-            // }
-            // ViuerSupported::NotSupported | ViuerSupported::Sixel => {
             ViuerSupported::NotSupported => {
                 #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
                 self.ueberzug_instance.clear_cover_ueberzug()?;

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -235,7 +235,7 @@ impl Model {
                         std::fs::create_dir_all(&cache_file)?;
                     }
                     cache_file.push("termusic_cover.jpg");
-                    img.save(cache_file.clone())?;
+                    img.save(&cache_file)?;
                     if !cache_file.exists() {
                         anyhow::bail!("cover file is not saved correctly");
                     }

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -22,12 +22,6 @@
  * SOFTWARE.
  */
 use crate::ui::model::{Model, ViuerSupported};
-#[cfg(any(
-    feature = "cover-viuer-iterm",
-    feature = "cover-viuer-kitty",
-    feature = "cover-viuer-sixel"
-))]
-use anyhow::anyhow;
 use anyhow::{Context, Result};
 use bytes::Buf;
 use image::io::Reader as ImageReader;
@@ -277,19 +271,19 @@ impl Model {
             #[cfg(feature = "cover-viuer-kitty")]
             ViuerSupported::Kitty => {
                 self.clear_image_viuer_kitty()
-                    .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
+                    .context("clear_photo kitty")?;
                 Self::remove_temp_files()?;
             }
             #[cfg(feature = "cover-viuer-iterm")]
             ViuerSupported::ITerm => {
                 self.clear_image_viuer_kitty()
-                    .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
+                    .context("clear_photo iterm")?;
                 Self::remove_temp_files()?;
             }
             #[cfg(feature = "cover-viuer-sixel")]
             ViuerSupported::Sixel => {
                 self.clear_image_viuer_kitty()
-                    .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
+                    .context("clear_photo sixel")?;
                 // sixel does not use temp-files, so no cleaning necessary
             }
             ViuerSupported::NotSupported => {

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -217,7 +217,7 @@ impl Model {
             Ok(xywh) => {
                 // error!("{:?}", self.viuer_supported);
                 match self.viuer_supported {
-                    ViuerSupported::Kitty | ViuerSupported::ITerm => {
+                    ViuerSupported::Kitty | ViuerSupported::ITerm | ViuerSupported::Sixel=> {
                         let config = viuer::Config {
                             transparent: true,
                             absolute_offset: true,
@@ -263,10 +263,11 @@ impl Model {
                     .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
                 Self::remove_temp_files()?;
             }
-            // ViuerSupported::Sixel => {
-            //     self.clear_image_viuer_kitty()
-            //         .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
-            // }
+            ViuerSupported::Sixel => {
+                self.clear_image_viuer_kitty()
+                    .map_err(|e| anyhow!("Clear album photo error: {}", e))?;
+                // sixel does not use temp-files, so no cleaning necessary
+            }
             // ViuerSupported::ITerm => {
             //     // FIXME: This is a total clear of the whole screen. I haven't found a better way to clear
             //     // iterm images

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -227,7 +227,7 @@ impl Model {
         // error!("{:?}", self.viuer_supported);
         match self.viuer_supported {
             ViuerSupported::NotSupported => {
-                #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+                #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
                 {
                     let mut cache_file = dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
                     cache_file.push("termusic");
@@ -289,7 +289,7 @@ impl Model {
                 // sixel does not use temp-files, so no cleaning necessary
             }
             ViuerSupported::NotSupported => {
-                #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+                #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
                 self.ueberzug_instance.clear_cover_ueberzug()?;
             }
         }

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -28,7 +28,7 @@ use crate::ui::Application;
 use termusiclib::sqlite::{DataBase, SearchCriteria};
 use termusiclib::types::{Id, Msg, SearchLyricState, YoutubeOptions};
 
-#[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+#[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
 use termusiclib::ueberzug::UeInstance;
 use termusiclib::{
     config::Settings,
@@ -83,7 +83,7 @@ pub struct Model {
     pub time_pos: Duration,
     pub lyric_line: String,
     youtube_options: YoutubeOptions,
-    #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+    #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
     pub ueberzug_instance: UeInstance,
     pub songtag_options: Vec<SongTag>,
     pub sender_songtag: Sender<SearchLyricState>,
@@ -151,7 +151,7 @@ impl Model {
         let db_criteria = SearchCriteria::Artist;
         let terminal = TerminalBridge::new().expect("Could not initialize terminal");
 
-        #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+        #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
         let ueberzug_instance = UeInstance::default();
         let db_path = get_app_config_path().expect("failed to get podcast db path.");
 
@@ -191,7 +191,7 @@ impl Model {
             youtube_options: tokio::task::spawn_blocking(YoutubeOptions::default)
                 .await
                 .expect("Failed to initialize YoutubeOptions in a blocking task due to a panic"),
-            #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
+            #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
             ueberzug_instance,
             songtag_options: vec![],
             sender_songtag: tx3,

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -115,7 +115,7 @@ pub struct Model {
 pub enum ViuerSupported {
     Kitty,
     ITerm,
-    // Sixel,
+    Sixel,
     NotSupported,
 }
 
@@ -131,6 +131,8 @@ impl Model {
             viuer_supported = ViuerSupported::Kitty;
         } else if viuer::is_iterm_supported() {
             viuer_supported = ViuerSupported::ITerm;
+        } else if viuer::is_sixel_supported() {
+            viuer_supported = ViuerSupported::Sixel;
         }
         let db = DataBase::new(&config);
         let db_criteria = SearchCriteria::Artist;

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -28,7 +28,7 @@ use crate::ui::Application;
 use termusiclib::sqlite::{DataBase, SearchCriteria};
 use termusiclib::types::{Id, Msg, SearchLyricState, YoutubeOptions};
 
-#[cfg(all(feature = "cover", not(target_os = "windows")))]
+#[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
 use termusiclib::ueberzug::UeInstance;
 use termusiclib::{
     config::Settings,
@@ -83,7 +83,7 @@ pub struct Model {
     pub time_pos: Duration,
     pub lyric_line: String,
     youtube_options: YoutubeOptions,
-    #[cfg(all(feature = "cover", not(target_os = "windows")))]
+    #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
     pub ueberzug_instance: UeInstance,
     pub songtag_options: Vec<SongTag>,
     pub sender_songtag: Sender<SearchLyricState>,
@@ -140,7 +140,7 @@ impl Model {
         // let viuer_supported =
         //     viuer::KittySupport::None != viuer::get_kitty_support() || viuer::is_iterm_supported();
 
-        #[cfg(all(feature = "cover", not(target_os = "windows")))]
+        #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
         let ueberzug_instance = UeInstance::default();
         let db_path = get_app_config_path().expect("failed to get podcast db path.");
 
@@ -180,7 +180,7 @@ impl Model {
             youtube_options: tokio::task::spawn_blocking(YoutubeOptions::default)
                 .await
                 .expect("Failed to initialize YoutubeOptions in a blocking task due to a panic"),
-            #[cfg(all(feature = "cover", not(target_os = "windows")))]
+            #[cfg(all(feature = "cover-uberzug", not(target_os = "windows")))]
             ueberzug_instance,
             songtag_options: vec![],
             sender_songtag: tx3,


### PR DESCRIPTION
This PR updates the TUI's terminal cover printing support by:
- renaming original feature `cover` to `cover-uberzug`
- add possibility to enable viuer's `sixel` feature
- change cover printing to be behind feature flags (to allow completely not having any cover printing compiled-in)

In addition there are some other changes that went alongside this:
- remove commented-out dependencies in `tui`
- remove unused dependencies in `tui`
- remove unnecessary clones
- change error mapping to be contexts instead (to retain the original error's backtrace)
- some slight de-denting of nested match blocks
- in `show_image` consistently pass-on all errors instead of maybe mounting some error (let the calling function handle that)

PS: the default features reflect what the default was before this PR