### PR TITLE
chore(issue_template/bug): add some more instructions for enabling logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,15 +16,17 @@ Make sure you read [Mastering-Markdown](https://guides.github.com/features/maste
 
 - System: <!--linux / macos / windows--> <!--Also include system version, and if on linux the distro-->
 - Termusic version: <!--termusic --version-->
-<!--If custom compile-->
+<!--If custom compile, like from repository or AUR-->
 - Rust version:
 
 Logs:
 
 <!--
-Logs can be found by default in your temporary directory; in linux its /tmp/termusic-{tui,server}.log
-Log location can also be manually set via TM_LOGFILE=/path/to/tui.log or TMS_LOGFILE=/path/to/server.log
-And Log-level can be set via RUST_LOG, see the following for all levels: https://docs.rs/flexi_logger/latest/flexi_logger/enum.Level.html
+Logs can be enabled with `--log-to-file`, they can then by default be found in your temporary directory
+- in linux its /tmp/termusic-{tui,server}.log
+- in windows its C:\Users\<username>\AppData\Local\Temp\termusic-{tui,server}.log
+Log location can also be manually set via `TM_LOGFILE=/path/to/tui.log` for the TUI or `TMS_LOGFILE=/path/to/server.log` for the Server.
+Log-level can be set via RUST_LOG, see the following for all levels: https://docs.rs/flexi_logger/latest/flexi_logger/enum.Level.html
 -->
 
 <!--When only doing a small section of the logs, please use a code-block inside "details"(or also known as spoiler)-->


### PR DESCRIPTION
because in version 0.9.0 it is not enabled by default and recent issues were opened with `no logs`