### PR TITLE
Rename `Cmus*Queue` with more descriptive names

### DIFF
--- a/lib/src/config/key.rs
+++ b/lib/src/config/key.rs
@@ -72,8 +72,10 @@ pub struct Keys {
     pub playlist_search: BindingForEvent,
     pub playlist_swap_down: BindingForEvent,
     pub playlist_swap_up: BindingForEvent,
-    pub playlist_cmus_lqueue: BindingForEvent,
-    pub playlist_cmus_tqueue: BindingForEvent,
+    #[serde(rename = "playlist_cmus_lqueue")] // backwards compat, cannot easily be changed
+    pub playlist_add_random_album: BindingForEvent,
+    #[serde(rename = "playlist_cmus_tqueue")] // backwards compat, cannot easily be changed
+    pub playlist_add_random_tracks: BindingForEvent,
     pub database_add_all: BindingForEvent,
     pub config_save: BindingForEvent,
     pub podcast_mark_played: BindingForEvent,
@@ -151,8 +153,8 @@ impl Keys {
             .chain(once(self.playlist_search))
             .chain(once(self.playlist_swap_down))
             .chain(once(self.playlist_swap_up))
-            .chain(once(self.playlist_cmus_lqueue))
-            .chain(once(self.playlist_cmus_tqueue))
+            .chain(once(self.playlist_add_random_album))
+            .chain(once(self.playlist_add_random_tracks))
     }
 
     fn iter_podcast(&self) -> impl Iterator<Item = BindingForEvent> {
@@ -493,11 +495,11 @@ impl Default for Keys {
                 code: Key::Char('K'),
                 modifier: KeyModifiers::SHIFT,
             },
-            playlist_cmus_lqueue: BindingForEvent {
+            playlist_add_random_album: BindingForEvent {
                 code: Key::Char('S'),
                 modifier: KeyModifiers::SHIFT,
             },
-            playlist_cmus_tqueue: BindingForEvent {
+            playlist_add_random_tracks: BindingForEvent {
                 code: Key::Char('s'),
                 modifier: KeyModifiers::NONE,
             },

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -249,10 +249,10 @@ pub enum KFMsg {
     PlaylistSwapDownBlurUp,
     PlaylistSwapUpBlurDown,
     PlaylistSwapUpBlurUp,
-    PlaylistLqueueBlurDown,
-    PlaylistLqueueBlurUp,
-    PlaylistTqueueBlurDown,
-    PlaylistTqueueBlurUp,
+    PlaylistAddRandomAlbumBlurDown,
+    PlaylistAddRandomAlbumBlurUp,
+    PlaylistAddRandomTracksBlurDown,
+    PlaylistAddRandomTracksBlurUp,
     LibrarySwitchRootBlurDown,
     LibrarySwitchRootBlurUp,
     LibraryAddRootBlurDown,
@@ -388,11 +388,9 @@ pub enum PLMsg {
     /// Swap a entry at INDEX with -1 (up)
     SwapUp(usize),
     /// Start choosing random albums to be added to the playlist
-    // TODO: the shortform "CmusLQueue" should also be explained
-    CmusLQueue,
+    AddRandomAlbum,
     /// Start choosing random tracks to be added to the playlist
-    // TODO: the shortform "CmusTQueue" should also be explained
-    CmusTQueue,
+    AddRandomTracks,
 }
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GSMsg {
@@ -598,8 +596,8 @@ pub enum IdKey {
     PlaylistSearch,
     PlaylistSwapDown,
     PlaylistSwapUp,
-    PlaylistLqueue,
-    PlaylistTqueue,
+    PlaylistAddRandomAlbum,
+    PlaylistAddRandomTracks,
     LibrarySwitchRoot,
     LibraryAddRoot,
     LibraryRemoveRoot,

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1160,8 +1160,8 @@ impl KEModifierSelect {
             IdKey::PlaylistSearch => keys.playlist_search.mod_key(),
             IdKey::PlaylistSwapDown => keys.playlist_swap_down.mod_key(),
             IdKey::PlaylistSwapUp => keys.playlist_swap_up.mod_key(),
-            IdKey::PlaylistLqueue => keys.playlist_cmus_lqueue.mod_key(),
-            IdKey::PlaylistTqueue => keys.playlist_cmus_tqueue.mod_key(),
+            IdKey::PlaylistAddRandomAlbum => keys.playlist_add_random_album.mod_key(),
+            IdKey::PlaylistAddRandomTracks => keys.playlist_add_random_tracks.mod_key(),
             IdKey::LibrarySwitchRoot => keys.library_switch_root.mod_key(),
             IdKey::LibraryAddRoot => keys.library_add_root.mod_key(),
             IdKey::LibraryRemoveRoot => keys.library_remove_root.mod_key(),
@@ -2409,50 +2409,58 @@ impl Component<Msg, NoUserEvent> for ConfigGlobalConfig {
 }
 
 #[derive(MockComponent)]
-pub struct ConfigPlaylistLqueue {
+pub struct ConfigPlaylistAddRandomAlbum {
     component: KEModifierSelect,
 }
 
-impl ConfigPlaylistLqueue {
+impl ConfigPlaylistAddRandomAlbum {
     pub fn new(config: SharedSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
                 " Playlist Select Album ",
-                IdKey::PlaylistLqueue,
+                IdKey::PlaylistAddRandomAlbum,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(KFMsg::PlaylistLqueueBlurDown)),
-                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(KFMsg::PlaylistLqueueBlurUp)),
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(
+                    KFMsg::PlaylistAddRandomAlbumBlurDown,
+                )),
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(
+                    KFMsg::PlaylistAddRandomAlbumBlurUp,
+                )),
             ),
         }
     }
 }
 
-impl Component<Msg, NoUserEvent> for ConfigPlaylistLqueue {
+impl Component<Msg, NoUserEvent> for ConfigPlaylistAddRandomAlbum {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }
 }
 
 #[derive(MockComponent)]
-pub struct ConfigPlaylistTqueue {
+pub struct ConfigPlaylistAddRandomTracks {
     component: KEModifierSelect,
 }
 
-impl ConfigPlaylistTqueue {
+impl ConfigPlaylistAddRandomTracks {
     pub fn new(config: SharedSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
                 " Playlist Select Tracks ",
-                IdKey::PlaylistTqueue,
+                IdKey::PlaylistAddRandomTracks,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(KFMsg::PlaylistTqueueBlurDown)),
-                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(KFMsg::PlaylistTqueueBlurUp)),
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(
+                    KFMsg::PlaylistAddRandomTracksBlurDown,
+                )),
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(
+                    KFMsg::PlaylistAddRandomTracksBlurUp,
+                )),
             ),
         }
     }
 }
 
