### PR TITLE
Fix README MSRV mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build status](https://github.com/tramhao/termusic/actions/workflows/build.yml/badge.svg)](https://github.com/tramhao/termusic/actions)
 [![crates.io](https://img.shields.io/crates/v/termusic.svg)](https://crates.io/crates/termusic)
 [![dependency status](https://deps.rs/repo/github/tramhao/termusic/status.svg)](https://deps.rs/repo/github/tramhao/termusic)
-[![MSRV](https://img.shields.io/badge/MSRV-1.74.0-blue)](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.75.0-blue)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
 # Terminal Music and Podcast Player written in Rust
 
 Listen to music and podcasts freely as both in freedom and free of charge!
@@ -54,7 +54,7 @@ Default backend: `rusty`
 ### Requirements
 
 #### MSRV
-You will need to build with the stable rust toolchain. Minimal Supported Rust Version 1.74.1.
+You will need to build with the stable rust toolchain. Minimal Supported Rust Version 1.75.0.
 
 ### git
 


### PR DESCRIPTION
~~Depends on #308 (as otherwise the tests would fail because of clippy)~~

This PR updates the README MSRV mentions to be 1.75 (which is the current actual MSRV)