### PR TITLE
fix(build.rs): check that the git repository is actually termusic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
 - Feat(tui): allow Sixel to be used for covers.
 - Feat(tui): allow all cover providers to not be compiled in.
+- Fix: update the build scripts to check that the repository is actually the `termusic` repository before using the git version.
 - Fix: allow backends to be compiled in for `termusic-playback` but not in `termusic-server`.
 - Fix: on backend mpv, clear media-title on EndOfFile.
 - Fix: consistent media-title(/radio-title) handling across all backends.

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 fn main() {
     // set what version string to use for the build
@@ -22,42 +22,74 @@ fn main() {
 
         let cargo_toml_or_default = cargo_toml_version.unwrap_or(String::from("unknown"));
 
-        // How to read the git version, first all the variants:
-        // Termusic-server v0.7.11-302-g63396ee5-dirty[g]
-        // Termusic-server v0.7.11-302-g63396ee5[g]
-        // Termusic-server v0.7.11[g]
-        // Termusic-server v0.7.11[c]
-        // Termusic-server unknown
-        //
-        // "Termusic-server" is the binary name
-        // "v0.7.11" is the latest tag on the branch
-        // "302" is the number of commits since the tag, not always present
-        // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
-        // the rest "63396ee5" is the abbreviated commit sha
-        // "dirty" indicates the build has uncommited changes
-        // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
-        let version = Command::new("git")
-            .args(["describe", "--tags", "--always", "--dirty"])
-            .output()
-            .ok()
-            .and_then(|v| {
-                // print stderr for debugging purposes, it will not be shown unless the build.rs panics
-                if !v.stderr.is_empty() {
-                    eprintln!(
-                        "{}",
-                        String::from_utf8(v.stderr).unwrap_or("couldnt parse utf8 stderr".into())
-                    );
-                }
-
-                String::from_utf8(v.stdout).ok()
-            })
-            // ignore output if the string gotten is empty
-            .and_then(|v| if v.is_empty() { None } else { Some(v) })
-            // add a indicator for git version
-            .map(|v| format!("{}[g]", v.trim()))
+        let version = git_version()
             // fallback to Cargo.toml version, if git is unavailable (like having downloaded the source archive)
             .unwrap_or(cargo_toml_or_default);
 
         println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
+    }
+}
+
+fn git_version() -> Option<String> {
+    let toplevel_dir = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|v| {
+            print_stderr(&v.stderr);
+
+            String::from_utf8(v.stdout).ok()
+        })
+        .map(|mut v| {
+            // remove the ending "\n" that may exist
+            v.truncate(v.trim_end().len());
+
+            v
+        })
+        .map(PathBuf::from)?;
+
+    // not in the termusic repository, but still in a git repo, for example in a AUR build
+    // is there maybe a better way to check this?
+    if !toplevel_dir.join("Cargo.toml").exists()
+        && !toplevel_dir.join("lib").exists()
+        && !toplevel_dir.join("tui").exists()
+        && !toplevel_dir.join("server").exists()
+    {
+        return None;
+    }
+
+    // How to read the git version, first all the variants:
+    // Termusic-server v0.7.11-302-g63396ee5-dirty[g]
+    // Termusic-server v0.7.11-302-g63396ee5[g]
+    // Termusic-server v0.7.11[g]
+    // Termusic-server v0.7.11[c]
+    // Termusic-server unknown
+    //
+    // "Termusic-server" is the binary name
+    // "v0.7.11" is the latest tag on the branch
+    // "302" is the number of commits since the tag, not always present
+    // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
+    // the rest "63396ee5" is the abbreviated commit sha
+    // "dirty" indicates the build has uncommited changes
+    // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
+    Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|v| {
+            print_stderr(&v.stderr);
+
+            String::from_utf8(v.stdout).ok()
+        })
+        // ignore output if the string gotten is empty
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        // add a indicator for git version
+        .map(|v| format!("{}[g]", v.trim()))
+}
+
+/// print stderr for debugging purposes, it will not be shown unless the build.rs panics
+fn print_stderr(stderr: &[u8]) {
+    if !stderr.is_empty() {
+        eprintln!("{}", String::from_utf8_lossy(stderr));
     }
 }

