### PR TITLE
Refactor playlist parsing

### DIFF
--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -90,3 +90,32 @@ pub fn decode(content: &str) -> Result<Vec<ASXItem>, Box<dyn Error>> {
 
     Ok(list)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn asx() {
+        let s = r#"<asx version="3.0">
+  <title>Test-Liste</title>
+  <entry>
+    <title>title1</title>
+    <ref href="ref1"/>
+  </entry>
+  <entry>
+    <title>title2</title>
+    <ref href="ref2"/>
+  </entry>
+</asx>"#;
+        let items = decode(s);
+        assert!(items.is_ok());
+        let items = items.unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].url, "ref1");
+        assert_eq!(items[0].title, "title1");
+        assert_eq!(items[1].url, "ref2");
+        assert_eq!(items[1].title, "title2");
+    }
+}

--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -3,15 +3,15 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::error::Error;
 
-#[derive(Clone)]
-pub struct PlaylistItem {
+#[derive(Debug, Clone, PartialEq)]
+pub struct ASXItem {
     pub title: String,
     pub url: String,
 }
 
-pub fn decode(content: &str) -> Result<Vec<PlaylistItem>, Box<dyn Error>> {
+pub fn decode(content: &str) -> Result<Vec<ASXItem>, Box<dyn Error>> {
     let mut list = vec![];
-    let mut item = PlaylistItem {
+    let mut item = ASXItem {
         title: String::new(),
         url: String::new(),
     };

--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -9,6 +9,10 @@ pub struct ASXItem {
     pub url: String,
 }
 
+/// ASX or "Advanced Stream Redirector" is a standard made by microsoft for windows media player, XML based.
+///
+/// <https://en.wikipedia.org/wiki/Advanced_Stream_Redirector>
+/// <https://learn.microsoft.com/en-us/windows/win32/wmp/asx-element>
 pub fn decode(content: &str) -> Result<Vec<ASXItem>, Box<dyn Error>> {
     let mut list = vec![];
     let mut item = ASXItem {

--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -18,7 +18,7 @@ pub fn decode(content: &str) -> Result<Vec<ASXItem>, Box<dyn Error>> {
 
     let mut reader = Reader::from_str(content);
     reader.trim_text(true);
-    let mut xml_stack = vec![];
+    let mut xml_stack = Vec::with_capacity(3);
     let mut buf = Vec::new();
     let decoder = reader.decoder();
     loop {

--- a/lib/src/playlist/m3u.rs
+++ b/lib/src/playlist/m3u.rs
@@ -1,14 +1,23 @@
 //! Extract urls from M3U playlist files
 
+// TODO: resolve relative paths
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct M3UItem {
     pub url: String,
 }
 
+/// M3U(8) is a de-facto standart (meaning there is no formal standard), where each line that does not start with `#` is a entry, separated by newlines
+///
+/// <https://en.wikipedia.org/wiki/M3U#File_format>
 pub fn decode(content: &str) -> Vec<M3UItem> {
     let lines = content.lines();
     let mut list = vec![];
     for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+
         if line.starts_with('#') {
             continue;
         }
@@ -18,4 +27,25 @@ pub fn decode(content: &str) -> Vec<M3UItem> {
         });
     }
     list
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_parse() {
+        let playlist = r#"/some/absolute/unix/path.mp3
+# this is a test comment, below is a empty line to be ignored
+
+relative.mp3
+https://somewhere.url/path"#;
+
+        let results = decode(&playlist);
+        assert_eq!(results.len(), 3);
+        assert_eq!(&results[0].url, "/some/absolute/unix/path.mp3");
+        assert_eq!(&results[1].url, "relative.mp3");
+        assert_eq!(&results[2].url, "https://somewhere.url/path");
+    }
 }

--- a/lib/src/playlist/m3u.rs
+++ b/lib/src/playlist/m3u.rs
@@ -1,10 +1,11 @@
 //! Extract urls from M3U playlist files
 
-pub struct PlaylistItem {
+#[derive(Debug, Clone, PartialEq)]
+pub struct M3UItem {
     pub url: String,
 }
 
-pub fn decode(content: &str) -> Vec<PlaylistItem> {
+pub fn decode(content: &str) -> Vec<M3UItem> {
     let lines = content.lines();
     let mut list = vec![];
     for line in lines {
@@ -12,7 +13,7 @@ pub fn decode(content: &str) -> Vec<PlaylistItem> {
             continue;
         }
 
-        list.push(PlaylistItem {
+        list.push(M3UItem {
             url: String::from(line),
         });
     }

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -36,7 +36,7 @@ use std::error::Error;
 /// * `content` - A string slice containing a playlist
 #[allow(clippy::single_match_else)]
 pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
-    let mut set = vec![];
+    let mut set: Vec<String> = vec![];
     let content_small = content.to_lowercase();
     if content_small.contains("<playlist") {
         let xspf_items = xspf::decode(content)?;
@@ -64,8 +64,7 @@ pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
             set.push(item.url);
         }
     }
-    let v: Vec<String> = set.into_iter().collect();
-    Ok(v)
+    Ok(set)
 }
 #[allow(unused)]
 pub fn is_content_hls(content: &str) -> bool {

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -78,33 +78,4 @@ pub fn is_content_hls(content: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn xspf() {
-        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
-<playlist version="1" xmlns="http://xspf.org/ns/0/">
-    <trackList>
-    <track>
-        <title>Title</title>
-        <identifier>Identifier</identifier>
-        <location>http://this.is.an.example</location>
-    </track>
-    <track>
-        <title>Title2</title>
-        <identifier>Identifier2</identifier>
-        <location>http://this.is.an.example2</location>
-    </track>
-    </trackList>
-</playlist>"#;
-        let items = crate::playlist::xspf::decode(s);
-        assert!(items.is_ok());
-        let items = items.unwrap();
-        assert!(items.len() == 2);
-        assert!(items[0].url == "http://this.is.an.example");
-        assert!(items[0].title == "Title");
-        assert!(items[0].identifier == "Identifier");
-        assert!(items[1].url == "http://this.is.an.example2");
-        assert!(items[1].title == "Title2");
-        assert!(items[1].identifier == "Identifier2");
-    }
-}
+mod tests {}

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -48,8 +48,8 @@ pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
             if !item.url.is_empty() {
                 set.push(item.url);
             }
-            if !item.identifier.is_empty() {
-                set.push(item.identifier);
+            if let Some(identifier) = item.identifier {
+                set.push(identifier);
             }
         }
     } else if content_small.contains("<asx") {

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -67,17 +67,6 @@ pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
     Ok(set)
 }
 
-#[allow(unused)]
-pub fn is_content_hls(content: &str) -> bool {
-    if content.contains("EXT-X-STREAM-INF") {
-        return true;
-    }
-    if content.contains("EXT-X-TARGETDURATION") {
-        return true;
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -107,27 +107,4 @@ mod tests {
         assert!(items[1].title == "Title2");
         assert!(items[1].identifier == "Identifier2");
     }
-
-    #[test]
-    fn asx() {
-        let s = r#"<asx version="3.0">
-  <title>Test-Liste</title>
-  <entry>
-    <title>title1</title>
-    <ref href="ref1"/>
-  </entry>
-  <entry>
-    <title>title2</title>
-    <ref href="ref2"/>
-  </entry>
-</asx>"#;
-        let items = crate::playlist::asx::decode(s);
-        assert!(items.is_ok());
-        let items = items.unwrap();
-        assert!(items.len() == 2);
-        assert!(items[0].url == "ref1");
-        assert!(items[0].title == "title1");
-        assert!(items[1].url == "ref2");
-        assert!(items[1].title == "title2");
-    }
 }

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -130,43 +130,4 @@ mod tests {
         assert!(items[1].url == "ref2");
         assert!(items[1].title == "title2");
     }
-
-    #[test]
-    fn pls() {
-        let items = crate::playlist::pls::decode(
-            "[playlist]
-File1=http://this.is.an.example
-Title1=mytitle
-        ",
-        );
-        assert!(items.len() == 1);
-        assert!(items[0].url == "http://this.is.an.example");
-        assert!(items[0].title == "mytitle");
-    }
-
-    #[test]
-    fn pls2() {
-        let items = crate::playlist::pls::decode(
-            "[playlist]
-File1=http://this.is.an.example
-Title=mytitle
-        ",
-        );
-        assert!(items.len() == 1);
-        assert!(items[0].url == "http://this.is.an.example");
-        assert!(items[0].title == "mytitle");
-    }
-
-    #[test]
-    fn pls3() {
-        let items = crate::playlist::pls::decode(
-            "[Playlist]
-File1=http://this.is.an.example
-Title=mytitle
-        ",
-        );
-        assert!(items.len() == 1);
-        assert!(items[0].url == "http://this.is.an.example");
-        assert!(items[0].title == "mytitle");
-    }
 }

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -38,40 +38,31 @@ use std::error::Error;
 pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
     let mut set = vec![];
     let content_small = content.to_lowercase();
-    match content_small.find("<playlist") {
-        Some(_) => {
-            let xspf_items = xspf::decode(content)?;
-            for item in xspf_items {
-                if !item.url.is_empty() {
-                    set.push(item.url);
-                }
-                if !item.identifier.is_empty() {
-                    set.push(item.identifier);
-                }
+    if content_small.contains("<playlist") {
+        let xspf_items = xspf::decode(content)?;
+        for item in xspf_items {
+            if !item.url.is_empty() {
+                set.push(item.url);
+            }
+            if !item.identifier.is_empty() {
+                set.push(item.identifier);
             }
         }
-        None => match content_small.find("<asx") {
-            Some(_) => {
-                let pls_items = asx::decode(content)?;
-                for item in pls_items {
-                    set.push(item.url);
-                }
-            }
-            None => match content_small.find("[playlist]") {
-                Some(_) => {
-                    let pls_items = pls::decode(content);
-                    for item in pls_items {
-                        set.push(item.url);
-                    }
-                }
-                None => {
-                    let m3u_items = m3u::decode(content);
-                    for item in m3u_items {
-                        set.push(item.url);
-                    }
-                }
-            },
-        },
+    } else if content_small.contains("<asx") {
+        let pls_items = asx::decode(content)?;
+        for item in pls_items {
+            set.push(item.url);
+        }
+    } else if content_small.contains("[playlist]") {
+        let pls_items = pls::decode(content);
+        for item in pls_items {
+            set.push(item.url);
+        }
+    } else {
+        let m3u_items = m3u::decode(content);
+        for item in m3u_items {
+            set.push(item.url);
+        }
     }
     let v: Vec<String> = set.into_iter().collect();
     Ok(v)

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -132,13 +132,6 @@ mod tests {
     }
 
     #[test]
-    fn m3u() {
-        let items = crate::playlist::m3u::decode("http://this.is.an.example");
-        assert!(items.len() == 1);
-        assert!(items[0].url == "http://this.is.an.example");
-    }
-
-    #[test]
     fn pls() {
         let items = crate::playlist::pls::decode(
             "[playlist]

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -10,7 +10,13 @@ mod xspf;
 use std::error::Error;
 
 /// Decode playlist content string. It checks for M3U, PLS, XSPF and ASX content in the string.
+///
+/// Returns the parsed entries from the playlist, in playlist order.
+///
+/// NOTE: currently there is a mix of url and other things in this list
+///
 /// # Example
+///
 /// ```rust
 /// let list = playlist_decoder::decode(r##"<?xml version="1.0" encoding="UTF-8"?>
 ///    <playlist version="1" xmlns="http://xspf.org/ns/0/">
@@ -32,12 +38,10 @@ use std::error::Error;
 ///     println!("{:?}", item);
 /// }
 /// ```
-/// # Arguments
-/// * `content` - A string slice containing a playlist
-#[allow(clippy::single_match_else)]
 pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
     let mut set: Vec<String> = vec![];
     let content_small = content.to_lowercase();
+
     if content_small.contains("<playlist") {
         let xspf_items = xspf::decode(content)?;
         for item in xspf_items {
@@ -64,6 +68,7 @@ pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
             set.push(item.url);
         }
     }
+
     Ok(set)
 }
 

--- a/lib/src/playlist/pls.rs
+++ b/lib/src/playlist/pls.rs
@@ -1,13 +1,17 @@
 //! Decode File and Title parts from simple playlist PLS files
 
-use std::collections::HashMap;
-
-// TODO: order the result in the way the playlist defines it, see test "multiple_files"
+use std::collections::{hash_map::Entry, HashMap};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PLSItem {
-    pub title: String,
+    pub title: Option<String>,
     pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+struct PrivateItem {
+    pub title: Option<String>,
+    pub url: Option<String>,
 }
 
 /// PLS is a file format similar in style to INI (but does not have a official standard).
@@ -15,54 +19,173 @@ pub struct PLSItem {
 ///
 /// <https://en.wikipedia.org/wiki/PLS_(file_format)>
 pub fn decode(content: &str) -> Vec<PLSItem> {
-    let lines = content.lines();
-    let mut list = vec![];
-    let mut found_pls = false;
-    let mut map_urls = HashMap::new();
-    let mut map_title = HashMap::new();
-    let mut default_title = "";
+    let mut lines = content.lines();
+    let mut list: HashMap<u16, PrivateItem> = HashMap::with_capacity(1);
+
+    if let Found::No = skip_until_playlist(&mut lines) {
+        error!("Requested PLS playlist, but did not find PLS header!");
+
+        return Vec::new();
+    }
+
+    // optional "NumberOfEntries" footer checking
+    let mut number_of_entries: Option<u16> = None;
+
     for line in lines {
-        if line.starts_with('#') {
+        if is_comment(line) || line.is_empty() {
             continue;
         }
-        if line.trim().to_lowercase() == "[playlist]" {
-            found_pls = true;
-        } else if found_pls {
-            if line.starts_with("File") {
-                let idend = line.find('=');
-                if let Some(idend) = idend {
-                    let (key, value) = line.split_at(idend);
-                    let id: Result<u32, _> = key[4..idend].parse();
-                    if let Ok(id) = id {
-                        let (_, url) = value.split_at(1);
-                        map_urls.insert(id, url);
+
+        // because it matches INI style, there could be another header, we dont want to parse that though
+        if line.starts_with('[') {
+            info!("Found another header in PLS playlist!");
+            break;
+        }
+
+        if let Some(remainder) = line.strip_prefix("File") {
+            let Some((num, url)) = parse_id(remainder, line) else {
+                continue;
+            };
+
+            match list.entry(num) {
+                Entry::Occupied(mut o) => {
+                    let val = o.get_mut();
+                    if val.url.is_some() {
+                        warn!("Entry {} already had a URL set, overwriting!", num);
                     }
+                    val.url.replace(url.to_string());
                 }
-            } else if line.starts_with("Title") {
-                let idend = line.find('=');
-                if let Some(idend) = idend {
-                    let (key, value) = line.split_at(idend);
-                    let id: Result<u32, _> = key[5..idend].parse();
-                    let (_, title) = value.split_at(1);
-                    if let Ok(id) = id {
-                        map_title.insert(id, title);
-                    } else {
-                        default_title = title;
-                    }
+                Entry::Vacant(v) => {
+                    v.insert(PrivateItem {
+                        url: Some(url.to_string()),
+                        ..Default::default()
+                    });
                 }
             }
         }
+
+        if let Some(remainder) = line.strip_prefix("Title") {
+            let Some((num, title)) = parse_id(remainder, line) else {
+                continue;
+            };
+
+            match list.entry(num) {
+                Entry::Occupied(mut o) => {
+                    let val = o.get_mut();
+                    if val.title.is_some() {
+                        warn!("Entry {} already had a Title set, overwriting!", num);
+                    }
+                    val.title.replace(title.to_string());
+                }
+                Entry::Vacant(v) => {
+                    v.insert(PrivateItem {
+                        title: Some(title.to_string()),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        if let Some(remainder) = line.strip_prefix("NumberOfEntries") {
+            let Some((_, remainder)) = remainder.split_once('=') else {
+                warn!("Malformed line: {:#?}", line);
+                continue;
+            };
+
+            let Ok(num) = remainder.parse::<u16>() else {
+                warn!("Couldnt parse NumberOfEntries number! line: {:#?}", line);
+                continue;
+            };
+
+            number_of_entries.replace(num);
+        }
     }
 
-    for (key, value) in map_urls {
-        let title = map_title.get(&key).unwrap_or(&default_title);
-        list.push(PLSItem {
-            title: String::from(*title),
-            url: String::from(value),
-        });
+    // convert to the returned struct format, while also warning about bad entries and preserving number
+    let mut list: Vec<(u16, PLSItem)> = list
+        .into_iter()
+        .filter(|v| {
+            if v.1.url.is_none() {
+                warn!("PLS Entry {} has no url, excluding!", v.0);
+            }
+
+            v.1.url.is_some()
+        })
+        .map(|v| {
+            (
+                v.0,
+                PLSItem {
+                    title: v.1.title,
+                    // Safe unwrap, because of the filter
+                    url: v.1.url.unwrap(),
+                },
+            )
+        })
+        .collect();
+
+    if let Some(number_of_entries) = number_of_entries {
+        if number_of_entries as usize != list.len() {
+            warn!(
+                "NumberOfEntries mismatch! List: {}, NumberOfEntries: {}",
+                list.len(),
+                number_of_entries
+            );
+        }
     }
 
-    list
+    // sort by the numbers (like `File1`) to actually be in playlist order
+    list.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // convert into array without the preserved number as it is now sorted
+    list.into_iter().map(|v| v.1).collect()
+}
+
+/// Parse a Entry id from the start of the value until the first `=`.
+///
+/// Returns the parsed number and the remainder after the first `=`.
+fn parse_id<'a>(val: &'a str, line: &str) -> Option<(u16, &'a str)> {
+    if let Some((id, remainder)) = val.split_once('=') {
+        let Ok(num) = id.parse::<u16>() else {
+            error!("Couldnt parse PLS entry id for line {:#?}", line);
+            return None;
+        };
+
+        return Some((num, remainder));
+    }
+
+    None
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Found {
+    Yes,
+    No,
+}
+
+/// Skip the given iterator until a `[playlist]` header, or return [`Found::No`]
+fn skip_until_playlist<'a, 'b>(iter: &'a mut impl Iterator<Item = &'b str>) -> Found {
+    loop {
+        // if there is no line, we have not found the start
+        let Some(line) = iter.next() else {
+            return Found::No;
+        };
+
+        // skip all comments or empty lines, as they *could* be before anything
+        if line.is_empty() || is_comment(line) {
+            continue;
+        }
+
+        // return when finding the correct header
+        if line.trim().to_ascii_lowercase() == "[playlist]" {
+            return Found::Yes;
+        }
+    }
+}
+
+/// Check if the given value starts with a PLS / INI comment
+#[inline]
+fn is_comment(val: &str) -> bool {
+    val.starts_with('#') || val.starts_with(';')
 }
 
 #[cfg(test)]
@@ -80,7 +203,7 @@ Title1=mytitle
         );
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].url, "http://this.is.an.example");
-        assert_eq!(items[0].title, "mytitle");
+        assert_eq!(items[0].title, Some("mytitle".to_string()));
     }
 
     #[test]
@@ -92,10 +215,9 @@ File2=~/b.mp3
 File3=http://c.mp3",
         );
         assert_eq!(items.len(), 3);
-        // TODO: currently all 3 are parsed, but out-of-order
-        // assert_eq!(items[0].url, "/a.mp3");
-        // assert_eq!(items[1].url, "~/b.mp3");
-        // assert_eq!(items[2].url, "http://c.mp3");
+        assert_eq!(items[0].url, "/a.mp3");
+        assert_eq!(items[1].url, "~/b.mp3");
+        assert_eq!(items[2].url, "http://c.mp3");
     }
 
     #[test]
@@ -103,11 +225,11 @@ File3=http://c.mp3",
         let items = decode(
             "[Playlist]
 File1=http://this.is.an.example
-Title=mytitle
+Title1=mytitle
         ",
         );
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].url, "http://this.is.an.example");
-        assert_eq!(items[0].title, "mytitle");
+        assert_eq!(items[0].title, Some("mytitle".to_string()));
     }
 }

--- a/lib/src/playlist/pls.rs
+++ b/lib/src/playlist/pls.rs
@@ -2,12 +2,18 @@
 
 use std::collections::HashMap;
 
+// TODO: order the result in the way the playlist defines it, see test "multiple_files"
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct PLSItem {
     pub title: String,
     pub url: String,
 }
 
+/// PLS is a file format similar in style to INI (but does not have a official standard).
+/// Each entry is numbered in the key like `File1`, only `File` is required for a entry.
+///
+/// <https://en.wikipedia.org/wiki/PLS_(file_format)>
 pub fn decode(content: &str) -> Vec<PLSItem> {
     let lines = content.lines();
     let mut list = vec![];
@@ -57,4 +63,51 @@ pub fn decode(content: &str) -> Vec<PLSItem> {
     }
 
     list
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn one_file() {
+        let items = decode(
+            "[playlist]
+File1=http://this.is.an.example
+Title1=mytitle
+        ",
+        );
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].url, "http://this.is.an.example");
+        assert_eq!(items[0].title, "mytitle");
+    }
+
+    #[test]
+    fn multiple_files() {
+        let items = decode(
+            "[playlist]
+File1=/a.mp3
+File2=~/b.mp3
+File3=http://c.mp3",
+        );
+        assert_eq!(items.len(), 3);
+        // TODO: currently all 3 are parsed, but out-of-order
+        // assert_eq!(items[0].url, "/a.mp3");
+        // assert_eq!(items[1].url, "~/b.mp3");
+        // assert_eq!(items[2].url, "http://c.mp3");
+    }
+
+    #[test]
+    fn anycase_playlist_header() {
+        let items = decode(
+            "[Playlist]
+File1=http://this.is.an.example
+Title=mytitle
+        ",
+        );
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].url, "http://this.is.an.example");
+        assert_eq!(items[0].title, "mytitle");
+    }
 }

--- a/lib/src/playlist/pls.rs
+++ b/lib/src/playlist/pls.rs
@@ -2,12 +2,13 @@
 
 use std::collections::HashMap;
 
-pub struct PlaylistItem {
+#[derive(Debug, Clone, PartialEq)]
+pub struct PLSItem {
     pub title: String,
     pub url: String,
 }
 
-pub fn decode(content: &str) -> Vec<PlaylistItem> {
+pub fn decode(content: &str) -> Vec<PLSItem> {
     let lines = content.lines();
     let mut list = vec![];
     let mut found_pls = false;
@@ -49,7 +50,7 @@ pub fn decode(content: &str) -> Vec<PlaylistItem> {
 
     for (key, value) in map_urls {
         let title = map_title.get(&key).unwrap_or(&default_title);
-        list.push(PlaylistItem {
+        list.push(PLSItem {
             title: String::from(*title),
             url: String::from(value),
         });

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -10,6 +10,9 @@ pub struct XSPFItem {
     pub identifier: String,
 }
 
+/// XSPF or "XML Shareable Playlist Format", based on XML (as the name implies).
+///
+/// <https://www.xspf.org/spec>
 pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
     let mut list = vec![];
     let mut item = XSPFItem {

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -20,7 +20,7 @@ pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
 
     let mut reader = Reader::from_str(content);
     reader.trim_text(true);
-    let mut xml_stack = vec![];
+    let mut xml_stack = Vec::with_capacity(4);
     let mut buf = Vec::new();
     let decoder = reader.decoder();
     loop {

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -28,33 +28,9 @@ pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
     let decoder = reader.decoder();
     loop {
         match reader.read_event_into(&mut buf) {
-            Ok(Event::Empty(ref e)) => {
-                xml_stack.push(decoder.decode(e.name().as_ref())?.to_lowercase());
-
-                let path = xml_stack.join("/");
-                for a in e.attributes() {
-                    let a = a?;
-                    let key = decoder.decode(a.key.as_ref())?.to_lowercase();
-                    let value = decoder.decode(&a.value)?;
-                    if path == "asx/entry/ref" && key == "href" {
-                        item.url = value.to_string();
-                    }
-                }
-
-                xml_stack.pop();
-            }
+            // Ok(Event::Empty(ref e)) => {}
             Ok(Event::Start(ref e)) => {
                 xml_stack.push(decoder.decode(e.name().as_ref())?.to_lowercase());
-
-                let path = xml_stack.join("/");
-                for a in e.attributes() {
-                    let a = a?;
-                    let key = decoder.decode(a.key.as_ref())?.to_lowercase();
-                    let value = decoder.decode(&a.value)?;
-                    if path == "asx/entry/ref" && key == "href" {
-                        item.url = value.to_string();
-                    }
-                }
             }
             Ok(Event::End(_)) => {
                 let path = xml_stack.join("/");

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -3,16 +3,16 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::error::Error;
 
-#[derive(Clone)]
-pub struct PlaylistItem {
+#[derive(Debug, Clone, PartialEq)]
+pub struct XSPFItem {
     pub title: String,
     pub url: String,
     pub identifier: String,
 }
 
-pub fn decode(content: &str) -> Result<Vec<PlaylistItem>, Box<dyn Error>> {
+pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
     let mut list = vec![];
-    let mut item = PlaylistItem {
+    let mut item = XSPFItem {
         title: String::new(),
         url: String::new(),
         identifier: String::new(),

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -90,3 +90,38 @@ pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
 
     Ok(list)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn xspf() {
+        let s = r#"<?xml version="1.0" encoding="UTF-8"?>
+<playlist version="1" xmlns="http://xspf.org/ns/0/">
+    <trackList>
+    <track>
+        <title>Title</title>
+        <identifier>Identifier</identifier>
+        <location>http://this.is.an.example</location>
+    </track>
+    <track>
+        <title>Title2</title>
+        <identifier>Identifier2</identifier>
+        <location>http://this.is.an.example2</location>
+    </track>
+    </trackList>
+</playlist>"#;
+        let items = decode(s);
+        assert!(items.is_ok());
+        let items = items.unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].url, "http://this.is.an.example");
+        assert_eq!(items[0].title, "Title");
+        assert_eq!(items[0].identifier, "Identifier");
+        assert_eq!(items[1].url, "http://this.is.an.example2");
+        assert_eq!(items[1].title, "Title2");
+        assert_eq!(items[1].identifier, "Identifier2");
+    }
+}


### PR DESCRIPTION
This PR updates the playlist parsing (m3u, pls, asx, xspf):
- completely re-implement `pls` parsing
- remove `asx` related code from `xspf`
- update `xspf` to use options over empty strings
- update `asx` to use options over empty strings
- update `asx` to be a little more spec compliant (refuse entries without at least one `title` and `ref href`)
- move the tests to their respective modules
- add more tests to each module
- actually test the detection and redirection of the main playlist decode
- rename all `PlaylistItem` to their respective playlists name
- some slight cleanup (removing unused functions, improving code style, doc-comments / comments)