### PR TITLE
Derive `Copy` (and some other missing derives) where reasonably possible

### DIFF
--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -103,7 +103,7 @@ pub struct Xywh {
     pub align: Alignment,
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug)]
+#[derive(Clone, Copy, Deserialize, Serialize, Debug)]
 pub enum Alignment {
     BottomRight,
     BottomLeft,
@@ -112,13 +112,13 @@ pub enum Alignment {
 }
 
 impl Alignment {
-    const fn x(&self, absolute_x: u32, width: u32) -> u32 {
+    const fn x(self, absolute_x: u32, width: u32) -> u32 {
         match self {
             Self::BottomRight | Self::TopRight => Self::get_size_substract(absolute_x, width),
             Self::BottomLeft | Self::TopLeft => absolute_x,
         }
     }
-    const fn y(&self, absolute_y: u32, height: u32) -> u32 {
+    const fn y(self, absolute_y: u32, height: u32) -> u32 {
         match self {
             Self::BottomRight | Self::BottomLeft => {
                 Self::get_size_substract(absolute_y, height / 2)
@@ -194,7 +194,7 @@ impl Xywh {
             y,
             width,
             height,
-            align: self.align.clone(),
+            align: self.align,
         })
     }
     fn calculate_xywh(
@@ -240,7 +240,7 @@ impl Xywh {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum SeekStep {
     Short,
     Long,
@@ -258,7 +258,7 @@ impl std::fmt::Display for SeekStep {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub enum LastPosition {
     Yes,
     No,

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -54,7 +54,7 @@ pub struct SongTag {
     // genre: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Copy)]
 pub enum ServiceProvider {
     Netease,
     Kugou,

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -51,7 +51,7 @@ pub enum Msg {
     None,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum XYWHMsg {
     Hide,
     MoveLeft,
@@ -77,7 +77,7 @@ pub enum DLMsg {
     FetchPhotoErr(String),
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LyricMsg {
     LyricTextAreaBlurUp,
     LyricTextAreaBlurDown,
@@ -191,7 +191,7 @@ pub enum ConfigEditorMsg {
     FallbackHighlightBlurUp,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KFMsg {
     DatabaseAddAllBlurDown,
     DatabaseAddAllBlurUp,
@@ -333,7 +333,7 @@ pub enum LIMsg {
     RemoveRoot,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DBMsg {
     AddAllToPlaylist,
     AddPlaylist(usize),
@@ -466,7 +466,7 @@ pub enum TEMsg {
     TESelectLyricOk(usize),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TFMsg {
     CounterDeleteBlurDown,
     CounterDeleteBlurUp,
@@ -486,7 +486,7 @@ pub enum TFMsg {
     TextareaLyricBlurUp,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum Id {
     ConfigEditor(IdConfigEditor),
     DBListCriteria,
@@ -521,7 +521,7 @@ pub enum Id {
     YoutubeSearchTablePopup,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdTagEditor {
     CounterDelete,
     LabelHint,
@@ -534,7 +534,7 @@ pub enum IdTagEditor {
     TextareaLyric,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdConfigEditor {
     AlbumPhotoAlign,
     CEThemeSelect,
@@ -598,7 +598,7 @@ pub enum IdConfigEditor {
     FallbackLabel,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdKey {
     DatabaseAddAll,
     GlobalConfig,

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -189,7 +189,7 @@ impl CEColorSelect {
         on_key_shift: Msg,
         on_key_backshift: Msg,
     ) -> Self {
-        let init_value = Self::init_color_select(&id, &config.read().style_color_symbol);
+        let init_value = Self::init_color_select(id, &config.read().style_color_symbol);
         let mut choices = vec![];
         for color in &COLOR_LIST {
             choices.push(String::from(*color));
@@ -217,11 +217,8 @@ impl CEColorSelect {
         }
     }
 
-    const fn init_color_select(
-        id: &IdConfigEditor,
-        style_color_symbol: &StyleColorSymbol,
-    ) -> usize {
-        match *id {
+    const fn init_color_select(id: IdConfigEditor, style_color_symbol: &StyleColorSymbol) -> usize {
+        match id {
             IdConfigEditor::LibraryForeground => style_color_symbol.library_foreground.as_usize(),
             IdConfigEditor::LibraryBackground => style_color_symbol.library_background.as_usize(),
             IdConfigEditor::LibraryBorder => style_color_symbol.library_border.as_usize(),
@@ -271,10 +268,7 @@ impl CEColorSelect {
                 Attribute::FocusStyle,
                 AttrValue::Style(Style::default().add_modifier(Modifier::BOLD).bg(color)),
             );
-            Msg::ConfigEditor(ConfigEditorMsg::ColorChanged(
-                self.id.clone(),
-                *color_config,
-            ))
+            Msg::ConfigEditor(ConfigEditorMsg::ColorChanged(self.id, *color_config))
         } else {
             self.attr(Attribute::Background, AttrValue::Color(Color::Red));
             self.attr(
@@ -872,10 +866,7 @@ impl ConfigInputHighlight {
             if let Some(s) = Self::string_to_unicode_char(&symbol) {
                 // success getting a unicode letter
                 self.update_symbol_after(Color::Green);
-                return Msg::ConfigEditor(ConfigEditorMsg::SymbolChanged(
-                    self.id.clone(),
-                    s.to_string(),
-                ));
+                return Msg::ConfigEditor(ConfigEditorMsg::SymbolChanged(self.id, s.to_string()));
             }
             // fail to get a unicode letter
             self.update_symbol_after(Color::Red);
@@ -886,10 +877,7 @@ impl ConfigInputHighlight {
             if let Some(s) = Self::string_to_unicode_char(&symbol) {
                 self.attr(Attribute::Value, AttrValue::String(s.to_string()));
                 self.update_symbol_after(Color::Green);
-                return Msg::ConfigEditor(ConfigEditorMsg::SymbolChanged(
-                    self.id.clone(),
-                    s.to_string(),
-                ));
+                return Msg::ConfigEditor(ConfigEditorMsg::SymbolChanged(self.id, s.to_string()));
             }
         }
         Msg::None

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -48,7 +48,7 @@ pub const INPUT_INVALID_STYLE: &str = "invalid-style";
 pub const INPUT_PLACEHOLDER: &str = "placeholder";
 pub const INPUT_PLACEHOLDER_STYLE: &str = "placeholder-style";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MyModifiers {
     None,
     Shift,
@@ -99,7 +99,7 @@ impl MyModifiers {
         }
     }
 
-    pub const fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             MyModifiers::None => "none",
             MyModifiers::Shift => "shift",
@@ -112,7 +112,7 @@ impl MyModifiers {
         }
     }
 
-    pub const fn as_modifier(&self) -> KeyModifiers {
+    pub const fn as_modifier(self) -> KeyModifiers {
         match self {
             Self::None => KeyModifiers::NONE,
             Self::Shift => KeyModifiers::SHIFT,

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1096,7 +1096,7 @@ impl KEModifierSelect {
         on_key_backtab: Msg,
     ) -> Self {
         let config_r = config.read();
-        let (init_select, init_key) = Self::init_modifier_select(&id, &config_r.keys);
+        let (init_select, init_key) = Self::init_modifier_select(id, &config_r.keys);
         let mut choices = vec![];
         for modifier in MyModifiers::LIST {
             choices.push(modifier.as_str());
@@ -1130,7 +1130,7 @@ impl KEModifierSelect {
     /// Get the Selected Modifier choice index for the given [`IdKey`] and the key representation as string
     ///
     /// Returns `(mod_list_index, key_str)`
-    fn init_modifier_select(id: &IdKey, keys: &Keys) -> (usize, String) {
+    fn init_modifier_select(id: IdKey, keys: &Keys) -> (usize, String) {
         let mod_key = match id {
             IdKey::DatabaseAddAll => keys.database_add_all.mod_key(),
             IdKey::GlobalConfig => keys.global_config_open.mod_key(),
@@ -1274,8 +1274,7 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
                             self.perform(Cmd::Type(ch));
                             if let Ok(binding) = self.key_event() {
                                 return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                                    self.id.clone(),
-                                    binding,
+                                    self.id, binding,
                                 )));
                             };
                         }
@@ -1294,8 +1293,7 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
 
                             if let Ok(binding) = self.key_event() {
                                 return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                                    self.id.clone(),
-                                    binding,
+                                    self.id, binding,
                                 )));
                             };
                         }
@@ -1313,8 +1311,7 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
 
                             if let Ok(binding) = self.key_event() {
                                 return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                                    self.id.clone(),
-                                    binding,
+                                    self.id, binding,
                                 )));
                             };
                         }
@@ -1358,8 +1355,7 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
                     State::One(_) => {
                         if let Ok(binding) = self.key_event() {
                             return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                                self.id.clone(),
-                                binding,
+                                self.id, binding,
                             )));
                         }
                         CmdResult::None
@@ -1377,8 +1373,7 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
                 // Some(Msg::None)
                 if let Ok(binding) = self.key_event() {
                     return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                        self.id.clone(),
-                        binding,
+                        self.id, binding,
                     )));
                 }
                 Some(Msg::None)

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -47,7 +47,7 @@ pub struct CEHeader {
 }
 
 impl CEHeader {
-    pub fn new(layout: &ConfigEditorLayout, config: &Settings) -> Self {
+    pub fn new(layout: ConfigEditorLayout, config: &Settings) -> Self {
         Self {
             component: Radio::default()
                 .borders(

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -339,7 +339,7 @@ impl Model {
             }
             ConfigEditorMsg::ColorChanged(id, color_config) => {
                 self.config_changed = true;
-                self.update_config_editor_color_changed(id, *color_config);
+                self.update_config_editor_color_changed(*id, *color_config);
             }
             ConfigEditorMsg::SymbolChanged(id, symbol) => {
                 self.config_changed = true;
@@ -359,14 +359,14 @@ impl Model {
                 };
             }
 
-            ConfigEditorMsg::KeyChange(id, binding) => self.update_key(id, binding),
-            ConfigEditorMsg::KeyFocus(msg) => self.update_key_focus(msg),
+            ConfigEditorMsg::KeyChange(id, binding) => self.update_key(*id, binding),
+            ConfigEditorMsg::KeyFocus(msg) => self.update_key_focus(*msg),
         }
         None
     }
 
     #[allow(clippy::too_many_lines)]
-    fn update_key_focus(&mut self, msg: &KFMsg) {
+    fn update_key_focus(&mut self, msg: KFMsg) {
         match msg {
             // Focus of key global page
             KFMsg::GlobalXywhHideBlurDown | KFMsg::GlobalLeftBlurUp => {
@@ -826,7 +826,7 @@ impl Model {
         }
     }
 
-    fn update_key(&mut self, id: &IdKey, binding: &BindingForEvent) {
+    fn update_key(&mut self, id: IdKey, binding: &BindingForEvent) {
         self.config_changed = true;
         match id {
             IdKey::DatabaseAddAll => self.ke_key_config.database_add_all = *binding,
@@ -915,7 +915,7 @@ impl Model {
 
     fn update_config_editor_color_changed(
         &mut self,
-        id: &IdConfigEditor,
+        id: IdConfigEditor,
         color_config: ColorTermusic,
     ) {
         match id {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1718,13 +1718,12 @@ impl Model {
     #[allow(clippy::too_many_lines)]
     pub fn mount_config_editor(&mut self) {
         self.config_layout = ConfigEditorLayout::General;
-        let layout = self.config_layout.clone();
 
         assert!(self
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(&layout, &self.config.read())),
+                Box::new(CEHeader::new(self.config_layout, &self.config.read())),
                 vec![]
             )
             .is_ok());
@@ -3239,12 +3238,11 @@ impl Model {
             ConfigEditorLayout::Key2 => self.config_layout = ConfigEditorLayout::General,
         }
 
-        let layout = self.config_layout.clone();
         assert!(self
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(&layout, &self.config.read())),
+                Box::new(CEHeader::new(self.config_layout, &self.config.read())),
                 vec![]
             )
             .is_ok());

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -143,6 +143,8 @@ pub struct GSTablePopup {
     source: Source,
     config: SharedSettings,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Source {
     Library,
     Playlist,

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -63,11 +63,11 @@ impl Model {
                     self.mount_error_popup(e.context("rename song by tag"));
                 }
             }
-            TEMsg::TEFocus(m) => self.update_tag_editor_focus(m),
+            TEMsg::TEFocus(m) => self.update_tag_editor_focus(*m),
         }
     }
 
-    fn update_tag_editor_focus(&mut self, msg: &TFMsg) {
+    fn update_tag_editor_focus(&mut self, msg: TFMsg) {
         match msg {
             TFMsg::TextareaLyricBlurDown | TFMsg::InputTitleBlurUp => {
                 self.app

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -53,14 +53,14 @@ use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
 use tuirealm::terminal::TerminalBridge;
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TermusicLayout {
     TreeView,
     DataBase,
     Podcast,
 }
 
-#[derive(PartialEq, Clone, Eq)]
+#[derive(Debug, PartialEq, Clone, Copy, Eq)]
 pub enum ConfigEditorLayout {
     General,
     Color,
@@ -114,7 +114,7 @@ pub struct Model {
     pub cmd_tx: UnboundedSender<PlayerCmd>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ViuerSupported {
     #[cfg(feature = "cover-viuer-kitty")]
     Kitty,

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -168,9 +168,9 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::Podcast(m) => self.update_podcast(&m),
-                Msg::LyricMessage(m) => self.update_lyric_textarea(&m),
+                Msg::LyricMessage(m) => self.update_lyric_textarea(m),
                 Msg::Download(m) => self.update_download_msg(&m),
-                Msg::Xywh(m) => self.update_xywh_msg(&m),
+                Msg::Xywh(m) => self.update_xywh_msg(m),
             }
         } else {
             None
@@ -188,7 +188,7 @@ impl Model {
         }
     }
 
-    fn update_xywh_msg(&mut self, msg: &XYWHMsg) -> Option<Msg> {
+    fn update_xywh_msg(&mut self, msg: XYWHMsg) -> Option<Msg> {
         match msg {
             XYWHMsg::MoveLeft => self.xywh_move_left(),
             XYWHMsg::MoveRight => self.xywh_move_right(),
@@ -203,7 +203,7 @@ impl Model {
         None
     }
 
-    fn update_lyric_textarea(&mut self, msg: &LyricMsg) -> Option<Msg> {
+    fn update_lyric_textarea(&mut self, msg: LyricMsg) -> Option<Msg> {
         match msg {
             LyricMsg::LyricTextAreaBlurUp => self.app.active(&Id::Playlist).ok(),
             LyricMsg::LyricTextAreaBlurDown => match self.layout {


### PR DESCRIPTION
This PR derives `Copy´ (among some other derives if missing like `Debug` and `PartialEq` and `Clone`) where it makes sense.

This makes the usage of those types easier and does not require having a reference to 1(to ~3) bytes.