--- a/tui/build.rs
+++ b/tui/build.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 fn main() {
     // set what version string to use for the build
@@ -22,42 +22,74 @@ fn main() {
 
         let cargo_toml_or_default = cargo_toml_version.unwrap_or(String::from("unknown"));
 
-        // How to read the git version, first all the variants:
-        // Termusic v0.7.11-302-g63396ee5-dirty[g]
-        // Termusic v0.7.11-302-g63396ee5[g]
-        // Termusic v0.7.11[g]
-        // Termusic v0.7.11[c]
-        // Termusic unknown
-        //
-        // "Termusic" is the binary name
-        // "v0.7.11" is the latest tag on the branch
-        // "302" is the number of commits since the tag, not always present
-        // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
-        // the rest "63396ee5" is the abbreviated commit sha
-        // "dirty" indicates the build has uncommited changes
-        // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
-        let version = Command::new("git")
-            .args(["describe", "--tags", "--always", "--dirty"])
-            .output()
-            .ok()
-            .and_then(|v| {
-                // print stderr for debugging purposes, it will not be shown unless the build.rs panics
-                if !v.stderr.is_empty() {
-                    eprintln!(
-                        "{}",
-                        String::from_utf8(v.stderr).unwrap_or("couldnt parse utf8 stderr".into())
-                    );
-                }
-
-                String::from_utf8(v.stdout).ok()
-            })
-            // ignore output if the string gotten is empty
-            .and_then(|v| if v.is_empty() { None } else { Some(v) })
-            // add a indicator for git version
-            .map(|v| format!("{}[g]", v.trim()))
+        let version = git_version()
             // fallback to Cargo.toml version, if git is unavailable (like having downloaded the source archive)
             .unwrap_or(cargo_toml_or_default);
 
         println!("cargo:rustc-env=TERMUSIC_VERSION={version}");
+    }
+}
+
+fn git_version() -> Option<String> {
+    let toplevel_dir = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|v| {
+            print_stderr(&v.stderr);
+
+            String::from_utf8(v.stdout).ok()
+        })
+        .map(|mut v| {
+            // remove the ending "\n" that may exist
+            v.truncate(v.trim_end().len());
+
+            v
+        })
+        .map(PathBuf::from)?;
+
+    // not in the termusic repository, but still in a git repo, for example in a AUR build
+    // is there maybe a better way to check this?
+    if !toplevel_dir.join("Cargo.toml").exists()
+        && !toplevel_dir.join("lib").exists()
+        && !toplevel_dir.join("tui").exists()
+        && !toplevel_dir.join("server").exists()
+    {
+        return None;
+    }
+
+    // How to read the git version, first all the variants:
+    // Termusic v0.7.11-302-g63396ee5-dirty[g]
+    // Termusic v0.7.11-302-g63396ee5[g]
+    // Termusic v0.7.11[g]
+    // Termusic v0.7.11[c]
+    // Termusic unknown
+    //
+    // "Termusic" is the binary name
+    // "v0.7.11" is the latest tag on the branch
+    // "302" is the number of commits since the tag, not always present
+    // "g63396ee5" is 2 parts, the "g" in the beginning means "git"
+    // the rest "63396ee5" is the abbreviated commit sha
+    // "dirty" indicates the build has uncommited changes
+    // "[g]" at the end means the version has been gotten from "git" ("[c]" means from "cargo")
+    Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .and_then(|v| {
+            print_stderr(&v.stderr);
+
+            String::from_utf8(v.stdout).ok()
+        })
+        // ignore output if the string gotten is empty
+        .and_then(|v| if v.is_empty() { None } else { Some(v) })
+        // add a indicator for git version
+        .map(|v| format!("{}[g]", v.trim()))
+}
+
+/// print stderr for debugging purposes, it will not be shown unless the build.rs panics
+fn print_stderr(stderr: &[u8]) {
+    if !stderr.is_empty() {
+        eprintln!("{}", String::from_utf8_lossy(stderr));
     }
 }


### PR DESCRIPTION
This PR extends the build.rs scripts to check for specific files to verify that the git repository is actually the termusic repository we expect and not some other like a AUR repository.

Maybe there exists a better way to check if the git repository is correct instead of just checking for specific files in the git toplevel.

i noticed this in https://github.com/tramhao/termusic/issues/320#issuecomment-2132192219