### PR TITLE
Refactor config theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change: update some dependencies.
 - Change: use more specific versions instead of just the major version (lib.rs suggestion).
 - Change: remove unused dependencies from all packages.
+- Change: add config options to customize Important Popup colors (`style_color_symbol.important_popup_*`).
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
 - Change(tui): rename previous feature `cover` to `cover-ueberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change: use more specific versions instead of just the major version (lib.rs suggestion).
 - Change: remove unused dependencies from all packages.
 - Change: add config options to customize Important Popup colors (`style_color_symbol.important_popup_*`).
+- Change: add config options to customize fallback colors (`style_color_symbol.fallback_*`).
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
 - Change(tui): rename previous feature `cover` to `cover-ueberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix: on backend mpv, clear media-title on EndOfFile.
 - Fix: consistent media-title(/radio-title) handling across all backends.
 - Fix: use async-reqwest in all places (instead of `reqwest::blocking`, fixes debug builds in some areas).
+- Fix: colors from the config & yaml theme are now parsed at time of load, instead of on-demand.
 - Fix(tui): ensure the Quit-Popup always has top-most focus.
 - Fix(tui): also close a Error-Popup with global-quit(default `q`) key.
 - Fix(tui): use a common code-path for all `No/Yes`-Popups.

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -66,9 +66,8 @@ impl From<ColorTermusic> for String {
 }
 
 impl ColorTermusic {
-    pub fn color(self, alacritty_theme: &Alacritty) -> Option<Color> {
-        // TODO: change return type
-        Some(match self {
+    pub fn color(self, alacritty_theme: &Alacritty) -> Color {
+        match self {
             Self::Foreground => alacritty_theme.foreground.into(),
             Self::Background => alacritty_theme.background.into(),
             Self::Black => alacritty_theme.black.into(),
@@ -88,7 +87,7 @@ impl ColorTermusic {
             Self::LightCyan => alacritty_theme.light_cyan.into(),
             Self::LightWhite => alacritty_theme.light_white.into(),
             Self::Reset => Color::Reset,
-        })
+        }
     }
 
     pub const fn as_usize(self) -> usize {
@@ -170,72 +169,72 @@ impl Default for StyleColorSymbol {
 }
 
 impl StyleColorSymbol {
-    pub fn library_foreground(&self) -> Option<Color> {
+    pub fn library_foreground(&self) -> Color {
         self.library_foreground.color(&self.alacritty_theme)
     }
-    pub fn library_background(&self) -> Option<Color> {
+    pub fn library_background(&self) -> Color {
         self.library_background.color(&self.alacritty_theme)
     }
-    pub fn library_highlight(&self) -> Option<Color> {
+    pub fn library_highlight(&self) -> Color {
         self.library_highlight.color(&self.alacritty_theme)
     }
-    pub fn library_border(&self) -> Option<Color> {
+    pub fn library_border(&self) -> Color {
         self.library_border.color(&self.alacritty_theme)
     }
 
-    pub fn playlist_foreground(&self) -> Option<Color> {
+    pub fn playlist_foreground(&self) -> Color {
         self.playlist_foreground.color(&self.alacritty_theme)
     }
-    pub fn playlist_background(&self) -> Option<Color> {
+    pub fn playlist_background(&self) -> Color {
         self.playlist_background.color(&self.alacritty_theme)
     }
-    pub fn playlist_highlight(&self) -> Option<Color> {
+    pub fn playlist_highlight(&self) -> Color {
         self.playlist_highlight.color(&self.alacritty_theme)
     }
-    pub fn playlist_border(&self) -> Option<Color> {
+    pub fn playlist_border(&self) -> Color {
         self.playlist_border.color(&self.alacritty_theme)
     }
 
-    pub fn progress_foreground(&self) -> Option<Color> {
+    pub fn progress_foreground(&self) -> Color {
         self.progress_foreground.color(&self.alacritty_theme)
     }
-    pub fn progress_background(&self) -> Option<Color> {
+    pub fn progress_background(&self) -> Color {
         self.progress_background.color(&self.alacritty_theme)
     }
-    pub fn progress_border(&self) -> Option<Color> {
+    pub fn progress_border(&self) -> Color {
         self.progress_border.color(&self.alacritty_theme)
     }
 
-    pub fn lyric_foreground(&self) -> Option<Color> {
+    pub fn lyric_foreground(&self) -> Color {
         self.lyric_foreground.color(&self.alacritty_theme)
     }
-    pub fn lyric_background(&self) -> Option<Color> {
+    pub fn lyric_background(&self) -> Color {
         self.lyric_background.color(&self.alacritty_theme)
     }
-    pub fn lyric_border(&self) -> Option<Color> {
+    pub fn lyric_border(&self) -> Color {
         self.lyric_border.color(&self.alacritty_theme)
     }
 
-    pub fn important_popup_foreground(&self) -> Option<Color> {
+    pub fn important_popup_foreground(&self) -> Color {
         self.important_popup_foreground.color(&self.alacritty_theme)
     }
-    pub fn important_popup_background(&self) -> Option<Color> {
+    pub fn important_popup_background(&self) -> Color {
         self.important_popup_background.color(&self.alacritty_theme)
     }
-    pub fn important_popup_border(&self) -> Option<Color> {
+    pub fn important_popup_border(&self) -> Color {
         self.important_popup_border.color(&self.alacritty_theme)
     }
 
-    pub fn fallback_foreground(&self) -> Option<Color> {
+    pub fn fallback_foreground(&self) -> Color {
         self.fallback_foreground.color(&self.alacritty_theme)
     }
-    pub fn fallback_background(&self) -> Option<Color> {
+    pub fn fallback_background(&self) -> Color {
         self.fallback_background.color(&self.alacritty_theme)
     }
-    pub fn fallback_highlight(&self) -> Option<Color> {
+    pub fn fallback_highlight(&self) -> Color {
         self.fallback_highlight.color(&self.alacritty_theme)
     }
-    pub fn fallback_border(&self) -> Option<Color> {
+    pub fn fallback_border(&self) -> Color {
         self.fallback_border.color(&self.alacritty_theme)
     }
 }

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -103,17 +103,25 @@ pub struct StyleColorSymbol {
     pub library_border: ColorTermusic,
     pub library_highlight: ColorTermusic,
     pub library_highlight_symbol: String,
+
     pub playlist_foreground: ColorTermusic,
     pub playlist_background: ColorTermusic,
     pub playlist_border: ColorTermusic,
     pub playlist_highlight: ColorTermusic,
     pub playlist_highlight_symbol: String,
+
     pub progress_foreground: ColorTermusic,
     pub progress_background: ColorTermusic,
     pub progress_border: ColorTermusic,
+
     pub lyric_foreground: ColorTermusic,
     pub lyric_background: ColorTermusic,
     pub lyric_border: ColorTermusic,
+
+    pub important_popup_foreground: ColorTermusic,
+    pub important_popup_background: ColorTermusic,
+    pub important_popup_border: ColorTermusic,
+
     pub alacritty_theme: Alacritty,
     pub currently_playing_track_symbol: String,
 }
@@ -126,17 +134,25 @@ impl Default for StyleColorSymbol {
             library_border: ColorTermusic::Blue,
             library_highlight: ColorTermusic::LightYellow,
             library_highlight_symbol: "\u{1f984}".to_string(),
+
             playlist_foreground: ColorTermusic::Foreground,
             playlist_background: ColorTermusic::Reset,
             playlist_border: ColorTermusic::Blue,
             playlist_highlight: ColorTermusic::LightYellow,
             playlist_highlight_symbol: "\u{1f680}".to_string(),
+
             progress_foreground: ColorTermusic::LightBlack,
             progress_background: ColorTermusic::Reset,
             progress_border: ColorTermusic::Blue,
+
             lyric_foreground: ColorTermusic::Foreground,
             lyric_background: ColorTermusic::Reset,
             lyric_border: ColorTermusic::Blue,
+
+            important_popup_foreground: ColorTermusic::Yellow,
+            important_popup_background: ColorTermusic::Reset,
+            important_popup_border: ColorTermusic::Yellow,
+
             alacritty_theme: Alacritty::default(),
             currently_playing_track_symbol: "►".to_string(),
         }
@@ -147,7 +163,6 @@ impl StyleColorSymbol {
     pub fn library_foreground(&self) -> Option<Color> {
         self.library_foreground.color(&self.alacritty_theme)
     }
-
     pub fn library_background(&self) -> Option<Color> {
         self.library_background.color(&self.alacritty_theme)
     }
@@ -157,6 +172,7 @@ impl StyleColorSymbol {
     pub fn library_border(&self) -> Option<Color> {
         self.library_border.color(&self.alacritty_theme)
     }
+
     pub fn playlist_foreground(&self) -> Option<Color> {
         self.playlist_foreground.color(&self.alacritty_theme)
     }
@@ -169,6 +185,7 @@ impl StyleColorSymbol {
     pub fn playlist_border(&self) -> Option<Color> {
         self.playlist_border.color(&self.alacritty_theme)
     }
+
     pub fn progress_foreground(&self) -> Option<Color> {
         self.progress_foreground.color(&self.alacritty_theme)
     }
@@ -178,6 +195,7 @@ impl StyleColorSymbol {
     pub fn progress_border(&self) -> Option<Color> {
         self.progress_border.color(&self.alacritty_theme)
     }
+
     pub fn lyric_foreground(&self) -> Option<Color> {
         self.lyric_foreground.color(&self.alacritty_theme)
     }
@@ -186,6 +204,16 @@ impl StyleColorSymbol {
     }
     pub fn lyric_border(&self) -> Option<Color> {
         self.lyric_border.color(&self.alacritty_theme)
+    }
+
+    pub fn important_popup_foreground(&self) -> Option<Color> {
+        self.important_popup_foreground.color(&self.alacritty_theme)
+    }
+    pub fn important_popup_background(&self) -> Option<Color> {
+        self.important_popup_background.color(&self.alacritty_theme)
+    }
+    pub fn important_popup_border(&self) -> Option<Color> {
+        self.important_popup_border.color(&self.alacritty_theme)
     }
 }
 

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt::Display;
 use std::fs::File;
 use std::io::BufReader;
+use std::num::ParseIntError;
 use std::path::Path;
 use tuirealm::props::Color;
 
@@ -64,50 +67,33 @@ impl From<ColorTermusic> for String {
 
 impl ColorTermusic {
     pub fn color(self, alacritty_theme: &Alacritty) -> Option<Color> {
-        match self {
-            Self::Foreground => parse_hex_color(&alacritty_theme.foreground),
-            Self::Background => parse_hex_color(&alacritty_theme.background),
-            Self::Black => parse_hex_color(&alacritty_theme.black),
-            Self::Red => parse_hex_color(&alacritty_theme.red),
-            Self::Green => parse_hex_color(&alacritty_theme.green),
-            Self::Yellow => parse_hex_color(&alacritty_theme.yellow),
-            Self::Blue => parse_hex_color(&alacritty_theme.blue),
-            Self::Magenta => parse_hex_color(&alacritty_theme.magenta),
-            Self::Cyan => parse_hex_color(&alacritty_theme.cyan),
-            Self::White => parse_hex_color(&alacritty_theme.white),
-            Self::LightBlack => parse_hex_color(&alacritty_theme.light_black),
-            Self::LightRed => parse_hex_color(&alacritty_theme.light_red),
-            Self::LightGreen => parse_hex_color(&alacritty_theme.light_green),
-            Self::LightYellow => parse_hex_color(&alacritty_theme.light_yellow),
-            Self::LightBlue => parse_hex_color(&alacritty_theme.light_blue),
-            Self::LightMagenta => parse_hex_color(&alacritty_theme.light_magenta),
-            Self::LightCyan => parse_hex_color(&alacritty_theme.light_cyan),
-            Self::LightWhite => parse_hex_color(&alacritty_theme.light_white),
-            Self::Reset => Some(Color::Reset),
-        }
+        // TODO: change return type
+        Some(match self {
+            Self::Foreground => alacritty_theme.foreground.into(),
+            Self::Background => alacritty_theme.background.into(),
+            Self::Black => alacritty_theme.black.into(),
+            Self::Red => alacritty_theme.red.into(),
+            Self::Green => alacritty_theme.green.into(),
+            Self::Yellow => alacritty_theme.yellow.into(),
+            Self::Blue => alacritty_theme.blue.into(),
+            Self::Magenta => alacritty_theme.magenta.into(),
+            Self::Cyan => alacritty_theme.cyan.into(),
+            Self::White => alacritty_theme.white.into(),
+            Self::LightBlack => alacritty_theme.light_black.into(),
+            Self::LightRed => alacritty_theme.light_red.into(),
+            Self::LightGreen => alacritty_theme.light_green.into(),
+            Self::LightYellow => alacritty_theme.light_yellow.into(),
+            Self::LightBlue => alacritty_theme.light_blue.into(),
+            Self::LightMagenta => alacritty_theme.light_magenta.into(),
+            Self::LightCyan => alacritty_theme.light_cyan.into(),
+            Self::LightWhite => alacritty_theme.light_white.into(),
+            Self::Reset => Color::Reset,
+        })
     }
 
     pub const fn as_usize(self) -> usize {
         self as usize
     }
-}
-
-/// Try to parse the string as a 7-length hex color, returning [`None`] if unable to parse
-///
-/// Example input: `#010101`
-pub fn parse_hex_color(color: &str) -> Option<Color> {
-    let without_prefix = color.trim_start_matches('#');
-
-    // not in a format we support
-    if without_prefix.len() != 6 {
-        return None;
-    }
-
-    let r = u8::from_str_radix(&without_prefix[0..=1], 16).ok()?;
-    let g = u8::from_str_radix(&without_prefix[2..=3], 16).ok()?;
-    let b = u8::from_str_radix(&without_prefix[4..=5], 16).ok()?;
-
-    Some(Color::Rgb(r, g, b))
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
@@ -203,31 +189,138 @@ impl StyleColorSymbol {
     }
 }
 
+// TODO: consider upgrading this with "thiserror"
+/// Error for when [`ThemeColor`] parsing fails
+#[derive(Debug, Clone, PartialEq)]
+pub enum ColorParseError {
+    ParseIntError(ParseIntError),
+    IncorrectLength(usize),
+}
+
+impl ColorParseError {
+    #[cfg(test)]
+    fn is_parseint_error(&self) -> bool {
+        match self {
+            Self::ParseIntError(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Display for ColorParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let alternate = f.alternate();
+        write!(
+            f,
+            "Failed to parse color because of {}",
+            match self {
+                Self::ParseIntError(v) =>
+                    if alternate {
+                        format!("{v:#}")
+                    } else {
+                        format!("{v}")
+                    },
+                Self::IncorrectLength(length) =>
+                    format!("Incorrect length {length}, expected 1(prefix) + 6"),
+            }
+        )
+    }
+}
+
+impl Error for ColorParseError {}
+
+/// The rgb colors
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct AlacrittyColor {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl AlacrittyColor {
+    /// Convert from a prefix + 6 length string
+    ///
+    /// Example: input `#010101`
+    pub fn from_hex(input: &str) -> Result<Self, ColorParseError> {
+        let without_prefix = input.trim_start_matches('#');
+
+        // not in a format we support
+        if without_prefix.len() != 6 {
+            return Err(ColorParseError::IncorrectLength(without_prefix.len()));
+        }
+
+        let r = u8::from_str_radix(&without_prefix[0..=1], 16)
+            .map_err(ColorParseError::ParseIntError)?;
+        let g = u8::from_str_radix(&without_prefix[2..=3], 16)
+            .map_err(ColorParseError::ParseIntError)?;
+        let b = u8::from_str_radix(&without_prefix[4..=5], 16)
+            .map_err(ColorParseError::ParseIntError)?;
+
+        Ok(Self { r, g, b })
+    }
+
+    /// Convert to hex prefix + 6 length string
+    #[inline]
+    pub fn to_hex(self) -> String {
+        format!("#{:02x}{:02x}{:02x}", self.r, self.g, self.b)
+    }
+}
+
+impl TryFrom<String> for AlacrittyColor {
+    type Error = ColorParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_hex(&value)
+    }
+}
+
+impl TryFrom<&str> for AlacrittyColor {
+    type Error = ColorParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_hex(value)
+    }
+}
+
+impl From<AlacrittyColor> for String {
+    fn from(val: AlacrittyColor) -> Self {
+        AlacrittyColor::to_hex(val)
+    }
+}
+
+impl From<AlacrittyColor> for Color {
+    fn from(val: AlacrittyColor) -> Self {
+        Color::Rgb(val.r, val.g, val.b)
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub struct Alacritty {
     pub path: String,
     name: String,
     author: String,
-    background: String,
-    foreground: String,
-    cursor: String,
-    text: String,
-    black: String,
-    red: String,
-    green: String,
-    yellow: String,
-    blue: String,
-    magenta: String,
-    cyan: String,
-    white: String,
-    light_black: String,
-    light_red: String,
-    light_green: String,
-    light_yellow: String,
-    light_blue: String,
-    light_magenta: String,
-    light_cyan: String,
-    light_white: String,
+    background: AlacrittyColor,
+    foreground: AlacrittyColor,
+    cursor: AlacrittyColor,
+    text: AlacrittyColor,
+    black: AlacrittyColor,
+    red: AlacrittyColor,
+    green: AlacrittyColor,
+    yellow: AlacrittyColor,
+    blue: AlacrittyColor,
+    magenta: AlacrittyColor,
+    cyan: AlacrittyColor,
+    white: AlacrittyColor,
+    light_black: AlacrittyColor,
+    light_red: AlacrittyColor,
+    light_green: AlacrittyColor,
+    light_yellow: AlacrittyColor,
+    light_blue: AlacrittyColor,
+    light_magenta: AlacrittyColor,
+    light_cyan: AlacrittyColor,
+    light_white: AlacrittyColor,
 }
 
 impl Default for Alacritty {
@@ -236,26 +329,26 @@ impl Default for Alacritty {
             path: String::new(),
             name: "default".to_string(),
             author: "Larry Hao".to_string(),
-            background: "#101421".to_string(),
-            foreground: "#fffbf6".to_string(),
-            cursor: "#FFFFFF".to_string(),
-            text: "#1E1E1E".to_string(),
-            black: "#2e2e2e".to_string(),
-            red: "#eb4129".to_string(),
-            green: "#abe047".to_string(),
-            yellow: "#f6c744".to_string(),
-            blue: "#47a0f3".to_string(),
-            magenta: "#7b5cb0".to_string(),
-            cyan: "#64dbed".to_string(),
-            white: "#e5e9f0".to_string(),
-            light_black: "#565656".to_string(),
-            light_red: "#ec5357".to_string(),
-            light_green: "#c0e17d".to_string(),
-            light_yellow: "#f9da6a".to_string(),
-            light_blue: "#49a4f8".to_string(),
-            light_magenta: "#a47de9".to_string(),
-            light_cyan: "#99faf2".to_string(),
-            light_white: "#ffffff".to_string(),
+            background: AlacrittyColor::from_hex("#101421").unwrap(),
+            foreground: AlacrittyColor::from_hex("#fffbf6").unwrap(),
+            cursor: AlacrittyColor::from_hex("#ffffff").unwrap(),
+            text: AlacrittyColor::from_hex("#1e1e1e").unwrap(),
+            black: AlacrittyColor::from_hex("#2e2e2e").unwrap(),
+            red: AlacrittyColor::from_hex("#eb4129").unwrap(),
+            green: AlacrittyColor::from_hex("#abe047").unwrap(),
+            yellow: AlacrittyColor::from_hex("#f6c744").unwrap(),
+            blue: AlacrittyColor::from_hex("#47a0f3").unwrap(),
+            magenta: AlacrittyColor::from_hex("#7b5cb0").unwrap(),
+            cyan: AlacrittyColor::from_hex("#64dbed").unwrap(),
+            white: AlacrittyColor::from_hex("#e5e9f0").unwrap(),
+            light_black: AlacrittyColor::from_hex("#565656").unwrap(),
+            light_red: AlacrittyColor::from_hex("#ec5357").unwrap(),
+            light_green: AlacrittyColor::from_hex("#c0e17d").unwrap(),
+            light_yellow: AlacrittyColor::from_hex("#f9da6a").unwrap(),
+            light_blue: AlacrittyColor::from_hex("#49a4f8").unwrap(),
+            light_magenta: AlacrittyColor::from_hex("#a47de9").unwrap(),
+            light_cyan: AlacrittyColor::from_hex("#99faf2").unwrap(),
+            light_white: AlacrittyColor::from_hex("#ffffff").unwrap(),
         }
     }
 }
@@ -264,33 +357,33 @@ impl Alacritty {
     /// Convert a [`YAMLTheme`] to this type
     ///
     /// Cannot be a [`From`] implementation because of the additional set `path` parameter
-    pub fn from_yaml_theme(value: YAMLTheme, path: String) -> Self {
+    pub fn from_yaml_theme(value: YAMLTheme, path: String) -> Result<Self, ColorParseError> {
         let colors = value.colors;
-        Alacritty {
+        Ok(Alacritty {
             path,
             name: colors.name,
             author: colors.author,
-            background: colors.primary.background,
-            foreground: colors.primary.foreground,
-            cursor: colors.cursor.cursor,
-            text: colors.cursor.text,
-            black: colors.normal.black,
-            red: colors.normal.red,
-            green: colors.normal.green,
-            yellow: colors.normal.yellow,
-            blue: colors.normal.blue,
-            magenta: colors.normal.magenta,
-            cyan: colors.normal.cyan,
-            white: colors.normal.white,
-            light_black: colors.bright.black,
-            light_red: colors.bright.red,
-            light_green: colors.bright.green,
-            light_yellow: colors.bright.yellow,
-            light_blue: colors.bright.blue,
-            light_magenta: colors.bright.magenta,
-            light_cyan: colors.bright.cyan,
-            light_white: colors.bright.white,
-        }
+            background: colors.primary.background.try_into()?,
+            foreground: colors.primary.foreground.try_into()?,
+            cursor: colors.cursor.cursor.try_into()?,
+            text: colors.cursor.text.try_into()?,
+            black: colors.normal.black.try_into()?,
+            red: colors.normal.red.try_into()?,
+            green: colors.normal.green.try_into()?,
+            yellow: colors.normal.yellow.try_into()?,
+            blue: colors.normal.blue.try_into()?,
+            magenta: colors.normal.magenta.try_into()?,
+            cyan: colors.normal.cyan.try_into()?,
+            white: colors.normal.white.try_into()?,
+            light_black: colors.bright.black.try_into()?,
+            light_red: colors.bright.red.try_into()?,
+            light_green: colors.bright.green.try_into()?,
+            light_yellow: colors.bright.yellow.try_into()?,
+            light_blue: colors.bright.blue.try_into()?,
+            light_magenta: colors.bright.magenta.try_into()?,
+            light_cyan: colors.bright.cyan.try_into()?,
+            light_white: colors.bright.white.try_into()?,
+        })
     }
 
     /// Load a YAML Theme and then convert it to a [`Alacritty`] instance
@@ -298,7 +391,7 @@ impl Alacritty {
         let parsed: YAMLTheme = serde_yaml::from_reader(BufReader::new(File::open(path)?))?;
         let path_str = path.to_string_lossy().to_string();
 
-        Ok(Self::from_yaml_theme(parsed, path_str))
+        Ok(Self::from_yaml_theme(parsed, path_str)?)
     }
 }
 
@@ -309,27 +402,25 @@ mod tests {
     #[test]
     fn should_parse_default_colors() {
         let def = Alacritty::default();
+        assert_eq!(Color::from(def.background), Color::Rgb(16, 20, 33));
+    }
+
+    #[test]
+    fn should_not_parse_incorrect_input() {
         assert_eq!(
-            parse_hex_color(&def.background).unwrap(),
-            Color::Rgb(16, 20, 33)
+            AlacrittyColor::from_hex(""),
+            Err(ColorParseError::IncorrectLength(0))
         );
-        assert!(parse_hex_color(&def.foreground).is_some());
-        assert!(parse_hex_color(&def.cursor).is_some());
-        assert!(parse_hex_color(&def.text).is_some());
-        assert!(parse_hex_color(&def.black).is_some());
-        assert!(parse_hex_color(&def.red).is_some());
-        assert!(parse_hex_color(&def.green).is_some());
-        assert!(parse_hex_color(&def.yellow).is_some());
-        assert!(parse_hex_color(&def.blue).is_some());
-        assert!(parse_hex_color(&def.magenta).is_some());
-        assert!(parse_hex_color(&def.cyan).is_some());
-        assert!(parse_hex_color(&def.white).is_some());
-        assert!(parse_hex_color(&def.light_black).is_some());
-        assert!(parse_hex_color(&def.light_red).is_some());
-        assert!(parse_hex_color(&def.light_green).is_some());
-        assert!(parse_hex_color(&def.light_yellow).is_some());
-        assert!(parse_hex_color(&def.light_blue).is_some());
-        assert!(parse_hex_color(&def.light_magenta).is_some());
-        assert!(parse_hex_color(&def.light_white).is_some());
+        assert_eq!(
+            AlacrittyColor::from_hex("#111"),
+            Err(ColorParseError::IncorrectLength(3))
+        );
+        assert_eq!(
+            AlacrittyColor::from_hex("#01010101"),
+            Err(ColorParseError::IncorrectLength(8))
+        );
+        assert!(AlacrittyColor::from_hex("#ZZZZZZ")
+            .unwrap_err()
+            .is_parseint_error());
     }
 }

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
@@ -93,32 +92,22 @@ impl ColorTermusic {
     }
 }
 
-lazy_static::lazy_static! {
-    /**
-     * Regex matches:
-     * - group 1: Red
-     * - group 2: Green
-     * - group 3: Blue
-     */
-    static ref COLOR_HEX_REGEX: Regex = Regex::new(r"#(:?[0-9a-fA-F]{2})(:?[0-9a-fA-F]{2})(:?[0-9a-fA-F]{2})").unwrap();
-}
-
-/// # Panics
-/// panics could happen when color parse failed
+/// Try to parse the string as a 7-length hex color, returning [`None`] if unable to parse
+///
+/// Example input: `#010101`
 pub fn parse_hex_color(color: &str) -> Option<Color> {
-    COLOR_HEX_REGEX.captures(color).map(|groups| {
-        Color::Rgb(
-            u8::from_str_radix(groups.get(1).unwrap().as_str(), 16)
-                .ok()
-                .unwrap(),
-            u8::from_str_radix(groups.get(2).unwrap().as_str(), 16)
-                .ok()
-                .unwrap(),
-            u8::from_str_radix(groups.get(3).unwrap().as_str(), 16)
-                .ok()
-                .unwrap(),
-        )
-    })
+    let without_prefix = color.trim_start_matches('#');
+
+    // not in a format we support
+    if without_prefix.len() != 6 {
+        return None;
+    }
+
+    let r = u8::from_str_radix(&without_prefix[0..=1], 16).ok()?;
+    let g = u8::from_str_radix(&without_prefix[2..=3], 16).ok()?;
+    let b = u8::from_str_radix(&without_prefix[4..=5], 16).ok()?;
+
+    Some(Color::Rgb(r, g, b))
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -312,3 +312,35 @@ impl Alacritty {
         Ok(Self::from_yaml_theme(parsed, path_str))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_default_colors() {
+        let def = Alacritty::default();
+        assert_eq!(
+            parse_hex_color(&def.background).unwrap(),
+            Color::Rgb(16, 20, 33)
+        );
+        assert!(parse_hex_color(&def.foreground).is_some());
+        assert!(parse_hex_color(&def.cursor).is_some());
+        assert!(parse_hex_color(&def.text).is_some());
+        assert!(parse_hex_color(&def.black).is_some());
+        assert!(parse_hex_color(&def.red).is_some());
+        assert!(parse_hex_color(&def.green).is_some());
+        assert!(parse_hex_color(&def.yellow).is_some());
+        assert!(parse_hex_color(&def.blue).is_some());
+        assert!(parse_hex_color(&def.magenta).is_some());
+        assert!(parse_hex_color(&def.cyan).is_some());
+        assert!(parse_hex_color(&def.white).is_some());
+        assert!(parse_hex_color(&def.light_black).is_some());
+        assert!(parse_hex_color(&def.light_red).is_some());
+        assert!(parse_hex_color(&def.light_green).is_some());
+        assert!(parse_hex_color(&def.light_yellow).is_some());
+        assert!(parse_hex_color(&def.light_blue).is_some());
+        assert!(parse_hex_color(&def.light_magenta).is_some());
+        assert!(parse_hex_color(&def.light_white).is_some());
+    }
+}

--- a/lib/src/config/theme.rs
+++ b/lib/src/config/theme.rs
@@ -122,6 +122,11 @@ pub struct StyleColorSymbol {
     pub important_popup_background: ColorTermusic,
     pub important_popup_border: ColorTermusic,
 
+    pub fallback_foreground: ColorTermusic,
+    pub fallback_background: ColorTermusic,
+    pub fallback_border: ColorTermusic,
+    pub fallback_highlight: ColorTermusic,
+
     pub alacritty_theme: Alacritty,
     pub currently_playing_track_symbol: String,
 }
@@ -152,6 +157,11 @@ impl Default for StyleColorSymbol {
             important_popup_foreground: ColorTermusic::Yellow,
             important_popup_background: ColorTermusic::Reset,
             important_popup_border: ColorTermusic::Yellow,
+
+            fallback_foreground: ColorTermusic::Foreground,
+            fallback_background: ColorTermusic::Reset,
+            fallback_border: ColorTermusic::Blue,
+            fallback_highlight: ColorTermusic::LightYellow,
 
             alacritty_theme: Alacritty::default(),
             currently_playing_track_symbol: "►".to_string(),
@@ -214,6 +224,19 @@ impl StyleColorSymbol {
     }
     pub fn important_popup_border(&self) -> Option<Color> {
         self.important_popup_border.color(&self.alacritty_theme)
+    }
+
+    pub fn fallback_foreground(&self) -> Option<Color> {
+        self.fallback_foreground.color(&self.alacritty_theme)
+    }
+    pub fn fallback_background(&self) -> Option<Color> {
+        self.fallback_background.color(&self.alacritty_theme)
+    }
+    pub fn fallback_highlight(&self) -> Option<Color> {
+        self.fallback_highlight.color(&self.alacritty_theme)
+    }
+    pub fn fallback_border(&self) -> Option<Color> {
+        self.fallback_border.color(&self.alacritty_theme)
     }
 }
 

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -180,6 +180,15 @@ pub enum ConfigEditorMsg {
     ImportantPopupBackgroundBlurUp,
     ImportantPopupBorderBlurDown,
     ImportantPopupBorderBlurUp,
+
+    FallbackForegroundBlurDown,
+    FallbackForegroundBlurUp,
+    FallbackBackgroundBlurDown,
+    FallbackBackgroundBlurUp,
+    FallbackBorderBlurDown,
+    FallbackBorderBlurUp,
+    FallbackHighlightBlurDown,
+    FallbackHighlightBlurUp,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -581,6 +590,12 @@ pub enum IdConfigEditor {
     ImportantPopupBackground,
     ImportantPopupBorder,
     ImportantPopupForeground,
+
+    FallbackBackground,
+    FallbackBorder,
+    FallbackForeground,
+    FallbackHighlight,
+    FallbackLabel,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -91,6 +91,7 @@ pub enum ConfigEditorMsg {
     PodcastSimulDownloadBlurUp,
     PodcastMaxRetriesBlurDown,
     PodcastMaxRetriesBlurUp,
+
     AlbumPhotoAlignBlurDown,
     AlbumPhotoAlignBlurUp,
     ChangeLayout,
@@ -107,12 +108,14 @@ pub enum ConfigEditorMsg {
     KeyFocus(KFMsg),
     MusicDirBlurDown,
     MusicDirBlurUp,
+
     PlaylistDisplaySymbolBlurDown,
     PlaylistDisplaySymbolBlurUp,
     PlaylistRandomTrackBlurDown,
     PlaylistRandomTrackBlurUp,
     PlaylistRandomAlbumBlurDown,
     PlaylistRandomAlbumBlurUp,
+
     LibraryForegroundBlurDown,
     LibraryForegroundBlurUp,
     LibraryBackgroundBlurDown,
@@ -123,6 +126,7 @@ pub enum ConfigEditorMsg {
     LibraryHighlightBlurUp,
     LibraryHighlightSymbolBlurDown,
     LibraryHighlightSymbolBlurUp,
+
     PlaylistForegroundBlurDown,
     PlaylistForegroundBlurUp,
     PlaylistBackgroundBlurDown,
@@ -133,21 +137,25 @@ pub enum ConfigEditorMsg {
     PlaylistHighlightBlurUp,
     PlaylistHighlightSymbolBlurDown,
     PlaylistHighlightSymbolBlurUp,
+
     ProgressForegroundBlurDown,
     ProgressForegroundBlurUp,
     ProgressBackgroundBlurDown,
     ProgressBackgroundBlurUp,
     ProgressBorderBlurDown,
     ProgressBorderBlurUp,
+
     LyricForegroundBlurDown,
     LyricForegroundBlurUp,
     LyricBackgroundBlurDown,
     LyricBackgroundBlurUp,
     LyricBorderBlurDown,
     LyricBorderBlurUp,
+
     ThemeSelectBlurDown,
     ThemeSelectBlurUp,
     ThemeSelectLoad(usize),
+
     KeyChange(IdKey, BindingForEvent),
     SaveLastPositionBlurDown,
     SaveLastPosotionBlurUp,
@@ -155,14 +163,23 @@ pub enum ConfigEditorMsg {
     SeekStepBlurUp,
     KillDaemonBlurDown,
     KillDaemonBlurUp,
+
     PlayerUseMprisBlurDown,
     PlayerUseMprisBlurUp,
     PlayerUseDiscordBlurDown,
     PlayerUseDiscordBlurUp,
     PlayerPortBlurDown,
     PlayerPortBlurUp,
+
     CurrentlyPlayingTrackSymbolBlurDown,
     CurrentlyPlayingTrackSymbolBlurUp,
+
+    ImportantPopupForegroundBlurDown,
+    ImportantPopupForegroundBlurUp,
+    ImportantPopupBackgroundBlurDown,
+    ImportantPopupBackgroundBlurUp,
+    ImportantPopupBorderBlurDown,
+    ImportantPopupBorderBlurUp,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -518,20 +535,24 @@ pub enum IdConfigEditor {
     Header,
     Key(IdKey),
     KillDamon,
+
     LibraryBackground,
     LibraryBorder,
     LibraryForeground,
     LibraryHighlight,
     LibraryHighlightSymbol,
     LibraryLabel,
+
     LyricBackground,
     LyricBorder,
     LyricForeground,
     LyricLabel,
+
     MusicDir,
     PlayerPort,
     PlayerUseDiscord,
     PlayerUseMpris,
+
     PlaylistBackground,
     PlaylistBorder,
     PlaylistDisplaySymbol,
@@ -541,16 +562,25 @@ pub enum IdConfigEditor {
     PlaylistLabel,
     PlaylistRandomAlbum,
     PlaylistRandomTrack,
+
     CurrentlyPlayingTrackSymbol,
+
     PodcastDir,
     PodcastMaxRetries,
     PodcastSimulDownload,
+
     ProgressBackground,
     ProgressBorder,
     ProgressForeground,
     ProgressLabel,
+
     SaveLastPosition,
     SeekStep,
+
+    ImportantPopupLabel,
+    ImportantPopupBackground,
+    ImportantPopupBorder,
+    ImportantPopupForeground,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -244,16 +244,30 @@ impl CEColorSelect {
             IdConfigEditor::LibraryBackground => style_color_symbol.library_background.as_usize(),
             IdConfigEditor::LibraryBorder => style_color_symbol.library_border.as_usize(),
             IdConfigEditor::LibraryHighlight => style_color_symbol.library_highlight.as_usize(),
+
             IdConfigEditor::PlaylistForeground => style_color_symbol.playlist_foreground.as_usize(),
             IdConfigEditor::PlaylistBackground => style_color_symbol.playlist_background.as_usize(),
             IdConfigEditor::PlaylistBorder => style_color_symbol.playlist_border.as_usize(),
             IdConfigEditor::PlaylistHighlight => style_color_symbol.playlist_highlight.as_usize(),
+
             IdConfigEditor::ProgressForeground => style_color_symbol.progress_foreground.as_usize(),
             IdConfigEditor::ProgressBackground => style_color_symbol.progress_background.as_usize(),
             IdConfigEditor::ProgressBorder => style_color_symbol.progress_border.as_usize(),
+
             IdConfigEditor::LyricForeground => style_color_symbol.lyric_foreground.as_usize(),
             IdConfigEditor::LyricBackground => style_color_symbol.lyric_background.as_usize(),
             IdConfigEditor::LyricBorder => style_color_symbol.lyric_border.as_usize(),
+
+            IdConfigEditor::ImportantPopupForeground => {
+                style_color_symbol.important_popup_foreground.as_usize()
+            }
+            IdConfigEditor::ImportantPopupBackground => {
+                style_color_symbol.important_popup_background.as_usize()
+            }
+            IdConfigEditor::ImportantPopupBorder => {
+                style_color_symbol.important_popup_border.as_usize()
+            }
+
             _ => 0,
         }
     }
@@ -1147,6 +1161,120 @@ impl ConfigCurrentlyPlayingTrackSymbol {
 }
 
 impl Component<Msg, NoUserEvent> for ConfigCurrentlyPlayingTrackSymbol {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigImportantPopupTitle {
+    component: Label,
+}
+
+impl Default for ConfigImportantPopupTitle {
+    fn default() -> Self {
+        Self {
+            component: Label::default()
+                .modifiers(TextModifiers::BOLD)
+                .text(" Important Popup style "),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigImportantPopupTitle {
+    fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
+        None
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigImportantPopupForeground {
+    component: CEColorSelect,
+}
+
+impl ConfigImportantPopupForeground {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .important_popup_foreground()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Foreground ",
+                IdConfigEditor::ImportantPopupForeground,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupForegroundBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupForegroundBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigImportantPopupForeground {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigImportantPopupBackground {
+    component: CEColorSelect,
+}
+
+impl ConfigImportantPopupBackground {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .important_popup_background()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Background ",
+                IdConfigEditor::ImportantPopupBackground,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBackgroundBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBackgroundBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigImportantPopupBackground {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigImportantPopupBorder {
+    component: CEColorSelect,
+}
+
+impl ConfigImportantPopupBorder {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .important_popup_border()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Border ",
+                IdConfigEditor::ImportantPopupBorder,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBorderBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBorderBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigImportantPopupBorder {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -71,20 +71,20 @@ impl CEThemeSelectTable {
                     Borders::default().modifiers(BorderType::Rounded).color(
                         config
                             .style_color_symbol
-                            .library_border()
+                            .fallback_border()
                             .unwrap_or(Color::Blue),
                     ),
                 )
                 .foreground(
                     config
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Yellow),
                 )
                 .background(
                     config
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .title(" Themes: <Enter> to preview ", Alignment::Left)
@@ -92,7 +92,7 @@ impl CEThemeSelectTable {
                 .highlighted_color(
                     config
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
@@ -1312,7 +1312,7 @@ impl ConfigFallbackForeground {
         let color = config
             .read()
             .style_color_symbol
-            .library_foreground()
+            .fallback_foreground()
             .unwrap_or(Color::Blue);
         Self {
             component: CEColorSelect::new(

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -68,33 +68,15 @@ impl CEThemeSelectTable {
             let config = config.read();
             Table::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .fallback_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.fallback_border()),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(config.style_color_symbol.fallback_foreground())
+                .background(config.style_color_symbol.fallback_background())
                 .title(" Themes: <Enter> to preview ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(true)
                 .step(4)
@@ -274,9 +256,7 @@ impl CEColorSelect {
 
     fn update_color(&mut self, index: usize) -> Msg {
         if let Some(color_config) = COLOR_LIST.get(index) {
-            let color = color_config
-                .color(&self.config.read().style_color_symbol.alacritty_theme)
-                .unwrap_or(Color::Red);
+            let color = color_config.color(&self.config.read().style_color_symbol.alacritty_theme);
             // self.attr(Attribute::Foreground, AttrValue::Color(color));
             self.attr(Attribute::Background, AttrValue::Color(color));
             self.attr(
@@ -403,11 +383,7 @@ pub struct ConfigLibraryForeground {
 
 impl ConfigLibraryForeground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_foreground()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -434,11 +410,7 @@ pub struct ConfigLibraryBackground {
 
 impl ConfigLibraryBackground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_background()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -465,11 +437,7 @@ pub struct ConfigLibraryBorder {
 
 impl ConfigLibraryBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -496,11 +464,7 @@ pub struct ConfigLibraryHighlight {
 
 impl ConfigLibraryHighlight {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_highlight()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_highlight();
         Self {
             component: CEColorSelect::new(
                 " Highlight ",
@@ -548,11 +512,7 @@ pub struct ConfigPlaylistForeground {
 
 impl ConfigPlaylistForeground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .playlist_foreground()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.playlist_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -579,11 +539,7 @@ pub struct ConfigPlaylistBackground {
 
 impl ConfigPlaylistBackground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .playlist_background()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.playlist_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -610,11 +566,7 @@ pub struct ConfigPlaylistBorder {
 
 impl ConfigPlaylistBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .playlist_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.playlist_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -641,11 +593,7 @@ pub struct ConfigPlaylistHighlight {
 
 impl ConfigPlaylistHighlight {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .playlist_highlight()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.playlist_highlight();
         Self {
             component: CEColorSelect::new(
                 " Highlight ",
@@ -693,11 +641,7 @@ pub struct ConfigProgressForeground {
 
 impl ConfigProgressForeground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .progress_foreground()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.progress_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -724,11 +668,7 @@ pub struct ConfigProgressBackground {
 
 impl ConfigProgressBackground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .progress_background()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.progress_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -755,11 +695,7 @@ pub struct ConfigProgressBorder {
 
 impl ConfigProgressBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .progress_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.progress_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -807,11 +743,7 @@ pub struct ConfigLyricForeground {
 
 impl ConfigLyricForeground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .lyric_foreground()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.lyric_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -838,11 +770,7 @@ pub struct ConfigLyricBackground {
 
 impl ConfigLyricBackground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .lyric_background()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.lyric_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -869,11 +797,7 @@ pub struct ConfigLyricBorder {
 
 impl ConfigLyricBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .lyric_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.lyric_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -918,12 +842,9 @@ impl ConfigInputHighlight {
         };
         let component = Input::default()
             .borders(
-                Borders::default().modifiers(BorderType::Rounded).color(
-                    config_r
-                        .style_color_symbol
-                        .library_border()
-                        .unwrap_or(Color::Blue),
-                ),
+                Borders::default()
+                    .modifiers(BorderType::Rounded)
+                    .color(config_r.style_color_symbol.library_border()),
             )
             // .foreground(color)
             .input_type(InputType::Text)
@@ -944,12 +865,7 @@ impl ConfigInputHighlight {
     fn update_symbol(&mut self, result: CmdResult) -> Msg {
         if let CmdResult::Changed(State::One(StateValue::String(symbol))) = result.clone() {
             if symbol.is_empty() {
-                let color = self
-                    .config
-                    .read()
-                    .style_color_symbol
-                    .library_border()
-                    .unwrap_or(Color::Blue);
+                let color = self.config.read().style_color_symbol.library_border();
                 self.update_symbol_after(color);
                 return Msg::None;
             }
@@ -1198,8 +1114,7 @@ impl ConfigImportantPopupForeground {
         let color = config
             .read()
             .style_color_symbol
-            .important_popup_foreground()
-            .unwrap_or(Color::Blue);
+            .important_popup_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -1229,8 +1144,7 @@ impl ConfigImportantPopupBackground {
         let color = config
             .read()
             .style_color_symbol
-            .important_popup_background()
-            .unwrap_or(Color::Blue);
+            .important_popup_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -1257,11 +1171,7 @@ pub struct ConfigImportantPopupBorder {
 
 impl ConfigImportantPopupBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .important_popup_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.important_popup_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -1309,11 +1219,7 @@ pub struct ConfigFallbackForeground {
 
 impl ConfigFallbackForeground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .fallback_foreground()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.fallback_foreground();
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
@@ -1340,11 +1246,7 @@ pub struct ConfigFallbackBackground {
 
 impl ConfigFallbackBackground {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_background()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_background();
         Self {
             component: CEColorSelect::new(
                 " Background ",
@@ -1371,11 +1273,7 @@ pub struct ConfigFallbackBorder {
 
 impl ConfigFallbackBorder {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_border()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_border();
         Self {
             component: CEColorSelect::new(
                 " Border ",
@@ -1402,11 +1300,7 @@ pub struct ConfigFallbackHighlight {
 
 impl ConfigFallbackHighlight {
     pub fn new(config: SharedSettings) -> Self {
-        let color = config
-            .read()
-            .style_color_symbol
-            .library_highlight()
-            .unwrap_or(Color::Blue);
+        let color = config.read().style_color_symbol.library_highlight();
         Self {
             component: CEColorSelect::new(
                 " Highlight ",

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -374,6 +374,7 @@ impl Component<Msg, NoUserEvent> for CEColorSelect {
         }
     }
 }
+
 #[derive(MockComponent)]
 pub struct ConfigLibraryTitle {
     component: Label,
@@ -1275,6 +1276,151 @@ impl ConfigImportantPopupBorder {
 }
 
 impl Component<Msg, NoUserEvent> for ConfigImportantPopupBorder {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigFallbackTitle {
+    component: Label,
+}
+
+impl Default for ConfigFallbackTitle {
+    fn default() -> Self {
+        Self {
+            component: Label::default()
+                .modifiers(TextModifiers::BOLD)
+                .text(" Fallback style "),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigFallbackTitle {
+    fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
+        None
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigFallbackForeground {
+    component: CEColorSelect,
+}
+
+impl ConfigFallbackForeground {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .library_foreground()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Foreground ",
+                IdConfigEditor::FallbackForeground,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackForegroundBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackForegroundBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigFallbackForeground {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigFallbackBackground {
+    component: CEColorSelect,
+}
+
+impl ConfigFallbackBackground {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .library_background()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Background ",
+                IdConfigEditor::FallbackBackground,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackBackgroundBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackBackgroundBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigFallbackBackground {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigFallbackBorder {
+    component: CEColorSelect,
+}
+
+impl ConfigFallbackBorder {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .library_border()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Border ",
+                IdConfigEditor::FallbackBorder,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackBorderBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackBorderBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigFallbackBorder {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigFallbackHighlight {
+    component: CEColorSelect,
+}
+
+impl ConfigFallbackHighlight {
+    pub fn new(config: SharedSettings) -> Self {
+        let color = config
+            .read()
+            .style_color_symbol
+            .library_highlight()
+            .unwrap_or(Color::Blue);
+        Self {
+            component: CEColorSelect::new(
+                " Highlight ",
+                IdConfigEditor::FallbackHighlight,
+                color,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackHighlightBlurDown),
+                Msg::ConfigEditor(ConfigEditorMsg::FallbackHighlightBlurUp),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigFallbackHighlight {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -55,20 +55,10 @@ impl MusicDir {
         let component = Input::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightGreen),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightGreen),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .input_type(InputType::Text)
             .placeholder("~/Music", Style::default().fg(Color::Rgb(128, 128, 128)))
             .title(
@@ -180,21 +170,11 @@ impl ExitConfirmation {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Yes", "No"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Show exit confirmation? ", Alignment::Left)
             .value(usize::from(!enabled));
@@ -276,21 +256,11 @@ impl PlaylistDisplaySymbol {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Yes", "No"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Display symbol in playlist title? ", Alignment::Left)
             .value(usize::from(!enabled));
@@ -325,20 +295,10 @@ impl PlaylistRandomTrack {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::UnsignedInteger)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder("20", Style::default().fg(Color::Rgb(128, 128, 128)))
@@ -375,20 +335,10 @@ impl PlaylistRandomAlbum {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::UnsignedInteger)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder("1", Style::default().fg(Color::Rgb(128, 128, 128)))
@@ -428,20 +378,10 @@ impl PodcastDir {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::Text)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder(
@@ -481,20 +421,10 @@ impl PodcastSimulDownload {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::UnsignedInteger)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder(
@@ -534,20 +464,10 @@ impl PodcastMaxRetries {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::UnsignedInteger)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder(
@@ -592,21 +512,11 @@ impl AlbumPhotoAlign {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["BottomRight", "BottomLeft", "TopRight", "TopLeft"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Album Photo Align: ", Alignment::Left)
             .value(align);
@@ -645,21 +555,11 @@ impl SaveLastPosition {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Auto", "No", "Yes"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Remember last played position: ", Alignment::Left)
             .value(save_last_position);
@@ -697,21 +597,11 @@ impl ConfigSeekStep {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Auto", "Short(5)", "Long(30)"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Seek step in seconds: ", Alignment::Left)
             .value(seek_step);
@@ -746,21 +636,11 @@ impl KillDaemon {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Yes", "No"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Kill daemon when quit termusic? ", Alignment::Left)
             .value(usize::from(!enabled));
@@ -795,21 +675,11 @@ impl PlayerUseMpris {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Yes", "No"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Support Mpris? ", Alignment::Left)
             .value(usize::from(!enabled));
@@ -844,21 +714,11 @@ impl PlayerUseDiscord {
         let component = Radio::default()
             .borders(
                 Borders::default()
-                    .color(
-                        config_r
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightRed),
-                    )
+                    .color(config_r.style_color_symbol.library_border())
                     .modifiers(BorderType::Rounded),
             )
             .choices(&["Yes", "No"])
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::LightRed),
-            )
+            .foreground(config_r.style_color_symbol.library_highlight())
             .rewind(true)
             .title(" Update discord rpc? ", Alignment::Left)
             .value(usize::from(!enabled));
@@ -893,20 +753,10 @@ impl PlayerPort {
             Input::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
                 .input_type(InputType::UnsignedInteger)
                 .invalid_style(Style::default().fg(Color::Red))
                 .placeholder(

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1103,27 +1103,14 @@ impl KEModifierSelect {
         }
         let component = KeyCombo::default()
             .borders(
-                Borders::default().modifiers(BorderType::Rounded).color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_border()
-                        .unwrap_or(Color::Blue),
-                ),
+                Borders::default()
+                    .modifiers(BorderType::Rounded)
+                    .color(config_r.style_color_symbol.fallback_border()),
             )
-            .foreground(
-                config_r
-                    .style_color_symbol
-                    .fallback_foreground()
-                    .unwrap_or(Color::Blue),
-            )
+            .foreground(config_r.style_color_symbol.fallback_foreground())
             .title(name, Alignment::Left)
             .rewind(false)
-            .highlighted_color(
-                config_r
-                    .style_color_symbol
-                    .fallback_highlight()
-                    .unwrap_or(Color::LightGreen),
-            )
+            .highlighted_color(config_r.style_color_symbol.fallback_highlight())
             .highlighted_str(">> ")
             .choices(&choices)
             .placeholder("a/b/c", Style::default().fg(Color::Rgb(128, 128, 128)))

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1106,14 +1106,14 @@ impl KEModifierSelect {
                 Borders::default().modifiers(BorderType::Rounded).color(
                     config_r
                         .style_color_symbol
-                        .library_border()
+                        .fallback_border()
                         .unwrap_or(Color::Blue),
                 ),
             )
             .foreground(
                 config_r
                     .style_color_symbol
-                    .library_foreground()
+                    .fallback_foreground()
                     .unwrap_or(Color::Blue),
             )
             .title(name, Alignment::Left)
@@ -1121,7 +1121,7 @@ impl KEModifierSelect {
             .highlighted_color(
                 config_r
                     .style_color_symbol
-                    .library_highlight()
+                    .fallback_highlight()
                     .unwrap_or(Color::LightGreen),
             )
             .highlighted_str(">> ")

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -150,15 +150,15 @@ impl ConfigSavePopup {
                 YNConfirmStyle {
                     foreground_color: config
                         .style_color_symbol
-                        .library_foreground()
+                        .important_popup_foreground()
                         .unwrap_or(Color::Yellow),
                     background_color: config
                         .style_color_symbol
-                        .library_background()
+                        .important_popup_background()
                         .unwrap_or(Color::Reset),
                     border_color: config
                         .style_color_symbol
-                        .library_border()
+                        .important_popup_border()
                         .unwrap_or(Color::Yellow),
                     title_alignment: Alignment::Center,
                 }

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -36,7 +36,7 @@ pub use key_combo::*;
 
 use termusicplayback::SharedSettings;
 use tui_realm_stdlib::{Radio, Span};
-use tuirealm::props::{Alignment, BorderSides, BorderType, Borders, Color, Style, TextSpan};
+use tuirealm::props::{Alignment, BorderSides, BorderType, Borders, Style, TextSpan};
 use tuirealm::{event::NoUserEvent, Component, Event, MockComponent};
 
 use super::popups::{YNConfirm, YNConfirmStyle};
@@ -61,18 +61,8 @@ impl CEHeader {
                     "Keys Global",
                     "Keys Other",
                 ])
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Yellow),
-                )
-                .inactive(
-                    Style::default().fg(config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Red)),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
+                .inactive(Style::default().fg(config.style_color_symbol.library_highlight()))
                 .value(match layout {
                     ConfigEditorLayout::General => 0,
                     ConfigEditorLayout::Color => 1,
@@ -100,32 +90,23 @@ impl Footer {
             component: Span::default().spans(&[
                 TextSpan::new(format!("<{}>", config.keys.config_save))
                     .bold()
-                    .fg(config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Cyan)),
+                    .fg(config.style_color_symbol.library_highlight()),
                 TextSpan::new(" Save parameters ").bold(),
                 TextSpan::new(format!("<{}>", config.keys.global_esc))
                     .bold()
-                    .fg(config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Cyan)),
+                    .fg(config.style_color_symbol.library_highlight()),
                 TextSpan::new(" Exit ").bold(),
-                TextSpan::new("<TAB>").bold().fg(config
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::Cyan)),
+                TextSpan::new("<TAB>")
+                    .bold()
+                    .fg(config.style_color_symbol.library_highlight()),
                 TextSpan::new(" Change panel ").bold(),
-                TextSpan::new("<UP/DOWN>").bold().fg(config
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::Cyan)),
+                TextSpan::new("<UP/DOWN>")
+                    .bold()
+                    .fg(config.style_color_symbol.library_highlight()),
                 TextSpan::new(" Change field ").bold(),
-                TextSpan::new("<ENTER>").bold().fg(config
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::Cyan)),
+                TextSpan::new("<ENTER>")
+                    .bold()
+                    .fg(config.style_color_symbol.library_highlight()),
                 TextSpan::new(" Select theme/Preview symbol ").bold(),
             ]),
         }
@@ -148,18 +129,9 @@ impl ConfigSavePopup {
         let component =
             YNConfirm::new_with_cb(config, " Config changed. Do you want to save? ", |config| {
                 YNConfirmStyle {
-                    foreground_color: config
-                        .style_color_symbol
-                        .important_popup_foreground()
-                        .unwrap_or(Color::Yellow),
-                    background_color: config
-                        .style_color_symbol
-                        .important_popup_background()
-                        .unwrap_or(Color::Reset),
-                    border_color: config
-                        .style_color_symbol
-                        .important_popup_border()
-                        .unwrap_or(Color::Yellow),
+                    foreground_color: config.style_color_symbol.important_popup_foreground(),
+                    background_color: config.style_color_symbol.important_popup_background(),
+                    border_color: config.style_color_symbol.important_popup_border(),
                     title_alignment: Alignment::Center,
                 }
             });

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -177,7 +177,7 @@ impl Model {
                     .ok();
             }
             ConfigEditorMsg::LibraryForegroundBlurUp
-            | ConfigEditorMsg::ImportantPopupBorderBlurDown => {
+            | ConfigEditorMsg::FallbackHighlightBlurDown => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))
                     .ok();
@@ -259,6 +259,7 @@ impl Model {
                     .active(&Id::ConfigEditor(IdConfigEditor::ProgressBorder))
                     .ok();
             }
+
             ConfigEditorMsg::ProgressBorderBlurDown | ConfigEditorMsg::LyricBackgroundBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::LyricForeground))
@@ -275,6 +276,7 @@ impl Model {
                     .active(&Id::ConfigEditor(IdConfigEditor::LyricBorder))
                     .ok();
             }
+
             ConfigEditorMsg::LyricBorderBlurDown
             | ConfigEditorMsg::ImportantPopupBackgroundBlurUp => {
                 self.app
@@ -288,11 +290,35 @@ impl Model {
                     .ok();
             }
             ConfigEditorMsg::ImportantPopupBackgroundBlurDown
-            | ConfigEditorMsg::ThemeSelectBlurUp => {
+            | ConfigEditorMsg::FallbackForegroundBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder))
                     .ok();
             }
+
+            ConfigEditorMsg::ImportantPopupBorderBlurDown
+            | ConfigEditorMsg::FallbackBackgroundBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackForeground))
+                    .ok();
+            }
+            ConfigEditorMsg::FallbackForegroundBlurDown | ConfigEditorMsg::FallbackBorderBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackBackground))
+                    .ok();
+            }
+            ConfigEditorMsg::FallbackBackgroundBlurDown
+            | ConfigEditorMsg::FallbackHighlightBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackBorder))
+                    .ok();
+            }
+            ConfigEditorMsg::FallbackBorderBlurDown | ConfigEditorMsg::ThemeSelectBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackHighlight))
+                    .ok();
+            }
+
             ConfigEditorMsg::ThemeSelectLoad(index) => {
                 if let Some(theme_path_str) = self.ce_themes.get(*index) {
                     let theme_path = PathBuf::from(theme_path_str);

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -176,7 +176,8 @@ impl Model {
                     .active(&Id::ConfigEditor(IdConfigEditor::LibraryForeground))
                     .ok();
             }
-            ConfigEditorMsg::LibraryForegroundBlurUp | ConfigEditorMsg::LyricBorderBlurDown => {
+            ConfigEditorMsg::LibraryForegroundBlurUp
+            | ConfigEditorMsg::ImportantPopupBorderBlurDown => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))
                     .ok();
@@ -268,9 +269,28 @@ impl Model {
                     .active(&Id::ConfigEditor(IdConfigEditor::LyricBackground))
                     .ok();
             }
-            ConfigEditorMsg::LyricBackgroundBlurDown | ConfigEditorMsg::ThemeSelectBlurUp => {
+            ConfigEditorMsg::LyricBackgroundBlurDown
+            | ConfigEditorMsg::ImportantPopupForegroundBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::LyricBorder))
+                    .ok();
+            }
+            ConfigEditorMsg::LyricBorderBlurDown
+            | ConfigEditorMsg::ImportantPopupBackgroundBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupForeground))
+                    .ok();
+            }
+            ConfigEditorMsg::ImportantPopupForegroundBlurDown
+            | ConfigEditorMsg::ImportantPopupBorderBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBackground))
+                    .ok();
+            }
+            ConfigEditorMsg::ImportantPopupBackgroundBlurDown
+            | ConfigEditorMsg::ThemeSelectBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder))
                     .ok();
             }
             ConfigEditorMsg::ThemeSelectLoad(index) => {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,19 +1,20 @@
 use crate::ui::components::{
     AlbumPhotoAlign, CEHeader, CEThemeSelectTable, ConfigCurrentlyPlayingTrackSymbol,
-    ConfigDatabaseAddAll, ConfigGlobalConfig, ConfigGlobalDown, ConfigGlobalGotoBottom,
-    ConfigGlobalGotoTop, ConfigGlobalHelp, ConfigGlobalLayoutDatabase, ConfigGlobalLayoutPodcast,
-    ConfigGlobalLayoutTreeview, ConfigGlobalLeft, ConfigGlobalLyricAdjustBackward,
-    ConfigGlobalLyricAdjustForward, ConfigGlobalLyricCycle, ConfigGlobalPlayerNext,
-    ConfigGlobalPlayerPrevious, ConfigGlobalPlayerSeekBackward, ConfigGlobalPlayerSeekForward,
-    ConfigGlobalPlayerSpeedDown, ConfigGlobalPlayerSpeedUp, ConfigGlobalPlayerToggleGapless,
-    ConfigGlobalPlayerTogglePause, ConfigGlobalQuit, ConfigGlobalRight, ConfigGlobalSavePlaylist,
-    ConfigGlobalUp, ConfigGlobalVolumeDown, ConfigGlobalVolumeUp, ConfigGlobalXywhHide,
-    ConfigGlobalXywhMoveDown, ConfigGlobalXywhMoveLeft, ConfigGlobalXywhMoveRight,
-    ConfigGlobalXywhMoveUp, ConfigGlobalXywhZoomIn, ConfigGlobalXywhZoomOut,
-    ConfigImportantPopupBackground, ConfigImportantPopupBorder, ConfigImportantPopupForeground,
-    ConfigImportantPopupTitle, ConfigLibraryAddRoot, ConfigLibraryBackground, ConfigLibraryBorder,
-    ConfigLibraryDelete, ConfigLibraryForeground, ConfigLibraryHighlight,
-    ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
+    ConfigDatabaseAddAll, ConfigFallbackBackground, ConfigFallbackBorder, ConfigFallbackForeground,
+    ConfigFallbackHighlight, ConfigFallbackTitle, ConfigGlobalConfig, ConfigGlobalDown,
+    ConfigGlobalGotoBottom, ConfigGlobalGotoTop, ConfigGlobalHelp, ConfigGlobalLayoutDatabase,
+    ConfigGlobalLayoutPodcast, ConfigGlobalLayoutTreeview, ConfigGlobalLeft,
+    ConfigGlobalLyricAdjustBackward, ConfigGlobalLyricAdjustForward, ConfigGlobalLyricCycle,
+    ConfigGlobalPlayerNext, ConfigGlobalPlayerPrevious, ConfigGlobalPlayerSeekBackward,
+    ConfigGlobalPlayerSeekForward, ConfigGlobalPlayerSpeedDown, ConfigGlobalPlayerSpeedUp,
+    ConfigGlobalPlayerToggleGapless, ConfigGlobalPlayerTogglePause, ConfigGlobalQuit,
+    ConfigGlobalRight, ConfigGlobalSavePlaylist, ConfigGlobalUp, ConfigGlobalVolumeDown,
+    ConfigGlobalVolumeUp, ConfigGlobalXywhHide, ConfigGlobalXywhMoveDown, ConfigGlobalXywhMoveLeft,
+    ConfigGlobalXywhMoveRight, ConfigGlobalXywhMoveUp, ConfigGlobalXywhZoomIn,
+    ConfigGlobalXywhZoomOut, ConfigImportantPopupBackground, ConfigImportantPopupBorder,
+    ConfigImportantPopupForeground, ConfigImportantPopupTitle, ConfigLibraryAddRoot,
+    ConfigLibraryBackground, ConfigLibraryBorder, ConfigLibraryDelete, ConfigLibraryForeground,
+    ConfigLibraryHighlight, ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
     ConfigLibraryRemoveRoot, ConfigLibrarySearch, ConfigLibrarySearchYoutube,
     ConfigLibrarySwitchRoot, ConfigLibraryTagEditor, ConfigLibraryTitle, ConfigLibraryYank,
     ConfigLyricBackground, ConfigLyricBorder, ConfigLyricForeground, ConfigLyricTitle,
@@ -368,6 +369,35 @@ impl Model {
             _ => 8,
         };
 
+        let select_fallback_foreground_len = match self
+            .app
+            .state(&Id::ConfigEditor(IdConfigEditor::FallbackForeground))
+        {
+            Ok(State::One(_)) => 3,
+            _ => 8,
+        };
+        let select_fallback_background_len = match self
+            .app
+            .state(&Id::ConfigEditor(IdConfigEditor::FallbackBackground))
+        {
+            Ok(State::One(_)) => 3,
+            _ => 8,
+        };
+        let select_fallback_border_len = match self
+            .app
+            .state(&Id::ConfigEditor(IdConfigEditor::FallbackBorder))
+        {
+            Ok(State::One(_)) => 3,
+            _ => 8,
+        };
+        let select_fallback_highlight_len = match self
+            .app
+            .state(&Id::ConfigEditor(IdConfigEditor::FallbackHighlight))
+        {
+            Ok(State::One(_)) => 3,
+            _ => 8,
+        };
+
         self.terminal
             .raw_mut()
             .draw(|f| {
@@ -504,6 +534,22 @@ impl Model {
                     )
                     .split(chunks_style_bottom[0]);
 
+                let chunks_fallback = Layout::default()
+                    .direction(Direction::Vertical)
+                    .margin(0)
+                    .constraints(
+                        [
+                            Constraint::Length(1),
+                            Constraint::Length(select_fallback_foreground_len),
+                            Constraint::Length(select_fallback_background_len),
+                            Constraint::Length(select_fallback_border_len),
+                            Constraint::Length(select_fallback_highlight_len),
+                            Constraint::Min(3),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(chunks_style_bottom[1]);
+
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
 
@@ -514,6 +560,7 @@ impl Model {
                 );
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Footer), f, chunks_main[2]);
+
                 self.app.view(
                     &Id::ConfigEditor(IdConfigEditor::LibraryLabel),
                     f,
@@ -647,6 +694,32 @@ impl Model {
                     &Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder),
                     f,
                     chunks_important_popup[3],
+                );
+
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::FallbackLabel),
+                    f,
+                    chunks_fallback[0],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::FallbackForeground),
+                    f,
+                    chunks_fallback[1],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::FallbackBackground),
+                    f,
+                    chunks_fallback[2],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::FallbackBorder),
+                    f,
+                    chunks_fallback[3],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::FallbackHighlight),
+                    f,
+                    chunks_fallback[4],
                 );
 
                 Self::view_config_editor_commons(f, &mut self.app);
@@ -1828,6 +1901,7 @@ impl Model {
                 vec![]
             )
             .is_ok());
+
         assert!(self
             .app
             .remount(
@@ -1836,7 +1910,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1845,7 +1918,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1854,7 +1926,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1863,7 +1934,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1962,7 +2032,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1971,7 +2040,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1980,7 +2048,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -1998,7 +2065,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -2007,7 +2073,6 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
@@ -2016,12 +2081,52 @@ impl Model {
                 vec![]
             )
             .is_ok());
-
         assert!(self
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder),
                 Box::new(ConfigImportantPopupBorder::new(config.clone())),
+                vec![]
+            )
+            .is_ok());
+
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::FallbackLabel),
+                Box::<ConfigFallbackTitle>::default(),
+                vec![]
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::FallbackForeground),
+                Box::new(ConfigFallbackForeground::new(config.clone())),
+                vec![]
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::FallbackBackground),
+                Box::new(ConfigFallbackBackground::new(config.clone())),
+                vec![]
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::FallbackBorder),
+                Box::new(ConfigFallbackBorder::new(config.clone())),
+                vec![]
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::FallbackHighlight),
+                Box::new(ConfigFallbackHighlight::new(config.clone())),
                 vec![]
             )
             .is_ok());
@@ -2679,7 +2784,6 @@ impl Model {
             .app
             .umount(&Id::ConfigEditor(IdConfigEditor::LibraryLabel))
             .is_ok());
-
         assert!(self
             .app
             .umount(&Id::ConfigEditor(IdConfigEditor::LibraryForeground))
@@ -2770,6 +2874,28 @@ impl Model {
         assert!(self
             .app
             .umount(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder))
+            .is_ok());
+
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackLabel))
+            .is_ok());
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackForeground))
+            .is_ok());
+
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackBackground))
+            .is_ok());
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackBorder))
+            .is_ok());
+        assert!(self
+            .app
+            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackHighlight))
             .is_ok());
 
         assert!(self

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -6,8 +6,8 @@ use termusiclib::utils::{is_playlist, playlist_get_vec};
 use termusicplayback::SharedSettings;
 use tui_realm_stdlib::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::props::Borders;
 use tuirealm::props::{Alignment, BorderType, TableBuilder, TextSpan};
-use tuirealm::props::{Borders, Color};
 use tuirealm::{
     event::{Key, KeyEvent, KeyModifiers, NoUserEvent},
     AttrValue, Attribute, Component, Event, MockComponent, State, StateValue,
@@ -27,33 +27,15 @@ impl DBListCriteria {
             let config = config.read();
             List::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" DataBase ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -181,33 +163,15 @@ impl DBListSearchResult {
             let config = config.read();
             List::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Result ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -340,33 +304,15 @@ impl DBListSearchTracks {
             let config = config.read();
             List::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Tracks ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)

--- a/tui/src/ui/components/labels.rs
+++ b/tui/src/ui/components/labels.rs
@@ -28,7 +28,7 @@ use tui_realm_stdlib::{Label, Span, Spinner};
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, Color, PropPayload, PropValue, TextModifiers, TextSpan,
+    Alignment, AttrValue, Attribute, PropPayload, PropValue, TextModifiers, TextSpan,
 };
 use tuirealm::tui::layout::Rect;
 use tuirealm::{Component, Event, Frame, MockComponent, State};
@@ -44,18 +44,8 @@ impl LabelGeneric {
             component: Label::default()
                 .text(text)
                 .alignment(Alignment::Left)
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Cyan),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_highlight())
                 .modifiers(TextModifiers::BOLD),
         }
     }
@@ -81,18 +71,8 @@ impl LabelSpan {
             component: Span::default()
                 .spans(span)
                 .alignment(Alignment::Left)
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Cyan),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_highlight())
                 .modifiers(TextModifiers::BOLD),
             default_span: span.to_vec(),
             active_message_start_time: None,
@@ -160,18 +140,8 @@ impl DownloadSpinner {
     pub fn new(config: &Settings) -> Self {
         Self {
             component: Spinner::default()
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(config.style_color_symbol.library_highlight())
+                .background(config.style_color_symbol.library_background())
                 // .sequence("⣾⣽⣻⢿⡿⣟⣯⣷"),
                 // .sequence("▉▊▋▌▍▎▏▎▍▌▋▊▉"),
                 .sequence("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -12,7 +12,7 @@ use tui_realm_stdlib::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
-    Alignment, AttrValue, Attribute, BorderType, Borders, Color, PropPayload, PropValue, TextSpan,
+    Alignment, AttrValue, Attribute, BorderType, Borders, PropPayload, PropValue, TextSpan,
 };
 use tuirealm::{Component, Event, MockComponent, State, StateValue};
 
@@ -41,26 +41,11 @@ impl Lyric {
             Textarea::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .lyric_border()
-                                .unwrap_or(Color::Green),
-                        )
+                        .color(config.style_color_symbol.lyric_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .lyric_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .lyric_foreground()
-                        .unwrap_or(Color::Cyan),
-                )
+                .background(config.style_color_symbol.lyric_background())
+                .foreground(config.style_color_symbol.lyric_foreground())
                 .title(" Lyrics ", Alignment::Left)
                 // .wrap(true)
                 .step(4)

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -8,7 +8,6 @@ use tui_realm_treeview::{Node, Tree, TreeView, TREE_CMD_CLOSE, TREE_CMD_OPEN, TR
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{Alignment, BorderType, Borders, TableBuilder, TextSpan};
-use tuirealm::tui::style::Color;
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
@@ -28,38 +27,18 @@ impl MusicLibrary {
         let component = {
             let config = config.read();
             TreeView::default()
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .inactive(Style::default().fg(Color::Gray))
                 .indent_size(2)
                 .scroll_step(6)
                 .title(" Library ", Alignment::Left)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::Yellow),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlight_symbol(&config.style_color_symbol.library_highlight_symbol)
                 .preserve_state(true)
                 // .highlight_symbol("🦄")

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -13,8 +13,8 @@ use termusicplayback::PlayerCmd;
 use termusicplayback::SharedSettings;
 
 use tui_realm_stdlib::Table;
+use tuirealm::props::Borders;
 use tuirealm::props::{Alignment, BorderType, PropPayload, PropValue, TableBuilder, TextSpan};
-use tuirealm::props::{Borders, Color};
 use tuirealm::{
     command::{Cmd, CmdResult, Direction, Position},
     event::KeyModifiers,
@@ -36,33 +36,15 @@ impl Playlist {
             let config = config.read();
             Table::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .playlist_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.playlist_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .playlist_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .playlist_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.playlist_background())
+                .foreground(config.style_color_symbol.playlist_foreground())
                 .title(" Playlist ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .playlist_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.playlist_highlight())
                 .highlighted_str(&config.style_color_symbol.playlist_highlight_symbol)
                 .rewind(false)
                 .step(4)

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Handle;
 use tui_realm_stdlib::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::{Alignment, BorderType, TableBuilder, TextSpan};
-use tuirealm::props::{Borders, Color, PropPayload, PropValue};
+use tuirealm::props::{Borders, PropPayload, PropValue};
 use tuirealm::{
     event::{Key, KeyEvent, KeyModifiers, NoUserEvent},
     AttrValue, Attribute, Component, Event, MockComponent, State, StateValue,
@@ -35,33 +35,15 @@ impl FeedsList {
             let config = config.read();
             List::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Podcast Feeds: ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -213,33 +195,15 @@ impl EpisodeList {
             let config = config.read();
             List::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Episodes: ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -7,7 +7,7 @@ use tui_realm_stdlib::Input;
 use tuirealm::{
     command::{Cmd, CmdResult, Direction, Position},
     event::{Key, KeyEvent, KeyModifiers},
-    props::{Alignment, BorderType, Borders, Color, InputType},
+    props::{Alignment, BorderType, Borders, InputType},
     Component, Event, MockComponent, NoUserEvent, State, StateValue,
 };
 
@@ -25,18 +25,9 @@ impl DeleteConfirmRadioPopup {
         let component =
             YNConfirm::new_with_cb(config, " Are sure you want to delete? ", |config| {
                 YNConfirmStyle {
-                    foreground_color: config
-                        .style_color_symbol
-                        .important_popup_foreground()
-                        .unwrap_or(Color::LightRed),
-                    background_color: config
-                        .style_color_symbol
-                        .important_popup_background()
-                        .unwrap_or(Color::Reset),
-                    border_color: config
-                        .style_color_symbol
-                        .important_popup_border()
-                        .unwrap_or(Color::LightRed),
+                    foreground_color: config.style_color_symbol.important_popup_foreground(),
+                    background_color: config.style_color_symbol.important_popup_background(),
+                    border_color: config.style_color_symbol.important_popup_border(),
                     title_alignment: Alignment::Left,
                 }
             });
@@ -61,23 +52,11 @@ impl DeleteConfirmInputPopup {
     pub fn new(style_color_symbol: &StyleColorSymbol) -> Self {
         Self {
             component: Input::default()
-                .foreground(
-                    style_color_symbol
-                        .important_popup_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    style_color_symbol
-                        .important_popup_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(style_color_symbol.important_popup_foreground())
+                .background(style_color_symbol.important_popup_background())
                 .borders(
                     Borders::default()
-                        .color(
-                            style_color_symbol
-                                .important_popup_border()
-                                .unwrap_or(Color::Green),
-                        )
+                        .color(style_color_symbol.important_popup_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -27,15 +27,15 @@ impl DeleteConfirmRadioPopup {
                 YNConfirmStyle {
                     foreground_color: config
                         .style_color_symbol
-                        .library_foreground()
+                        .important_popup_foreground()
                         .unwrap_or(Color::LightRed),
                     background_color: config
                         .style_color_symbol
-                        .library_background()
+                        .important_popup_background()
                         .unwrap_or(Color::Reset),
                     border_color: config
                         .style_color_symbol
-                        .library_border()
+                        .important_popup_border()
                         .unwrap_or(Color::LightRed),
                     title_alignment: Alignment::Left,
                 }
@@ -63,17 +63,21 @@ impl DeleteConfirmInputPopup {
             component: Input::default()
                 .foreground(
                     style_color_symbol
-                        .library_foreground()
+                        .important_popup_foreground()
                         .unwrap_or(Color::Yellow),
                 )
                 .background(
                     style_color_symbol
-                        .library_background()
+                        .important_popup_background()
                         .unwrap_or(Color::Reset),
                 )
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.library_border().unwrap_or(Color::Green))
+                        .color(
+                            style_color_symbol
+                                .important_popup_border()
+                                .unwrap_or(Color::Green),
+                        )
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -47,13 +47,13 @@ impl GSInputPopup {
                     .background(
                         config
                             .style_color_symbol
-                            .library_background()
+                            .fallback_background()
                             .unwrap_or(Color::Reset),
                     )
                     .foreground(
                         config
                             .style_color_symbol
-                            .library_foreground()
+                            .fallback_foreground()
                             .unwrap_or(Color::Magenta),
                     )
                     .borders(
@@ -61,7 +61,7 @@ impl GSInputPopup {
                             .color(
                                 config
                                     .style_color_symbol
-                                    .library_border()
+                                    .fallback_border()
                                     .unwrap_or(Color::Magenta),
                             )
                             .modifiers(BorderType::Rounded),
@@ -78,13 +78,13 @@ impl GSInputPopup {
                     .background(
                         config
                             .style_color_symbol
-                            .library_background()
+                            .fallback_background()
                             .unwrap_or(Color::Reset),
                     )
                     .foreground(
                         config
                             .style_color_symbol
-                            .library_foreground()
+                            .fallback_foreground()
                             .unwrap_or(Color::Magenta),
                     )
                     .borders(
@@ -92,7 +92,7 @@ impl GSInputPopup {
                             .color(
                                 config
                                     .style_color_symbol
-                                    .library_border()
+                                    .fallback_border()
                                     .unwrap_or(Color::Magenta),
                             )
                             .modifiers(BorderType::Rounded),
@@ -209,7 +209,7 @@ impl GSTablePopup {
                         .color(
                             config_r
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -217,13 +217,13 @@ impl GSTablePopup {
                 .background(
                     config_r
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config_r
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .title(title_library, Alignment::Left)
@@ -231,7 +231,7 @@ impl GSTablePopup {
                 .highlighted_color(
                     config_r
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
@@ -254,7 +254,7 @@ impl GSTablePopup {
                         .color(
                             config_r
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -262,13 +262,13 @@ impl GSTablePopup {
                 .background(
                     config_r
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config_r
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .title(title_playlist, Alignment::Left)
@@ -276,7 +276,7 @@ impl GSTablePopup {
                 .highlighted_color(
                     config_r
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
@@ -298,7 +298,7 @@ impl GSTablePopup {
                         .color(
                             config_r
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -306,13 +306,13 @@ impl GSTablePopup {
                 .background(
                     config_r
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config_r
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .title(title_database, Alignment::Left)
@@ -320,7 +320,7 @@ impl GSTablePopup {
                 .highlighted_color(
                     config_r
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
@@ -342,7 +342,7 @@ impl GSTablePopup {
                         .color(
                             config_r
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -350,13 +350,13 @@ impl GSTablePopup {
                 .background(
                     config_r
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config_r
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .title(title_episode, Alignment::Left)
@@ -364,7 +364,7 @@ impl GSTablePopup {
                 .highlighted_color(
                     config_r
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
@@ -386,7 +386,7 @@ impl GSTablePopup {
                         .color(
                             config_r
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -394,13 +394,13 @@ impl GSTablePopup {
                 .background(
                     config_r
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config_r
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .title(title_podcast, Alignment::Left)
@@ -408,7 +408,7 @@ impl GSTablePopup {
                 .highlighted_color(
                     config_r
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -30,7 +30,7 @@ use tui_realm_stdlib::{Input, Table};
 use tui_realm_treeview::TREE_INITIAL_NODE;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, InputType, TableBuilder, TextSpan};
+use tuirealm::props::{Alignment, BorderType, Borders, InputType, TableBuilder, TextSpan};
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
@@ -44,26 +44,11 @@ impl GSInputPopup {
         match source {
             Source::Episode => Self {
                 component: Input::default()
-                    .background(
-                        config
-                            .style_color_symbol
-                            .fallback_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .fallback_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
+                    .background(config.style_color_symbol.fallback_background())
+                    .foreground(config.style_color_symbol.fallback_foreground())
                     .borders(
                         Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .fallback_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
+                            .color(config.style_color_symbol.fallback_border())
                             .modifiers(BorderType::Rounded),
                     )
                     .input_type(InputType::Text)
@@ -75,26 +60,11 @@ impl GSInputPopup {
             },
             _ => Self {
                 component: Input::default()
-                    .background(
-                        config
-                            .style_color_symbol
-                            .fallback_background()
-                            .unwrap_or(Color::Reset),
-                    )
-                    .foreground(
-                        config
-                            .style_color_symbol
-                            .fallback_foreground()
-                            .unwrap_or(Color::Magenta),
-                    )
+                    .background(config.style_color_symbol.fallback_background())
+                    .foreground(config.style_color_symbol.fallback_foreground())
                     .borders(
                         Borders::default()
-                            .color(
-                                config
-                                    .style_color_symbol
-                                    .fallback_border()
-                                    .unwrap_or(Color::Magenta),
-                            )
+                            .color(config.style_color_symbol.fallback_border())
                             .modifiers(BorderType::Rounded),
                     )
                     .input_type(InputType::Text)
@@ -206,34 +176,14 @@ impl GSTablePopup {
             Source::Library => Table::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config_r
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config_r.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config_r
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config_r
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config_r.style_color_symbol.fallback_background())
+                .foreground(config_r.style_color_symbol.fallback_foreground())
                 .title(title_library, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -251,34 +201,14 @@ impl GSTablePopup {
             Source::Playlist => Table::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config_r
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config_r.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config_r
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config_r
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config_r.style_color_symbol.fallback_background())
+                .foreground(config_r.style_color_symbol.fallback_foreground())
                 .title(title_playlist, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -295,34 +225,14 @@ impl GSTablePopup {
             Source::Database => Table::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config_r
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config_r.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config_r
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config_r
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config_r.style_color_symbol.fallback_background())
+                .foreground(config_r.style_color_symbol.fallback_foreground())
                 .title(title_database, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -339,34 +249,14 @@ impl GSTablePopup {
             Source::Episode => Table::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config_r
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config_r.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config_r
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config_r
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config_r.style_color_symbol.fallback_background())
+                .foreground(config_r.style_color_symbol.fallback_foreground())
                 .title(title_episode, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)
@@ -383,34 +273,14 @@ impl GSTablePopup {
             Source::Podcast => Table::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config_r
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config_r.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config_r
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config_r
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config_r.style_color_symbol.fallback_background())
+                .foreground(config_r.style_color_symbol.fallback_foreground())
                 .title(title_podcast, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config_r
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
                 .rewind(false)
                 .step(4)

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -43,26 +43,26 @@ impl HelpPopup {
                     Borders::default().modifiers(BorderType::Rounded).color(
                         config
                             .style_color_symbol
-                            .library_border()
+                            .fallback_border()
                             .unwrap_or(Color::Green),
                     ),
                 )
                 .foreground(
                     config
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Yellow),
                 )
                 .background(
                     config
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Black),
                 )
                 .highlighted_color(
                     config
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -40,31 +40,13 @@ impl HelpPopup {
             let keys = &config.keys;
             Table::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .fallback_border()
-                            .unwrap_or(Color::Green),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.fallback_border()),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Black),
-                )
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .foreground(config.style_color_symbol.fallback_foreground())
+                .background(config.style_color_symbol.fallback_background())
+                .highlighted_color(config.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .scroll(true)
                 .title(" Help: Esc or Enter to exit ", Alignment::Center)

--- a/tui/src/ui/components/popups/podcast.rs
+++ b/tui/src/ui/components/popups/podcast.rs
@@ -7,7 +7,7 @@ use tui_realm_stdlib::{Input, Table};
 use tuirealm::{
     command::{Cmd, CmdResult, Direction, Position},
     event::{Key, KeyEvent, KeyModifiers},
-    props::{Alignment, BorderType, Borders, Color, InputType, TableBuilder, TextSpan},
+    props::{Alignment, BorderType, Borders, InputType, TableBuilder, TextSpan},
     Component, Event, MockComponent, NoUserEvent, State, StateValue,
 };
 
@@ -24,19 +24,11 @@ impl PodcastAddPopup {
     pub fn new(style_color_symbol: &StyleColorSymbol) -> Self {
         Self {
             component: Input::default()
-                .foreground(
-                    style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(style_color_symbol.library_foreground())
+                .background(style_color_symbol.library_background())
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.library_border().unwrap_or(Color::Green))
+                        .color(style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -107,18 +99,9 @@ impl FeedDeleteConfirmRadioPopup {
         let component =
             YNConfirm::new_with_cb(config, " Are sure you to delete the feed? ", |config| {
                 YNConfirmStyle {
-                    foreground_color: config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::LightRed),
-                    background_color: config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                    border_color: config
-                        .style_color_symbol
-                        .library_border()
-                        .unwrap_or(Color::LightRed),
+                    foreground_color: config.style_color_symbol.library_foreground(),
+                    background_color: config.style_color_symbol.library_background(),
+                    border_color: config.style_color_symbol.library_border(),
                     title_alignment: Alignment::Left,
                 }
             });
@@ -146,19 +129,11 @@ impl FeedDeleteConfirmInputPopup {
     pub fn new(style_color_symbol: &StyleColorSymbol) -> Self {
         Self {
             component: Input::default()
-                .foreground(
-                    style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(style_color_symbol.library_foreground())
+                .background(style_color_symbol.library_background())
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.library_border().unwrap_or(Color::Green))
+                        .color(style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -234,37 +209,17 @@ impl PodcastSearchTablePopup {
         let component = {
             let config = config.read();
             Table::default()
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config.style_color_symbol.library_background())
+                .foreground(config.style_color_symbol.library_foreground())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .foreground(Color::Yellow)
                 .title(" Enter to add feed: ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 // .highlighted_str("🚀")
                 .rewind(false)

--- a/tui/src/ui/components/popups/quit.rs
+++ b/tui/src/ui/components/popups/quit.rs
@@ -23,10 +23,7 @@
  */
 use termusiclib::types::{Id, Msg};
 use termusicplayback::SharedSettings;
-use tuirealm::{
-    props::{Alignment, Color},
-    Component, Event, MockComponent, NoUserEvent,
-};
+use tuirealm::{props::Alignment, Component, Event, MockComponent, NoUserEvent};
 
 use crate::ui::model::Model;
 
@@ -41,18 +38,9 @@ impl QuitPopup {
     pub fn new(config: SharedSettings) -> Self {
         let component = YNConfirm::new_with_cb(config, " Are sure you want to quit? ", |config| {
             YNConfirmStyle {
-                foreground_color: config
-                    .style_color_symbol
-                    .important_popup_foreground()
-                    .unwrap_or(Color::Yellow),
-                background_color: config
-                    .style_color_symbol
-                    .important_popup_background()
-                    .unwrap_or(Color::Reset),
-                border_color: config
-                    .style_color_symbol
-                    .important_popup_border()
-                    .unwrap_or(Color::Yellow),
+                foreground_color: config.style_color_symbol.important_popup_foreground(),
+                background_color: config.style_color_symbol.important_popup_background(),
+                border_color: config.style_color_symbol.important_popup_border(),
                 title_alignment: Alignment::Center,
             }
         });

--- a/tui/src/ui/components/popups/quit.rs
+++ b/tui/src/ui/components/popups/quit.rs
@@ -43,15 +43,15 @@ impl QuitPopup {
             YNConfirmStyle {
                 foreground_color: config
                     .style_color_symbol
-                    .library_foreground()
+                    .important_popup_foreground()
                     .unwrap_or(Color::Yellow),
                 background_color: config
                     .style_color_symbol
-                    .library_background()
+                    .important_popup_background()
                     .unwrap_or(Color::Reset),
                 border_color: config
                     .style_color_symbol
-                    .library_border()
+                    .important_popup_border()
                     .unwrap_or(Color::Yellow),
                 title_alignment: Alignment::Center,
             }

--- a/tui/src/ui/components/popups/saveplaylist.rs
+++ b/tui/src/ui/components/popups/saveplaylist.rs
@@ -27,17 +27,17 @@ impl SavePlaylistPopup {
             component: Input::default()
                 .foreground(
                     style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Yellow),
                 )
                 .background(
                     style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.library_border().unwrap_or(Color::Green))
+                        .color(style_color_symbol.fallback_border().unwrap_or(Color::Green))
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -113,15 +113,15 @@ impl SavePlaylistConfirmPopup {
             YNConfirmStyle {
                 foreground_color: config
                     .style_color_symbol
-                    .library_foreground()
+                    .important_popup_foreground()
                     .unwrap_or(Color::Yellow),
                 background_color: config
                     .style_color_symbol
-                    .library_background()
+                    .important_popup_background()
                     .unwrap_or(Color::Reset),
                 border_color: config
                     .style_color_symbol
-                    .library_border()
+                    .important_popup_border()
                     .unwrap_or(Color::Yellow),
                 title_alignment: Alignment::Center,
             }

--- a/tui/src/ui/components/popups/saveplaylist.rs
+++ b/tui/src/ui/components/popups/saveplaylist.rs
@@ -8,7 +8,7 @@ use tui_realm_stdlib::Input;
 use tuirealm::{
     command::{Cmd, CmdResult, Direction, Position},
     event::{Key, KeyEvent, KeyModifiers},
-    props::{Alignment, BorderType, Borders, Color, InputType},
+    props::{Alignment, BorderType, Borders, InputType},
     Component, Event, MockComponent, NoUserEvent, State, StateValue,
 };
 
@@ -25,19 +25,11 @@ impl SavePlaylistPopup {
     pub fn new(style_color_symbol: &StyleColorSymbol) -> Self {
         Self {
             component: Input::default()
-                .foreground(
-                    style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(style_color_symbol.fallback_foreground())
+                .background(style_color_symbol.fallback_background())
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.fallback_border().unwrap_or(Color::Green))
+                        .color(style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -111,18 +103,9 @@ impl SavePlaylistConfirmPopup {
     pub fn new(config: SharedSettings, filename: &str) -> Self {
         let component = YNConfirm::new_with_cb(config, " Playlist exists. Overwrite? ", |config| {
             YNConfirmStyle {
-                foreground_color: config
-                    .style_color_symbol
-                    .important_popup_foreground()
-                    .unwrap_or(Color::Yellow),
-                background_color: config
-                    .style_color_symbol
-                    .important_popup_background()
-                    .unwrap_or(Color::Reset),
-                border_color: config
-                    .style_color_symbol
-                    .important_popup_border()
-                    .unwrap_or(Color::Yellow),
+                foreground_color: config.style_color_symbol.important_popup_foreground(),
+                background_color: config.style_color_symbol.important_popup_background(),
+                border_color: config.style_color_symbol.important_popup_border(),
                 title_alignment: Alignment::Center,
             }
         });

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -43,13 +43,13 @@ impl YSInputPopup {
                 .background(
                     config
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .borders(
@@ -57,7 +57,7 @@ impl YSInputPopup {
                         .color(
                             config
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -127,13 +127,13 @@ impl YSTablePopup {
                 .background(
                     config
                         .style_color_symbol
-                        .library_background()
+                        .fallback_background()
                         .unwrap_or(Color::Reset),
                 )
                 .foreground(
                     config
                         .style_color_symbol
-                        .library_foreground()
+                        .fallback_foreground()
                         .unwrap_or(Color::Magenta),
                 )
                 .borders(
@@ -141,7 +141,7 @@ impl YSTablePopup {
                         .color(
                             config
                                 .style_color_symbol
-                                .library_border()
+                                .fallback_border()
                                 .unwrap_or(Color::Magenta),
                         )
                         .modifiers(BorderType::Rounded),
@@ -155,7 +155,7 @@ impl YSTablePopup {
                 .highlighted_color(
                     config
                         .style_color_symbol
-                        .library_highlight()
+                        .fallback_highlight()
                         .unwrap_or(Color::LightBlue),
                 )
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -28,7 +28,7 @@ use termusicplayback::SharedSettings;
 use tui_realm_stdlib::{Input, Table};
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, InputType, TableBuilder, TextSpan};
+use tuirealm::props::{Alignment, BorderType, Borders, InputType, TableBuilder, TextSpan};
 use tuirealm::{Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
@@ -40,26 +40,11 @@ impl YSInputPopup {
     pub fn new(config: &Settings) -> Self {
         Self {
             component: Input::default()
-                .background(
-                    config
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config.style_color_symbol.fallback_background())
+                .foreground(config.style_color_symbol.fallback_foreground())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -124,26 +109,11 @@ impl YSTablePopup {
         let component = {
             let config = config.read();
             Table::default()
-                .background(
-                    config
-                        .style_color_symbol
-                        .fallback_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .fallback_foreground()
-                        .unwrap_or(Color::Magenta),
-                )
+                .background(config.style_color_symbol.fallback_background())
+                .foreground(config.style_color_symbol.fallback_foreground())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .fallback_border()
-                                .unwrap_or(Color::Magenta),
-                        )
+                        .color(config.style_color_symbol.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .foreground(Color::Yellow)
@@ -152,12 +122,7 @@ impl YSTablePopup {
                     Alignment::Left,
                 )
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .fallback_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.fallback_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 // .highlighted_str("🚀")
                 .rewind(false)

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -5,7 +5,7 @@ use termusiclib::track::{MediaType, Track};
 use termusiclib::types::{Id, Msg};
 use tui_realm_stdlib::ProgressBar;
 use tuirealm::event::NoUserEvent;
-use tuirealm::props::{Alignment, BorderType, Borders, Color, PropPayload, PropValue};
+use tuirealm::props::{Alignment, BorderType, Borders, PropPayload, PropValue};
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent};
 
 #[derive(MockComponent)]
@@ -20,26 +20,11 @@ impl Progress {
             component: ProgressBar::default()
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .progress_border()
-                                .unwrap_or(Color::LightMagenta),
-                        )
+                        .color(config.style_color_symbol.progress_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(
-                    config
-                        .style_color_symbol
-                        .progress_background()
-                        .unwrap_or(Color::Reset),
-                )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .progress_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
+                .background(config.style_color_symbol.progress_background())
+                .foreground(config.style_color_symbol.progress_foreground())
                 .label("Progress")
                 .title(
                     format!(

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -206,27 +206,16 @@ impl TECounterDelete {
             let config = config.read();
             Counter::default()
                 .alignment(Alignment::Center)
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .background(config.style_color_symbol.library_background())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightRed),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 .foreground(
                     // config
                     //     .style_color_symbol
-                    //     .library_highlight()
-                    //     .unwrap_or(Color::Cyan),
+                    //     .library_highlight(),
                     Color::Red,
                 )
                 .modifiers(TextModifiers::BOLD)

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -26,7 +26,7 @@ use termusicplayback::SharedSettings;
 use tui_realm_stdlib::Input;
 use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, InputType};
+use tuirealm::props::{Alignment, BorderType, Borders, InputType};
 use tuirealm::{Component, Event, MockComponent};
 
 /// Common Field Properties and event handling
@@ -42,26 +42,11 @@ impl EditField {
         let component = {
             let config = config.read();
             Input::default()
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Cyan),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Black),
-                )
+                .foreground(config.style_color_symbol.library_foreground())
+                .background(config.style_color_symbol.library_background())
                 .borders(
                     Borders::default()
-                        .color(
-                            config
-                                .style_color_symbol
-                                .library_border()
-                                .unwrap_or(Color::LightYellow),
-                        )
+                        .color(config.style_color_symbol.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 .input_type(InputType::Text)

--- a/tui/src/ui/components/tag_editor/te_select_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_select_lyric.rs
@@ -26,7 +26,7 @@ use termusicplayback::SharedSettings;
 use tui_realm_stdlib::Select;
 use tuirealm::command::{Cmd, CmdResult, Direction};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color};
+use tuirealm::props::{Alignment, BorderType, Borders};
 use tuirealm::{Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
@@ -41,27 +41,14 @@ impl TESelectLyric {
             let config = config.read();
             Select::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::LightRed),
-                )
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Select a lyric ", Alignment::Center)
                 .rewind(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightGreen),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
                 .choices(&["No Lyric"])
         };

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -31,7 +31,7 @@ use tokio::runtime::Handle;
 use tui_realm_stdlib::Table;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, TableBuilder, TextSpan};
+use tuirealm::props::{Alignment, BorderType, Borders, TableBuilder, TextSpan};
 use tuirealm::{Component, Event, MockComponent, State, StateValue};
 
 #[derive(MockComponent)]
@@ -46,33 +46,15 @@ impl TETableLyricOptions {
             let config = config.read();
             Table::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::Blue),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Yellow),
-                )
-                .background(
-                    config
-                        .style_color_symbol
-                        .library_background()
-                        .unwrap_or(Color::Reset),
-                )
+                .foreground(config.style_color_symbol.library_foreground())
+                .background(config.style_color_symbol.library_background())
                 .title(" Search Results ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(
-                    config
-                        .style_color_symbol
-                        .library_highlight()
-                        .unwrap_or(Color::LightBlue),
-                )
+                .highlighted_color(config.style_color_symbol.library_highlight())
                 .highlighted_str("\u{1f680}")
                 // .highlighted_str("🚀")
                 .rewind(false)

--- a/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
@@ -28,7 +28,7 @@ use termusicplayback::SharedSettings;
 use tui_realm_stdlib::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, BorderType, Borders, Color, TextSpan};
+use tuirealm::props::{Alignment, BorderType, Borders, TextSpan};
 use tuirealm::{Component, Event, MockComponent};
 
 #[derive(MockComponent)]
@@ -43,19 +43,11 @@ impl TETextareaLyric {
             let config = config.read();
             Textarea::default()
                 .borders(
-                    Borders::default().modifiers(BorderType::Rounded).color(
-                        config
-                            .style_color_symbol
-                            .library_border()
-                            .unwrap_or(Color::LightMagenta),
-                    ),
+                    Borders::default()
+                        .modifiers(BorderType::Rounded)
+                        .color(config.style_color_symbol.library_border()),
                 )
-                .foreground(
-                    config
-                        .style_color_symbol
-                        .library_foreground()
-                        .unwrap_or(Color::Green),
-                )
+                .foreground(config.style_color_symbol.library_foreground())
                 .title(" Lyrics ", Alignment::Left)
                 .step(4)
                 .highlighted_str("\u{1f3b5}")

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -31,7 +31,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use termusiclib::track::Track;
 use termusiclib::types::{Id, IdTagEditor};
-use tuirealm::props::{Alignment, AttrValue, Attribute, Color, PropPayload, PropValue, TextSpan};
+use tuirealm::props::{Alignment, AttrValue, Attribute, PropPayload, PropValue, TextSpan};
 use tuirealm::tui::layout::{Constraint, Direction, Layout};
 use tuirealm::tui::widgets::Clear;
 use tuirealm::State;
@@ -472,50 +472,28 @@ impl Model {
                     &[
                         TextSpan::new(format!("<{}>", config.keys.config_save))
                             .bold()
-                            .fg(config
-                                .style_color_symbol
-                                .library_highlight()
-                                .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Save tag ").fg(config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::White)),
+                            .fg(config.style_color_symbol.library_highlight()),
+                        TextSpan::new(" Save tag ")
+                            .fg(config.style_color_symbol.library_foreground()),
                         TextSpan::new(format!("<{}>", config.keys.global_esc))
                             .bold()
-                            .fg(config
-                                .style_color_symbol
-                                .library_highlight()
-                                .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Exit ").fg(config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::White)),
-                        TextSpan::new("<Tab/ShiftTab>").bold().fg(config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Change field ").fg(config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::White)),
-                        TextSpan::new("<ENTER>").bold().fg(config
-                            .style_color_symbol
-                            .library_highlight()
-                            .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" Search/Embed tag ").fg(config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::White)),
+                            .fg(config.style_color_symbol.library_highlight()),
+                        TextSpan::new(" Exit ").fg(config.style_color_symbol.library_foreground()),
+                        TextSpan::new("<Tab/ShiftTab>")
+                            .bold()
+                            .fg(config.style_color_symbol.library_highlight()),
+                        TextSpan::new(" Change field ")
+                            .fg(config.style_color_symbol.library_foreground()),
+                        TextSpan::new("<ENTER>")
+                            .bold()
+                            .fg(config.style_color_symbol.library_highlight()),
+                        TextSpan::new(" Search/Embed tag ")
+                            .fg(config.style_color_symbol.library_foreground()),
                         TextSpan::new(format!("<{}>", config.keys.library_search_youtube))
                             .bold()
-                            .fg(config
-                                .style_color_symbol
-                                .library_highlight()
-                                .unwrap_or(Color::Cyan)),
-                        TextSpan::new(" download ").fg(config
-                            .style_color_symbol
-                            .library_foreground()
-                            .unwrap_or(Color::White)),
+                            .fg(config.style_color_symbol.library_highlight()),
+                        TextSpan::new(" download ")
+                            .fg(config.style_color_symbol.library_foreground()),
                     ]
                 )),
                 Vec::default(),

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -572,77 +572,41 @@ impl Model {
                     &config,
                     &[
                         TextSpan::new(" Help: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_help))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(" Config: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_config_open))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(" Library: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_treeview))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(" Database: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_database))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(" Podcasts: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_podcast))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(" Version: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Blue))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         // maybe consider moving version into Help or Config or its own popup (like a About)
                         TextSpan::new(env!("TERMUSIC_VERSION"))
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                     ],
                 )),
@@ -669,23 +633,14 @@ impl Model {
                     &config,
                     &[
                         TextSpan::new("Full name: ")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_highlight()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_highlight())
                             .bold(),
                         TextSpan::new(path_string)
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Red))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                         TextSpan::new(filename).fg(Color::Cyan).bold(),
                         TextSpan::new(".m3u")
-                            .fg(config
-                                .style_color_symbol
-                                .fallback_foreground()
-                                .unwrap_or(Color::Cyan))
+                            .fg(config.style_color_symbol.fallback_foreground())
                             .bold(),
                     ],
                 )),
@@ -704,19 +659,9 @@ impl Model {
     ) {
         let config = self.config.read();
         let textspan = &[TextSpan::new(active_msg)
-            .fg(foreground.unwrap_or_else(|| {
-                config
-                    .style_color_symbol
-                    .library_highlight()
-                    .unwrap_or(Color::Cyan)
-            }))
+            .fg(foreground.unwrap_or_else(|| config.style_color_symbol.library_highlight()))
             .bold()
-            .bg(background.unwrap_or_else(|| {
-                config
-                    .style_color_symbol
-                    .library_background()
-                    .unwrap_or(Color::Reset)
-            }))];
+            .bg(background.unwrap_or_else(|| config.style_color_symbol.library_background()))];
         self.app
             .attr(
                 &Id::Label,

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -574,74 +574,74 @@ impl Model {
                         TextSpan::new(" Help: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_help))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Config: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_config_open))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Library: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_treeview))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Database: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_database))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Podcasts: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         TextSpan::new(format!("<{}>", config.keys.global_layout_podcast))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(" Version: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Blue))
                             .bold(),
                         // maybe consider moving version into Help or Config or its own popup (like a About)
                         TextSpan::new(env!("TERMUSIC_VERSION"))
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                     ],
@@ -671,20 +671,20 @@ impl Model {
                         TextSpan::new("Full name: ")
                             .fg(config
                                 .style_color_symbol
-                                .library_highlight()
+                                .fallback_highlight()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                         TextSpan::new(path_string)
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Red))
                             .bold(),
                         TextSpan::new(filename).fg(Color::Cyan).bold(),
                         TextSpan::new(".m3u")
                             .fg(config
                                 .style_color_symbol
-                                .library_foreground()
+                                .fallback_foreground()
                                 .unwrap_or(Color::Cyan))
                             .bold(),
                     ],


### PR DESCRIPTION
This PR does:
- add color customization `important_popup_*` (like quit, delete, save config, does not include Error)
- add color customization `fallback_*` (instead of relying on `library_*` as fallback, except for tag-editor, database and podcast views)
- refactor `lib::config::theme` to parse colors directly into integers on config / yaml parse, instead of on-demand (and also provides errors)
- change `lib::config::theme::StyleColorSymbol`'s functions (and by extension `ColorTermusic::color`) to not be fallible (thanks to the change above)

re #314 (not fully fixing it as this only concerns important popups and fallbacks, unless considered otherwise)

Note: this PR is basically to make the v2 config transition smoother by not having to change much else in the change to v2