-impl Component<Msg, NoUserEvent> for ConfigPlaylistTqueue {
+impl Component<Msg, NoUserEvent> for ConfigPlaylistAddRandomTracks {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -666,7 +666,7 @@ impl Model {
                     .ok();
             }
 
-            KFMsg::PlaylistSwapUpBlurDown | KFMsg::PlaylistLqueueBlurUp => {
+            KFMsg::PlaylistSwapUpBlurDown | KFMsg::PlaylistAddRandomAlbumBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
                         IdKey::DatabaseAddAll,
@@ -674,23 +674,23 @@ impl Model {
                     .ok();
             }
 
-            KFMsg::DatabaseAddAllBlurDown | KFMsg::PlaylistTqueueBlurUp => {
+            KFMsg::DatabaseAddAllBlurDown | KFMsg::PlaylistAddRandomTracksBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
-                        IdKey::PlaylistLqueue,
+                        IdKey::PlaylistAddRandomAlbum,
                     )))
                     .ok();
             }
 
-            KFMsg::PlaylistLqueueBlurDown | KFMsg::LibrarySwitchRootBlurUp => {
+            KFMsg::PlaylistAddRandomAlbumBlurDown | KFMsg::LibrarySwitchRootBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
-                        IdKey::PlaylistTqueue,
+                        IdKey::PlaylistAddRandomTracks,
                     )))
                     .ok();
             }
 
