### PR TITLE
Some discord IPC refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix(server): update Media-Controls volume on volume change instead of on tick.
 - Fix(server): update Media-Controls with *new* progress instead of last-tick progress.
 - Fix(server): dont start Media-Controls if not requested (like disabled via config).
+- Fix(server): dont start Discord IPC if not requested (like disabled via config).
 - Refactor: a lot less cloning and conversions where not necessary.
 - Refactor(server): on backend rusty, clean-up decoding & seeking.
 

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -18,7 +18,6 @@ enum RpcCommand {
 }
 
 impl Default for Rpc {
-    #[allow(clippy::cast_possible_wrap)]
     fn default() -> Self {
         let mut client = DiscordIpcClient::new(APP_ID).unwrap();
         let (tx, rx): (Sender<RpcCommand>, Receiver<RpcCommand>) = mpsc::channel();
@@ -51,10 +50,15 @@ impl Default for Rpc {
                             .large_text("terminal music player written in Rust");
                         // .small_image(smol_image)
                         // .small_text(state);
-                        let time = SystemTime::now()
+                        let time = if let Ok(v) = i64::try_from(SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap()
-                            .as_secs() as i64;
+                            .as_secs()) {
+                                v
+                            } else {
+                                warn!("SystemTime to i64 failed, discord interface cant handle this number");
+                                0
+                            };
                         let timestamp = activity::Timestamps::new().start(time);
                         // .end(self.time + self.duration);
 
@@ -90,10 +94,15 @@ impl Default for Rpc {
                             .large_image("termusic")
                             .large_text("terminal music player written in Rust");
 
-                        let time = SystemTime::now()
+                        let time = if let Ok(v) = i64::try_from(SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap()
-                            .as_secs() as i64;
+                            .as_secs()) {
+                                v
+                            } else {
+                                warn!("SystemTime to i64 failed, discord interface cant handle this number");
+                                0
+                            };
                         let timestamp = activity::Timestamps::new().start(time - time_pos);
 
                         client


### PR DESCRIPTION
This PR refactors some things related to the Discord IPC:
- dont start if not necessary (and start after config reload)
- exit discord thread if mpsc is closed
- dont infinitely try to reconnect and block the thread (also to not infinitely stall the commands)
- some slight style changes
- removing the need for `clippy::cast_possible_wrap`