### PR TITLE
refactor config & cli to use Path instead of Strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,7 +3518,9 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
+ "bstr",
  "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-shellexpand = "3.1"
+shellexpand = { version = "3.1", features = ["path"] }
 soundtouch = "0.4"
 souvlaki = "0.7.2"
 stream-download = { version = "0.5.2", features = ["reqwest-rustls"] }

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -359,7 +359,7 @@ impl Settings {
         path.push(FILE_NAME);
         let string = toml::to_string(self)?;
 
-        fs::write(path.to_string_lossy().as_ref(), string)?;
+        fs::write(path, string)?;
 
         Ok(())
     }

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -282,9 +282,9 @@ impl std::fmt::Display for LastPosition {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
-    pub music_dir: Vec<String>,
+    pub music_dir: Vec<PathBuf>,
     #[serde(skip)]
-    pub music_dir_from_cli: Option<String>,
+    pub music_dir_from_cli: Option<PathBuf>,
     #[serde(skip)]
     pub disable_album_art_from_cli: bool,
     #[serde(skip)]
@@ -299,7 +299,7 @@ pub struct Settings {
     pub player_gapless: bool,
     pub podcast_simultanious_download: usize,
     pub podcast_max_retries: usize,
-    pub podcast_dir: String,
+    pub podcast_dir: PathBuf,
     pub player_seek_step: SeekStep,
     pub player_remember_last_played_position: LastPosition,
     pub enable_exit_confirmation: bool,
@@ -322,7 +322,7 @@ impl Default for Settings {
         // if path.exists() {
         // }
         Self {
-            music_dir: MUSIC_DIR.to_vec(),
+            music_dir: MUSIC_DIR.iter().map(PathBuf::from).collect(),
             music_dir_from_cli: None,
             player_loop_mode: Loop::Random,
             player_volume: 70,
@@ -341,7 +341,7 @@ impl Default for Settings {
             disable_discord_rpc_from_cli: false,
             max_depth_cli: 4,
             podcast_simultanious_download: 3,
-            podcast_dir: PODCAST_DIR.to_string(),
+            podcast_dir: PathBuf::from(PODCAST_DIR.as_str()),
             podcast_max_retries: 3,
             player_seek_step: SeekStep::Auto,
             kill_daemon_when_quit: true,

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -48,16 +48,16 @@ pub const FILE_NAME: &str = "config.toml";
 lazy_static! {
     static ref MUSIC_DIR: Vec<String> = {
         let mut vec = Vec::new();
-        let mut path = dirs::audio_dir()
-            .unwrap_or_else(|| PathBuf::from(shellexpand::tilde("~/Music").to_string()));
+        let mut path =
+            dirs::audio_dir().unwrap_or_else(|| PathBuf::from(shellexpand::path::tilde("~/Music")));
         vec.push(path.as_path().to_string_lossy().to_string());
         path.push("mp3");
         vec.push(path.as_path().to_string_lossy().to_string());
         vec
     };
     static ref PODCAST_DIR: String = {
-        let mut path = dirs::audio_dir()
-            .unwrap_or_else(|| PathBuf::from(shellexpand::tilde("~/Music").to_string()));
+        let mut path =
+            dirs::audio_dir().unwrap_or_else(|| PathBuf::from(shellexpand::path::tilde("~/Music")));
         path.push(Path::new("podcast"));
         path.as_path().to_string_lossy().to_string()
     };

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -35,31 +35,28 @@ use image::DynamicImage;
 pub use key::{BindingForEvent, Keys};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{fs, net::IpAddr};
 pub use theme::{Alacritty, ColorTermusic, StyleColorSymbol};
 
 /// The filename of the config
 pub const FILE_NAME: &str = "config.toml";
 
-// pub const MUSIC_DIR: [&str; 2] = ["~/Music/mp3", "~/Music"];
-// pub const PODCAST_DIR: &str = "~/.cache/termusic/podcast";
-
 lazy_static! {
-    static ref MUSIC_DIR: Vec<String> = {
+    static ref MUSIC_DIR: Vec<PathBuf> = {
         let mut vec = Vec::new();
         let mut path =
             dirs::audio_dir().unwrap_or_else(|| PathBuf::from(shellexpand::path::tilde("~/Music")));
-        vec.push(path.as_path().to_string_lossy().to_string());
+        vec.push(path.clone());
         path.push("mp3");
-        vec.push(path.as_path().to_string_lossy().to_string());
+        vec.push(path);
         vec
     };
-    static ref PODCAST_DIR: String = {
+    static ref PODCAST_DIR: PathBuf = {
         let mut path =
             dirs::audio_dir().unwrap_or_else(|| PathBuf::from(shellexpand::path::tilde("~/Music")));
-        path.push(Path::new("podcast"));
-        path.as_path().to_string_lossy().to_string()
+        path.push("podcast");
+        path
     };
 }
 
@@ -317,12 +314,8 @@ pub struct Settings {
 
 impl Default for Settings {
     fn default() -> Self {
-        // let absolute_dir = shellexpand::tilde(&MUSIC_DIR).to_string();
-        // let path = Path::new(&dir);
-        // if path.exists() {
-        // }
         Self {
-            music_dir: MUSIC_DIR.iter().map(PathBuf::from).collect(),
+            music_dir: MUSIC_DIR.clone(),
             music_dir_from_cli: None,
             player_loop_mode: Loop::Random,
             player_volume: 70,
@@ -341,7 +334,7 @@ impl Default for Settings {
             disable_discord_rpc_from_cli: false,
             max_depth_cli: 4,
             podcast_simultanious_download: 3,
-            podcast_dir: PathBuf::from(PODCAST_DIR.as_str()),
+            podcast_dir: PODCAST_DIR.clone(),
             podcast_max_retries: 3,
             player_seek_step: SeekStep::Auto,
             kill_daemon_when_quit: true,

--- a/lib/src/podcast/mod.rs
+++ b/lib/src/podcast/mod.rs
@@ -572,13 +572,13 @@ impl Drop for TaskPool {
 /// Imports a list of podcasts from OPML format, either reading from a
 /// file or from stdin. If the `replace` flag is set, this replaces all
 /// existing data in the database.
-pub fn import_from_opml(db_path: &Path, config: &Settings, filepath: &str) -> Result<()> {
+pub fn import_from_opml(db_path: &Path, config: &Settings, file: &Path) -> Result<()> {
     // read from file or from stdin
-    let mut f =
-        File::open(filepath).with_context(|| format!("Could not open OPML file: {filepath}"))?;
+    let mut f = File::open(file)
+        .with_context(|| format!("Could not open OPML file: {}", file.display()))?;
     let mut contents = String::new();
     f.read_to_string(&mut contents)
-        .with_context(|| format!("Failed to read from OPML file: {filepath}"))?;
+        .with_context(|| format!("Failed to read from OPML file: {}", file.display()))?;
     let xml = contents;
 
     let mut podcast_list = import_opml_feeds(&xml).with_context(|| {
@@ -682,7 +682,7 @@ pub fn import_from_opml(db_path: &Path, config: &Settings, filepath: &str) -> Re
 
 /// Exports all podcasts to OPML format, either printing to stdout or
 /// exporting to a file.
-pub fn export_to_opml(db_path: &Path, file: &str) -> Result<()> {
+pub fn export_to_opml(db_path: &Path, file: &Path) -> Result<()> {
     let db_inst = Database::connect(db_path)?;
     let podcast_list = db_inst.get_podcasts()?;
     let opml = export_opml_feeds(&podcast_list);
@@ -692,10 +692,14 @@ pub fn export_to_opml(db_path: &Path, file: &str) -> Result<()> {
         .map_err(|err| anyhow!(err))
         .with_context(|| "Could not create OPML format")?;
 
-    let mut dst =
-        File::create(file).with_context(|| format!("Could not create output file: {file}"))?;
-    dst.write_all(xml.as_bytes())
-        .with_context(|| format!("Could not copy OPML data to output file: {file}"))?;
+    let mut dst = File::create(file)
+        .with_context(|| format!("Could not create output file: {}", file.display()))?;
+    dst.write_all(xml.as_bytes()).with_context(|| {
+        format!(
+            "Could not copy OPML data to output file: {}",
+            file.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -36,7 +36,7 @@ pub struct Args {
     pub action: Option<Action>,
     /// With no MUSIC_DIRECTORY, use config in `~/.config/termusic/config.toml`,
     /// default is ~/Music.
-    pub music_directory: Option<String>,
+    pub music_directory: Option<PathBuf>,
     /// Not showing album cover. default is showing.  
     #[arg(short = 'c', long)]
     pub disable_cover: bool,
@@ -108,12 +108,12 @@ pub enum Action {
     /// Import feeds from opml file.
     Export {
         #[arg(value_name = "FILE")]
-        file: String,
+        file: PathBuf,
     },
     /// Export feeds to opml file.
     Import {
         #[arg(value_name = "FILE")]
-        file: String,
+        file: PathBuf,
     },
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[cfg(any(feature = "gst", feature = "rusty"))]
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use music_player_service::MusicPlayerService;
 use parking_lot::Mutex;
@@ -375,7 +375,7 @@ fn get_config(args: &cli::Args) -> Result<Settings> {
     config.disable_discord_rpc_from_cli = args.disable_discord;
 
     if let Some(dir) = &args.music_directory {
-        config.music_dir_from_cli = get_path(dir);
+        config.music_dir_from_cli = Some(get_path(dir).context("cli provided music-dir")?);
     }
 
     config.max_depth_cli = match args.max_depth {
@@ -386,8 +386,7 @@ fn get_config(args: &cli::Args) -> Result<Settings> {
     Ok(config)
 }
 
-fn get_path(dir: &str) -> Option<String> {
-    let music_dir: Option<String>;
+fn get_path(dir: &str) -> Result<String> {
     let mut path = Path::new(&dir).to_path_buf();
 
     if path.exists() {
@@ -401,10 +400,8 @@ fn get_path(dir: &str) -> Option<String> {
             path = p_canonical;
         }
 
-        music_dir = Some(path.to_string_lossy().to_string());
-    } else {
-        error!("Error: unknown directory '{dir}'");
-        std::process::exit(0);
+        return Ok(path.to_string_lossy().to_string());
     }
-    music_dir
+
+    bail!("Error: non-existing directory '{dir}'");
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -2,7 +2,7 @@ mod cli;
 mod logger;
 mod music_player_service;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(any(feature = "gst", feature = "rusty"))]
 use std::time::Duration;
@@ -386,8 +386,8 @@ fn get_config(args: &cli::Args) -> Result<Settings> {
     Ok(config)
 }
 
-fn get_path(dir: &str) -> Result<String> {
-    let mut path = Path::new(&dir).to_path_buf();
+fn get_path(dir: &Path) -> Result<PathBuf> {
+    let mut path = dir.to_path_buf();
 
     if path.exists() {
         if !path.has_root() {
@@ -400,8 +400,8 @@ fn get_path(dir: &str) -> Result<String> {
             path = p_canonical;
         }
 
-        return Ok(path.to_string_lossy().to_string());
+        return Ok(path);
     }
 
-    bail!("Error: non-existing directory '{dir}'");
+    bail!("Error: non-existing directory '{}'", dir.display());
 }

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -35,7 +35,7 @@ pub struct Args {
     pub action: Option<Action>,
     /// With no `MUSIC_DIRECTORY`, use config in `~/.config/termusic/config.toml`,
     /// default is ~/Music.
-    pub music_directory: Option<String>,
+    pub music_directory: Option<PathBuf>,
     /// Not showing album cover. default is showing.  
     #[arg(short = 'c', long)]
     pub disable_cover: bool,
@@ -87,12 +87,12 @@ pub enum Action {
     /// Import feeds from opml file.
     Export {
         #[arg(value_name = "FILE")]
-        file: String,
+        file: PathBuf,
     },
     /// Export feeds to opml file.
     Import {
         #[arg(value_name = "FILE")]
-        file: String,
+        file: PathBuf,
     },
 }
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -232,8 +232,8 @@ fn get_config(args: &cli::Args) -> Result<Settings> {
     Ok(config)
 }
 
-fn get_path(dir: &str) -> Result<String> {
-    let mut path = Path::new(&dir).to_path_buf();
+fn get_path(dir: &Path) -> Result<PathBuf> {
+    let mut path = dir.to_path_buf();
 
     if path.exists() {
         if !path.has_root() {
@@ -246,39 +246,37 @@ fn get_path(dir: &str) -> Result<String> {
             path = p_canonical;
         }
 
-        return Ok(path.to_string_lossy().to_string());
+        return Ok(path);
     }
 
-    bail!("Error: non-existing directory '{dir}'");
+    bail!("Error: non-existing directory '{}'", dir.display());
 }
 
 fn execute_action(action: cli::Action, config: &Settings) -> Result<()> {
     match action {
         cli::Action::Import { file } => {
-            println!("need to import from file {file}");
+            println!("need to import from file {}", file.display());
 
-            let path_string = get_path(&file).context("import cli file-path")?;
+            let path = get_path(&file).context("import cli file-path")?;
             let config_dir_path =
                 utils::get_app_config_path().context("getting app-config-path")?;
 
-            podcast::import_from_opml(&config_dir_path, config, &PathBuf::from(path_string))
-                .context("import opml")?;
+            podcast::import_from_opml(&config_dir_path, config, &path).context("import opml")?;
         }
         cli::Action::Export { file } => {
-            println!("need to export to file {file}");
-            let path_string = get_path_export(&file);
+            println!("need to export to file {}", file.display());
+            let path = get_path_export(&file);
             let config_dir_path =
                 utils::get_app_config_path().context("getting app-config-path")?;
-            podcast::export_to_opml(&config_dir_path, &PathBuf::from(path_string))
-                .context("export opml")?;
+            podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
         }
     };
 
     Ok(())
 }
 
-fn get_path_export(dir: &str) -> String {
-    let mut path = Path::new(&dir).to_path_buf();
+fn get_path_export(dir: &Path) -> PathBuf {
+    let mut path = dir.to_path_buf();
 
     if !path.has_root() {
         if let Ok(p_base) = std::env::current_dir() {
@@ -290,5 +288,5 @@ fn get_path_export(dir: &str) -> String {
         path = p_canonical;
     }
 
-    path.to_string_lossy().to_string()
+    path
 }

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -35,6 +35,7 @@ use clap::Parser;
 use config::Settings;
 use flexi_logger::LogSpecification;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::process;
 use std::time::{Duration, Instant};
 use std::{error::Error, path::Path};
@@ -262,11 +263,15 @@ fn execute_action(action: cli::Action, config: &Settings) {
         cli::Action::Import { file } => {
             println!("need to import from file {file}");
 
-            let path_str = get_path(&file);
+            let path_string = get_path(&file);
             let db_path = utils::get_app_config_path();
 
-            if let (Some(path_str), Ok(db_path)) = (path_str, db_path) {
-                if let Err(e) = podcast::import_from_opml(db_path.as_path(), config, &path_str) {
+            if let (Some(path_string), Ok(db_path)) = (path_string, db_path) {
+                if let Err(e) = podcast::import_from_opml(
+                    db_path.as_path(),
+                    config,
+                    &PathBuf::from(path_string),
+                ) {
                     error!("Error when import file {file}: {e}");
                 }
             }
@@ -276,7 +281,9 @@ fn execute_action(action: cli::Action, config: &Settings) {
             let path_string = get_path_export(&file);
             if let Ok(db_path) = utils::get_app_config_path() {
                 println!("export to {path_string}");
-                if let Err(e) = podcast::export_to_opml(db_path.as_path(), &path_string) {
+                if let Err(e) =
+                    podcast::export_to_opml(db_path.as_path(), &PathBuf::from(path_string))
+                {
                     error!("Error when export file {file}: {e}");
                 }
             }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -45,7 +45,8 @@ impl MusicDir {
         let config_r = config.read();
         let mut music_dir = String::new();
         for m in &config_r.music_dir {
-            music_dir.push_str(m.as_str());
+            // this may be a problem in some slight cases
+            music_dir.push_str(&m.to_string_lossy());
             music_dir.push(';');
         }
         // remove the last ";"
@@ -389,7 +390,7 @@ impl PodcastDir {
                     Style::default().fg(Color::Rgb(128, 128, 128)),
                 )
                 .title(" Podcast Download Directory: ", Alignment::Left)
-                .value(&config.podcast_dir)
+                .value(config.podcast_dir.to_string_lossy())
         };
 
         Self { component, config }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -64,7 +64,7 @@ use crate::ui::model::{ConfigEditorLayout, Model};
 use crate::ui::utils::draw_area_in_absolute;
 use crate::ui::{Application, Id, IdConfigEditor, IdKey, Msg};
 use anyhow::{bail, Result};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use termusiclib::config::Alignment as XywhAlign;
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{PropPayload, PropValue, TableBuilder, TextSpan};
@@ -3302,11 +3302,10 @@ impl Model {
             // let mut vec = Vec::new();
             let vec = music_dir
                 .split(';')
-                .map(std::string::ToString::to_string)
+                .map(PathBuf::from)
                 .filter(|p| {
-                    let absolute_dir = shellexpand::tilde(p).to_string();
-                    let path = Path::new(&absolute_dir);
-                    path.exists()
+                    let absolute_dir = shellexpand::path::tilde(p);
+                    absolute_dir.exists()
                 })
                 .collect();
             config.music_dir = vec;
@@ -3348,10 +3347,9 @@ impl Model {
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PodcastDir))
         {
-            let absolute_dir = shellexpand::tilde(&podcast_dir).to_string();
-            let path = Path::new(&absolute_dir);
-            if path.exists() {
-                config.podcast_dir = absolute_dir;
+            let absolute_dir = shellexpand::path::tilde(&podcast_dir);
+            if absolute_dir.exists() {
+                config.podcast_dir = absolute_dir.into_owned();
             }
         }
         if let Ok(State::One(StateValue::String(podcast_simul_download))) = self

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -462,11 +462,11 @@ impl Model {
         let mut vec = Vec::new();
         let config = self.config.read();
         for dir in &config.music_dir {
-            let absolute_dir = shellexpand::tilde(dir).to_string();
+            let absolute_dir = shellexpand::path::tilde(dir).into_owned();
             vec.push(absolute_dir);
         }
         if let Some(dir) = &config.music_dir_from_cli {
-            let absolute_dir = shellexpand::tilde(&dir).to_string();
+            let absolute_dir = shellexpand::path::tilde(dir).into_owned();
             vec.push(absolute_dir);
         }
         if vec.is_empty() {
@@ -475,9 +475,9 @@ impl Model {
         drop(config);
 
         let mut index = 0;
-        let current_path_str = self.path.to_string_lossy().to_string();
+        let current_path = self.path.as_path();
         for (idx, dir) in vec.iter().enumerate() {
-            if current_path_str == *dir {
+            if current_path == *dir {
                 index = idx + 1;
                 break;
             }
@@ -493,17 +493,17 @@ impl Model {
     }
 
     pub fn library_add_root(&mut self) -> Result<()> {
-        let current_path_string = self.path.to_string_lossy().to_string();
+        let current_path = self.path.as_path();
 
         let mut config = self.config.write();
 
         for dir in &config.music_dir {
-            let absolute_dir = shellexpand::tilde(dir).to_string();
-            if absolute_dir == current_path_string {
+            let absolute_dir = shellexpand::path::tilde(dir);
+            if absolute_dir == current_path {
                 bail!("Add root failed, same root already exists");
             }
         }
-        config.music_dir.push(current_path_string);
+        config.music_dir.push(current_path.to_path_buf());
         let res = config.save();
         drop(config);
         match res {
@@ -518,13 +518,13 @@ impl Model {
     }
 
     pub fn library_remove_root(&mut self) -> Result<()> {
-        let current_path_string = self.path.to_string_lossy().to_string();
+        let current_path = self.path.as_path();
         let mut config = self.config.write();
 
         let mut vec = Vec::new();
         for dir in &config.music_dir {
-            let absolute_dir = shellexpand::tilde(dir).to_string();
-            if absolute_dir == current_path_string {
+            let absolute_dir = shellexpand::path::tilde(dir);
+            if absolute_dir == current_path {
                 continue;
             }
             vec.push(dir.clone());

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -224,16 +224,19 @@ impl Model {
         }
     }
 
+    /// Get the first music directory or the cli provided music dir resolved
     pub fn get_full_path_from_config(config: &Settings) -> PathBuf {
-        let mut full_path = String::new();
+        if let Some(music_dir) = &config.music_dir_from_cli {
+            return shellexpand::path::tilde(music_dir).into_owned();
+        };
+
         if let Some(dir) = config.music_dir.first() {
-            full_path = shellexpand::tilde(dir).to_string();
+            return shellexpand::path::tilde(dir).into_owned();
         }
 
-        if let Some(music_dir) = &config.music_dir_from_cli {
-            full_path = shellexpand::tilde(music_dir).to_string();
-        };
-        PathBuf::from(full_path)
+        warn!("No Music directory found!");
+
+        PathBuf::new()
     }
 
     pub fn init_config(&mut self) {


### PR DESCRIPTION
This PR refactors the `Settings` and `CLI` fields to use Paths instead of strings where it makes sense, including all other parts that touched that.

In addition to just switching to paths, some functions also now error more correctly on problems instead of being marked "successful" (like import / export)