-            KFMsg::PlaylistTqueueBlurDown | KFMsg::LibraryAddRootBlurUp => {
+            KFMsg::PlaylistAddRandomTracksBlurDown | KFMsg::LibraryAddRootBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
                         IdKey::LibrarySwitchRoot,
@@ -835,8 +835,12 @@ impl Model {
             IdKey::PlaylistSearch => self.ke_key_config.playlist_search = *binding,
             IdKey::PlaylistSwapDown => self.ke_key_config.playlist_swap_down = *binding,
             IdKey::PlaylistSwapUp => self.ke_key_config.playlist_swap_up = *binding,
-            IdKey::PlaylistLqueue => self.ke_key_config.playlist_cmus_lqueue = *binding,
-            IdKey::PlaylistTqueue => self.ke_key_config.playlist_cmus_tqueue = *binding,
+            IdKey::PlaylistAddRandomAlbum => {
+                self.ke_key_config.playlist_add_random_album = *binding;
+            }
+            IdKey::PlaylistAddRandomTracks => {
+                self.ke_key_config.playlist_add_random_tracks = *binding;
+            }
             IdKey::LibrarySwitchRoot => self.ke_key_config.library_switch_root = *binding,
             IdKey::LibraryAddRoot => self.ke_key_config.library_add_root = *binding,
             IdKey::LibraryRemoveRoot => self.ke_key_config.library_remove_root = *binding,

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -15,11 +15,11 @@ use crate::ui::components::{
     ConfigLibraryRemoveRoot, ConfigLibrarySearch, ConfigLibrarySearchYoutube,
     ConfigLibrarySwitchRoot, ConfigLibraryTagEditor, ConfigLibraryTitle, ConfigLibraryYank,
     ConfigLyricBackground, ConfigLyricBorder, ConfigLyricForeground, ConfigLyricTitle,
-    ConfigPlaylistBackground, ConfigPlaylistBorder, ConfigPlaylistDelete, ConfigPlaylistDeleteAll,
-    ConfigPlaylistForeground, ConfigPlaylistHighlight, ConfigPlaylistHighlightSymbol,
-    ConfigPlaylistLqueue, ConfigPlaylistModeCycle, ConfigPlaylistPlaySelected,
-    ConfigPlaylistSearch, ConfigPlaylistShuffle, ConfigPlaylistSwapDown, ConfigPlaylistSwapUp,
-    ConfigPlaylistTitle, ConfigPlaylistTqueue, ConfigPodcastDeleteAllFeeds,
+    ConfigPlaylistAddRandomAlbum, ConfigPlaylistAddRandomTracks, ConfigPlaylistBackground,
+    ConfigPlaylistBorder, ConfigPlaylistDelete, ConfigPlaylistDeleteAll, ConfigPlaylistForeground,
+    ConfigPlaylistHighlight, ConfigPlaylistHighlightSymbol, ConfigPlaylistModeCycle,
+    ConfigPlaylistPlaySelected, ConfigPlaylistSearch, ConfigPlaylistShuffle,
+    ConfigPlaylistSwapDown, ConfigPlaylistSwapUp, ConfigPlaylistTitle, ConfigPodcastDeleteAllFeeds,
     ConfigPodcastDeleteFeed, ConfigPodcastEpDeleteFile, ConfigPodcastEpDownload,
     ConfigPodcastMarkAllPlayed, ConfigPodcastMarkPlayed, ConfigPodcastRefreshAllFeeds,
     ConfigPodcastRefreshFeed, ConfigPodcastSearchAddFeed, ConfigProgressBackground,
@@ -1181,16 +1181,16 @@ impl Model {
             _ => 8,
         };
 
-        let select_playlist_lqueue_len = match self.app.state(&Id::ConfigEditor(
-            IdConfigEditor::Key(IdKey::PlaylistLqueue),
+        let select_playlist_random_album_len = match self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum),
         )) {
             Ok(State::One(_)) => 3,
             _ => 8,
         };
 
-        let tqueue_len = match self.app.state(&Id::ConfigEditor(IdConfigEditor::Key(
-            IdKey::PlaylistTqueue,
-        ))) {
+        let select_playlist_random_tracks_len = match self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::Key(IdKey::PlaylistAddRandomTracks),
+        )) {
             Ok(State::One(_)) => 3,
             _ => 8,
         };
@@ -1340,7 +1340,7 @@ impl Model {
                             Constraint::Length(select_playlist_swap_down_len),
                             Constraint::Length(select_playlist_swap_up_len),
                             Constraint::Length(select_database_add_all_len),
-                            Constraint::Length(select_playlist_lqueue_len),
+                            Constraint::Length(select_playlist_random_album_len),
                             Constraint::Min(0),
                         ]
                         .as_ref(),
@@ -1352,7 +1352,7 @@ impl Model {
                     .margin(0)
                     .constraints(
                         [
-                            Constraint::Length(tqueue_len),
+                            Constraint::Length(select_playlist_random_tracks_len),
                             Constraint::Length(library_switch_root_len),
                             Constraint::Length(library_add_root_len),
                             Constraint::Length(library_remove_root_len),
@@ -1473,13 +1473,13 @@ impl Model {
                     chunks_middle_column2[6],
                 );
                 self.app.view(
-                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistLqueue)),
+                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum)),
                     f,
                     chunks_middle_column2[7],
                 );
 
                 self.app.view(
-                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistTqueue)),
+                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomTracks)),
                     f,
                     chunks_middle_column3[0],
                 );
@@ -2263,8 +2263,8 @@ impl Model {
         assert!(self
             .app
             .remount(
-                Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistLqueue)),
-                Box::new(ConfigPlaylistLqueue::new(config.clone())),
+                Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum)),
+                Box::new(ConfigPlaylistAddRandomAlbum::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2272,8 +2272,8 @@ impl Model {
         assert!(self
             .app
             .remount(
-                Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistTqueue)),
-                Box::new(ConfigPlaylistTqueue::new(config.clone())),
+                Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomTracks)),
+                Box::new(ConfigPlaylistAddRandomTracks::new(config.clone())),
                 vec![],
             )
             .is_ok());
@@ -2828,13 +2828,13 @@ impl Model {
             .ok();
         self.app
             .umount(&Id::ConfigEditor(IdConfigEditor::Key(
-                IdKey::PlaylistLqueue,
+                IdKey::PlaylistAddRandomAlbum,
             )))
             .ok();
 
         self.app
             .umount(&Id::ConfigEditor(IdConfigEditor::Key(
-                IdKey::PlaylistTqueue,
+                IdKey::PlaylistAddRandomTracks,
             )))
             .ok();
 

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -344,9 +344,9 @@ impl Model {
     }
 
     pub fn playlist_add_random_tracks(&mut self) {
-        let playlist_select_random_album_quantity =
-            self.config.read().playlist_select_random_album_quantity;
-        let vec = self.playlist_get_random_tracks(playlist_select_random_album_quantity);
+        let playlist_select_random_track_quantity =
+            self.config.read().playlist_select_random_track_quantity;
+        let vec = self.playlist_get_random_tracks(playlist_select_random_track_quantity);
         self.playlist_add_all_from_db(&vec);
     }
 

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -187,11 +187,11 @@ impl Component<Msg, NoUserEvent> for Playlist {
                     _ => return Some(Msg::None),
                 }
             }
-            Event::Keyboard(key) if key == keys.playlist_cmus_lqueue.key_event() => {
-                return Some(Msg::Playlist(PLMsg::CmusLQueue));
+            Event::Keyboard(key) if key == keys.playlist_add_random_album.key_event() => {
+                return Some(Msg::Playlist(PLMsg::AddRandomAlbum));
             }
-            Event::Keyboard(key) if key == keys.playlist_cmus_tqueue.key_event() => {
-                return Some(Msg::Playlist(PLMsg::CmusTQueue));
+            Event::Keyboard(key) if key == keys.playlist_add_random_tracks.key_event() => {
+                return Some(Msg::Playlist(PLMsg::AddRandomTracks));
             }
             _ => CmdResult::None,
         };
@@ -336,17 +336,17 @@ impl Model {
         self.playlist_sync();
     }
 
-    pub fn playlist_add_cmus_lqueue(&mut self) {
+    pub fn playlist_add_random_album(&mut self) {
         let playlist_select_random_album_quantity =
             self.config.read().playlist_select_random_album_quantity;
-        let vec = self.playlist_get_records_for_cmus_lqueue(playlist_select_random_album_quantity);
+        let vec = self.playlist_get_random_album_tracks(playlist_select_random_album_quantity);
         self.playlist_add_all_from_db(&vec);
     }
 
-    pub fn playlist_add_cmus_tqueue(&mut self) {
+    pub fn playlist_add_random_tracks(&mut self) {
         let playlist_select_random_album_quantity =
             self.config.read().playlist_select_random_album_quantity;
-        let vec = self.playlist_get_records_for_cmus_tqueue(playlist_select_random_album_quantity);
+        let vec = self.playlist_get_random_tracks(playlist_select_random_album_quantity);
         self.playlist_add_all_from_db(&vec);
     }
 
@@ -561,7 +561,7 @@ impl Model {
             .is_ok());
     }
 
-    pub fn playlist_get_records_for_cmus_tqueue(&mut self, quantity: u32) -> Vec<TrackForDB> {
+    pub fn playlist_get_random_tracks(&mut self, quantity: u32) -> Vec<TrackForDB> {
         let mut result = vec![];
         if let Ok(vec) = self.db.get_all_records() {
             let mut i = 0;
@@ -583,7 +583,7 @@ impl Model {
         result
     }
 
-    pub fn playlist_get_records_for_cmus_lqueue(&mut self, quantity: u32) -> Vec<TrackForDB> {
+    pub fn playlist_get_random_album_tracks(&mut self, quantity: u32) -> Vec<TrackForDB> {
         let mut result = vec![];
         if let Ok(vec) = self.db.get_all_records() {
             loop {

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -231,8 +231,8 @@ impl HelpPopup {
                         .add_col(Self::comment("Swap track down/up in playlist"))
                         .add_row()
                         .add_col(Self::key(&[
-                            keys.playlist_cmus_tqueue,
-                            keys.playlist_cmus_lqueue,
+                            keys.playlist_add_random_tracks,
+                            keys.playlist_add_random_album,
                         ]))
                         .add_col(Self::comment("Select random tracks/albums to playlist"))
                         .add_row()

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -867,11 +867,11 @@ impl Model {
                     self.mount_error_popup(e.context("playlist sync playlist"));
                 }
             }
-            PLMsg::CmusLQueue => {
-                self.playlist_add_cmus_lqueue();
+            PLMsg::AddRandomAlbum => {
+                self.playlist_add_random_album();
             }
-            PLMsg::CmusTQueue => {
-                self.playlist_add_cmus_tqueue();
+            PLMsg::AddRandomTracks => {
+                self.playlist_add_random_tracks();
             }
             PLMsg::PlaylistTableBlurUp => match self.layout {
                 TermusicLayout::TreeView => assert!(self.app.active(&Id::Library).is_ok()),


### PR DESCRIPTION
~~Depends on #308 (as otherwise the tests would fail because of clippy)~~

This PR does 2 things:
- rename `Cmus*Queue` things to `AddRandomTracks` and `AddRandomAlbum`
- fix that `AddRandomTracks` made use of `playlist_select_random_album_quantity` instead of `playlist_select_random_track_quantity`