### PR TITLE
Config v2 Integration / Switchover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Change(tui): move version display to be the last instead of first element in the bottom-bar.
 - Change(tui): rename previous feature `cover` to `cover-ueberzug`
 - Feat: Add `TM_LOGTOFILE` and `TMS_LOGTOFILE` to control `--log-to-file` for tui and server respectively.
+- Feat: Add new V2 Config Layout, old v1 config is automatically migrated to v2.
 - Feat(tui): allow Sixel to be used for covers.
 - Feat(tui): allow all cover providers to not be compiled in.
 - Fix: update the build scripts to check that the repository is actually the `termusic` repository before using the git version.

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -8,17 +8,8 @@ mod tui_overlay;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
-pub use v1::{
-    Alacritty, Alignment, BindingForEvent, ColorTermusic, Keys, LastPosition, SeekStep, Settings,
-    StyleColorSymbol, Xywh,
-};
-
 pub use server_overlay::ServerOverlay;
 pub use tui_overlay::TuiOverlay;
-
-/// The Settings Object, but shared across many places
-// Note that this (at least currently) unused in lib itself, but used in many of the other dependant crates (playback, server, tui)
-pub type SharedSettings = Arc<RwLock<Settings>>;
 
 /// The Server-Settings Object, but shared across many places
 // Note that this (at least currently) unused in lib itself, but used in many of the other dependant crates (playback, server, tui)
@@ -27,12 +18,6 @@ pub type SharedServerSettings = Arc<RwLock<ServerOverlay>>;
 /// The Server-Settings Object, but shared across many places
 // Note that this (at least currently) unused in lib itself, but used in many of the other dependant crates (playback, server, tui)
 pub type SharedTuiSettings = Arc<RwLock<TuiOverlay>>;
-
-/// Create a new [`SharedSettings`] from just [`Settings`] without having to also depend on [`parking_lot`]
-#[inline]
-pub fn new_shared_settings(settings: Settings) -> SharedSettings {
-    Arc::new(RwLock::new(settings))
-}
 
 /// Create a new [`SharedServerSettings`] without having to also depend on [`parking_lot`]
 #[inline]

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -9,8 +9,8 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 pub use v1::{
-    Alacritty, Alignment, BindingForEvent, ColorTermusic, Keys, LastPosition, Loop, SeekStep,
-    Settings, StyleColorSymbol, Xywh,
+    Alacritty, Alignment, BindingForEvent, ColorTermusic, Keys, LastPosition, SeekStep, Settings,
+    StyleColorSymbol, Xywh,
 };
 
 pub use server_overlay::ServerOverlay;

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -155,6 +155,7 @@ impl<'a> ServerConfigVersionedDefaulted<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "version")]
 pub enum ServerConfigVersioned<'a> {
+    /// V2 is considered stable / non-backwards breaking changes allowed after b0daaddf58ec7f46b364fcf999c50d3aa043308f
     // Cow data so that we can use a reference for saving instead of cloning
     // Starting at Version 2 as the old format is referred as v1, but lives in a different config file name
     #[serde(rename = "2")]

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -370,16 +370,6 @@ mod v1_interop {
         }
     }
 
-    impl From<LoopMode> for v1::Loop {
-        fn from(value: LoopMode) -> Self {
-            match value {
-                LoopMode::Single => v1::Loop::Single,
-                LoopMode::Playlist => v1::Loop::Playlist,
-                LoopMode::Random => v1::Loop::Random,
-            }
-        }
-    }
-
     impl From<v1::SeekStep> for SeekStep {
         fn from(value: v1::SeekStep) -> Self {
             match value {

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -370,6 +370,16 @@ mod v1_interop {
         }
     }
 
+    impl From<LoopMode> for v1::Loop {
+        fn from(value: LoopMode) -> Self {
+            match value {
+                LoopMode::Single => v1::Loop::Single,
+                LoopMode::Playlist => v1::Loop::Playlist,
+                LoopMode::Random => v1::Loop::Random,
+            }
+        }
+    }
+
     impl From<v1::SeekStep> for SeekStep {
         fn from(value: v1::SeekStep) -> Self {
             match value {

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -177,6 +177,7 @@ impl<'a> TuiConfigVersionedDefaulted<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "version")]
 pub enum TuiConfigVersioned<'a> {
+    /// V2 is considered stable / non-backwards breaking changes allowed after b0daaddf58ec7f46b364fcf999c50d3aa043308f
     // Cow data so that we can use a reference for saving instead of cloning
     // Starting at Version 2 as the old format is referred as v1, but lives in a different config file name
     #[serde(rename = "2")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,6 +15,7 @@ pub mod track;
 pub mod types;
 pub mod ueberzug;
 pub mod utils;
+pub mod xywh;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,4 +1,4 @@
-use crate::config::{BindingForEvent, ColorTermusic};
+use crate::config::v2::tui::{keys::KeyBinding, theme::styles::ColorTermusic};
 use crate::invidious::{Instance, YoutubeVideo};
 use crate::podcast::{EpData, PodcastFeed, PodcastNoId};
 use crate::songtag::SongTag;
@@ -156,7 +156,7 @@ pub enum ConfigEditorMsg {
     ThemeSelectBlurUp,
     ThemeSelectLoad(usize),
 
-    KeyChange(IdKey, BindingForEvent),
+    KeyChange(IdKey, KeyBinding),
     SaveLastPositionBlurDown,
     SaveLastPosotionBlurUp,
     SeekStepBlurDown,

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -195,6 +195,8 @@ pub enum ConfigEditorMsg {
 pub enum KFMsg {
     DatabaseAddAllBlurDown,
     DatabaseAddAllBlurUp,
+    DatabaseAddSelectedBlurDown,
+    DatabaseAddSelectedBlurUp,
     GlobalConfigBlurDown,
     GlobalConfigBlurUp,
     GlobalDownBlurDown,
@@ -601,6 +603,7 @@ pub enum IdConfigEditor {
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdKey {
     DatabaseAddAll,
+    DatabaseAddSelected,
     GlobalConfig,
     GlobalDown,
     GlobalGotoBottom,

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -1,4 +1,4 @@
-use crate::config::Xywh;
+use crate::xywh::Xywh;
 use anyhow::Context;
 use anyhow::{bail, Result};
 use std::ffi::OsStr;

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::config::Settings;
 use anyhow::{anyhow, Context, Result};
 use pinyin::ToPinyin;
 use std::borrow::Cow;
@@ -9,6 +8,8 @@ use std::{
     process::{Child, Command},
 };
 use unicode_segmentation::UnicodeSegmentation;
+
+use crate::config::ServerOverlay;
 
 pub fn get_pin_yin(input: &str) -> String {
     let mut b = String::new();
@@ -98,8 +99,8 @@ pub fn get_app_config_path() -> Result<PathBuf> {
 }
 
 /// Get the podcast directoy resolved and created
-fn get_podcast_save_path(config: &Settings) -> Result<PathBuf> {
-    let full_path = shellexpand::path::tilde(&config.podcast_dir);
+fn get_podcast_save_path(config: &ServerOverlay) -> Result<PathBuf> {
+    let full_path = shellexpand::path::tilde(&config.settings.podcast.download_dir);
     if !full_path.exists() {
         std::fs::create_dir_all(&full_path)?;
     }
@@ -107,7 +108,7 @@ fn get_podcast_save_path(config: &Settings) -> Result<PathBuf> {
 }
 
 /// Get the download directory for the provided `pod_title` and create it if not existing
-pub fn create_podcast_dir(config: &Settings, pod_title: String) -> Result<PathBuf> {
+pub fn create_podcast_dir(config: &ServerOverlay, pod_title: String) -> Result<PathBuf> {
     let mut download_path = get_podcast_save_path(config).context("get podcast directory")?;
     download_path.push(pod_title);
     std::fs::create_dir_all(&download_path).context("creating podcast download directory")?;

--- a/lib/src/xywh.rs
+++ b/lib/src/xywh.rs
@@ -1,0 +1,159 @@
+use crate::config::v2::tui::{Alignment, CoverArtPosition};
+use anyhow::{bail, Result};
+use image::DynamicImage;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlignmentWrap(Alignment);
+
+impl AlignmentWrap {
+    const fn x(&self, absolute_x: u32, width: u32) -> u32 {
+        match self.0 {
+            Alignment::BottomRight | Alignment::TopRight => {
+                Self::get_size_substract(absolute_x, width)
+            }
+            Alignment::BottomLeft | Alignment::TopLeft => absolute_x,
+        }
+    }
+    const fn y(&self, absolute_y: u32, height: u32) -> u32 {
+        match self.0 {
+            Alignment::BottomRight | Alignment::BottomLeft => {
+                Self::get_size_substract(absolute_y, height / 2)
+            }
+            Alignment::TopRight | Alignment::TopLeft => absolute_y,
+        }
+    }
+
+    const fn get_size_substract(absolute_size: u32, size: u32) -> u32 {
+        if absolute_size > size {
+            return absolute_size - size;
+        }
+        0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Xywh {
+    pub x_between_1_100: u32,
+    pub y_between_1_100: u32,
+    pub width_between_1_100: u32,
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+    pub align: AlignmentWrap,
+}
+
+impl From<&CoverArtPosition> for Xywh {
+    fn from(value: &CoverArtPosition) -> Self {
+        // TODO: actually apply scale
+        Self {
+            align: AlignmentWrap(value.align),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for Xywh {
+    #[allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+    fn default() -> Self {
+        let width = 20_u32;
+        let height = 20_u32;
+        let (term_width, term_height) = Self::get_terminal_size_u32();
+        let x = term_width - 1;
+        let y = term_height - 9;
+
+        Self {
+            x_between_1_100: 100,
+            y_between_1_100: 77,
+            width_between_1_100: width,
+            x,
+            y,
+            width,
+            height,
+            align: AlignmentWrap(Alignment::default()),
+        }
+    }
+}
+impl Xywh {
+    pub fn move_left(&mut self) {
+        self.x_between_1_100 = self.x_between_1_100.saturating_sub(1);
+    }
+
+    pub fn move_right(&mut self) {
+        self.x_between_1_100 += 1;
+        self.x_between_1_100 = self.x_between_1_100.min(100);
+    }
+
+    pub fn move_up(&mut self) {
+        self.y_between_1_100 = self.y_between_1_100.saturating_sub(2);
+    }
+
+    pub fn move_down(&mut self) {
+        self.y_between_1_100 += 2;
+        self.y_between_1_100 = self.y_between_1_100.min(100);
+    }
+    pub fn zoom_in(&mut self) {
+        self.width_between_1_100 += 1;
+        self.width_between_1_100 = self.width_between_1_100.min(100);
+    }
+
+    pub fn zoom_out(&mut self) {
+        self.width_between_1_100 = self.width_between_1_100.saturating_sub(1);
+    }
+
+    pub fn update_size(&self, image: &DynamicImage) -> Result<Self> {
+        let (term_width, term_height) = Self::get_terminal_size_u32();
+        let (x, y, width, height) = self.calculate_xywh(term_width, term_height, image)?;
+        Ok(Self {
+            x_between_1_100: self.x_between_1_100,
+            y_between_1_100: self.y_between_1_100,
+            width_between_1_100: self.width_between_1_100,
+            x,
+            y,
+            width,
+            height,
+            align: self.align.clone(),
+        })
+    }
+    fn calculate_xywh(
+        &self,
+        term_width: u32,
+        term_height: u32,
+        image: &DynamicImage,
+    ) -> Result<(u32, u32, u32, u32)> {
+        let width = self.get_width(term_width)?;
+        let height = Self::get_height(width, term_height, image)?;
+        let (absolute_x, absolute_y) = (
+            self.x_between_1_100 * term_width / 100,
+            self.y_between_1_100 * term_height / 100,
+        );
+        let (x, y) = (
+            self.align.x(absolute_x, width),
+            self.align.y(absolute_y, height),
+        );
+        Ok((x, y, width, height))
+    }
+
+    fn get_width(&self, term_width: u32) -> Result<u32> {
+        let width = self.width_between_1_100 * term_width / 100;
+        Self::safe_guard_width_or_height(width, term_width)
+    }
+
+    fn safe_guard_width_or_height(size: u32, size_max: u32) -> Result<u32> {
+        if size > size_max {
+            bail!("image width is too big, please reduce image width");
+        }
+        Ok(size)
+    }
+
+    fn get_height(width: u32, term_height: u32, image: &DynamicImage) -> Result<u32> {
+        let (pic_width_orig, pic_height_orig) = image::GenericImageView::dimensions(image);
+        let height = (width * pic_height_orig) / (pic_width_orig);
+        Self::safe_guard_width_or_height(height, term_height * 2)
+    }
+
+    pub fn get_terminal_size_u32() -> (u32, u32) {
+        let (term_width, term_height) = viuer::terminal_size();
+        (u32::from(term_width), u32::from(term_height))
+    }
+}

--- a/playback/src/gstreamer_backend.rs
+++ b/playback/src/gstreamer_backend.rs
@@ -36,7 +36,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
-use termusiclib::config::Settings;
+use termusiclib::config::ServerOverlay;
 use termusiclib::track::{MediaType, Track};
 
 /// This trait allows for easy conversion of a path to a URI
@@ -188,7 +188,7 @@ pub struct GStreamerBackend {
 
 impl GStreamerBackend {
     #[allow(clippy::too_many_lines)]
-    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
+    pub fn new(config: &ServerOverlay, cmd_tx: crate::PlayerCmdSender) -> Self {
         gst::init().expect("Couldn't initialize Gstreamer");
         let ctx = glib::MainContext::default();
         let _guard = ctx.acquire();
@@ -381,9 +381,9 @@ impl GStreamerBackend {
             })
             .expect("failed to start gstreamer mainloop thread");
 
-        let volume = config.player_volume;
-        let speed = config.player_speed;
-        let gapless = config.player_gapless;
+        let volume = config.settings.player.volume;
+        let speed = config.settings.player.speed;
+        let gapless = config.settings.player.gapless;
 
         let mut this = Self {
             playbin,

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -533,7 +533,10 @@ impl GeneralPlayer {
             .remember_position
             .get_time(track.media_type)
         else {
-            info!("Not saving Last position Remembering last position is not enabled");
+            info!(
+                "Not saving Last position as \"Remember last position\" is not enabled for {:#?}",
+                track.media_type
+            );
             return;
         };
 

--- a/playback/src/mpv_backend.rs
+++ b/playback/src/mpv_backend.rs
@@ -35,7 +35,7 @@ use std::cmp;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::time::Duration;
-use termusiclib::config::Settings;
+use termusiclib::config::ServerOverlay;
 use termusiclib::track::Track;
 
 pub struct MpvBackend {
@@ -67,12 +67,12 @@ enum PlayerInternalCmd {
 
 impl MpvBackend {
     #[allow(clippy::too_many_lines, clippy::cast_precision_loss)]
-    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
+    pub fn new(config: &ServerOverlay, cmd_tx: crate::PlayerCmdSender) -> Self {
         let (command_tx, command_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
-        let volume = config.player_volume;
-        let speed = config.player_speed;
-        let gapless = config.player_gapless;
+        let volume = config.settings.player.volume;
+        let speed = config.settings.player.speed;
+        let gapless = config.settings.player.gapless;
         let position = Arc::new(Mutex::new(Duration::default()));
         let duration = Arc::new(Mutex::new(Duration::default()));
         let media_title = Arc::new(Mutex::new(String::new()));

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use termusiclib::config::v2::server::LoopMode;
 use termusiclib::podcast::{db::Database as DBPod, Episode};
 use termusiclib::track::MediaType;
 use termusiclib::{
-    config::Loop,
     track::Track,
     utils::{filetype_supported, get_app_config_path, get_parent_folder},
 };
@@ -64,7 +64,7 @@ pub struct Playlist {
     current_track: Option<Track>,
     next_track: Option<Track>,
     status: Status,
-    loop_mode: Loop,
+    loop_mode: LoopMode,
     config: SharedSettings,
     need_proceed_to_next: bool,
 }
@@ -83,7 +83,7 @@ impl Playlist {
             next_track: None,
             // index: Some(0),
             status: Status::Stopped,
-            loop_mode,
+            loop_mode: loop_mode.into(),
             current_track_index,
             current_track,
             played_index: Vec::new(),
@@ -216,15 +216,15 @@ impl Playlist {
     fn get_next_track_index(&self) -> usize {
         let mut next_track_index = self.current_track_index;
         match self.loop_mode {
-            Loop::Single => {}
+            LoopMode::Single => {}
 
-            Loop::Playlist => {
+            LoopMode::Playlist => {
                 next_track_index += 1;
                 if next_track_index >= self.len() {
                     next_track_index = 0;
                 }
             }
-            Loop::Random => {
+            LoopMode::Random => {
                 next_track_index = self.get_random_index();
             }
         }
@@ -239,15 +239,15 @@ impl Playlist {
             }
         }
         match self.loop_mode {
-            Loop::Single => {}
-            Loop::Playlist => {
+            LoopMode::Single => {}
+            LoopMode::Playlist => {
                 if self.current_track_index == 0 {
                     self.current_track_index = self.len() - 1;
                 } else {
                     self.current_track_index -= 1;
                 }
             }
-            Loop::Random => {
+            LoopMode::Random => {
                 self.current_track_index = self.get_random_index();
             }
         }
@@ -341,19 +341,19 @@ impl Playlist {
     /// Cycle through the loop modes and return the new mode
     ///
     /// order:
-    /// [Random](Loop::Random) -> [Playlist](Loop::Playlist)
-    /// [Playlist](Loop::Playlist) -> [Single](Loop::Single)
-    /// [Single](Loop::Single) -> [Random](Loop::Random)
-    pub fn cycle_loop_mode(&mut self) -> Loop {
+    /// [Random](LoopMode::Random) -> [Playlist](LoopMode::Playlist)
+    /// [Playlist](LoopMode::Playlist) -> [Single](LoopMode::Single)
+    /// [Single](LoopMode::Single) -> [Random](LoopMode::Random)
+    pub fn cycle_loop_mode(&mut self) -> LoopMode {
         match self.loop_mode {
-            Loop::Random => {
-                self.loop_mode = Loop::Playlist;
+            LoopMode::Random => {
+                self.loop_mode = LoopMode::Playlist;
             }
-            Loop::Playlist => {
-                self.loop_mode = Loop::Single;
+            LoopMode::Playlist => {
+                self.loop_mode = LoopMode::Single;
             }
-            Loop::Single => {
-                self.loop_mode = Loop::Random;
+            LoopMode::Single => {
+                self.loop_mode = LoopMode::Random;
             }
         };
         self.loop_mode

--- a/playback/src/rusty_backend/mod.rs
+++ b/playback/src/rusty_backend/mod.rs
@@ -20,6 +20,7 @@ pub use sink::Sink;
 pub use source::Source;
 use std::num::{NonZeroU16, NonZeroUsize};
 pub use stream::OutputStream;
+use termusiclib::config::ServerOverlay;
 use tokio::runtime::Handle;
 
 use crate::{MediaInfo, Speed, Volume};
@@ -53,7 +54,6 @@ use stream_download::{Settings as StreamSettings, StreamDownload};
 use symphonia::core::io::{
     MediaSource, MediaSourceStream, MediaSourceStreamOptions, ReadOnlySource,
 };
-use termusiclib::config::Settings;
 use termusiclib::track::{MediaType, Track};
 
 pub type TotalDuration = Option<Duration>;
@@ -100,14 +100,14 @@ pub struct RustyBackend {
 impl RustyBackend {
     #[allow(clippy::similar_names)]
     #[allow(clippy::too_many_lines)]
-    pub fn new(config: &Settings, cmd_tx: crate::PlayerCmdSender) -> Self {
+    pub fn new(config: &ServerOverlay, cmd_tx: crate::PlayerCmdSender) -> Self {
         let (picmd_tx, picmd_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
             mpsc::channel();
         let picmd_tx_local = picmd_tx.clone();
-        let volume = Arc::new(AtomicU16::from(config.player_volume));
+        let volume = Arc::new(AtomicU16::from(config.settings.player.volume));
         let volume_local = volume.clone();
-        let speed = config.player_speed;
-        let gapless = config.player_gapless;
+        let speed = config.settings.player.speed;
+        let gapless = config.settings.player.gapless;
         let position = Arc::new(Mutex::new(Duration::default()));
         let total_duration = Arc::new(Mutex::new(None));
         let total_duration_local = total_duration.clone();

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -43,7 +43,7 @@ pub struct Args {
     pub disable_discord: bool,
     /// Max depth(NUMBER) of folder, default is 4.
     #[arg(short, long)]
-    pub max_depth: Option<usize>,
+    pub max_depth: Option<u32>,
     #[arg(short, long, default_value_t = Backend::Default, env = "TMS_BACKEND")]
     pub backend: Backend,
     #[clap(flatten)]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -189,7 +189,7 @@ fn player_loop(
                 std::process::exit(0);
             }
             PlayerCmd::CycleLoop => {
-                player.config.write().player_loop_mode = player.playlist.cycle_loop_mode();
+                player.config.write().player_loop_mode = player.playlist.cycle_loop_mode().into();
             }
             PlayerCmd::Eos => {
                 info!("Eos received");

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -42,7 +42,7 @@ pub struct Args {
     pub disable_discord: bool,
     /// Max depth(NUMBER) of folder, default is 4.
     #[arg(short, long)]
-    pub max_depth: Option<usize>,
+    pub max_depth: Option<u32>,
     #[arg(short, long, default_value_t = Backend::Default, env = "TMS_BACKEND")]
     pub backend: Backend,
     #[clap(flatten)]

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -605,28 +605,38 @@ pub struct SaveLastPosition {
 }
 
 impl SaveLastPosition {
-    pub fn new(_config: CombinedSettings) -> Self {
-        todo!();
-        // let config_tui = config.tui.read();
-        // let save_last_position = match config.server.read().settings.player.remember_position {
-        //     LastPosition::Auto => 0,
-        //     LastPosition::No => 1,
-        //     LastPosition::Yes => 2,
-        // };
-        // let component = Radio::default()
-        //     .borders(
-        //         Borders::default()
-        //             .color(config_tui.settings.theme.library_border())
-        //             .modifiers(BorderType::Rounded),
-        //     )
-        //     .choices(&["Auto", "No", "Yes"])
-        //     .foreground(config_tui.settings.theme.library_highlight())
-        //     .rewind(true)
-        //     .title(" Remember last played position: ", Alignment::Left)
-        //     .value(save_last_position);
+    pub fn new(config: CombinedSettings) -> Self {
+        let config_tui = config.tui.read();
+        // 0 == unsupported, dont save value
+        let save_last_position = match config.server.read().settings.player.remember_position {
+            termusiclib::config::v2::server::RememberLastPosition::All(
+                termusiclib::config::v2::server::PositionYesNo::Simple(ref v),
+            ) => match v {
+                termusiclib::config::v2::server::PositionYesNoLower::Yes => 2,
+                termusiclib::config::v2::server::PositionYesNoLower::No => 1,
+            },
+            _ => 0,
+            // LastPosition::Auto => 0,
+            // LastPosition::No => 1,
+            // LastPosition::Yes => 2,
+        };
+        let component = Radio::default()
+            .borders(
+                Borders::default()
+                    .color(config_tui.settings.theme.library_border())
+                    .modifiers(BorderType::Rounded),
+            )
+            .choices(&["Unspported", "No", "Yes"])
+            .foreground(config_tui.settings.theme.library_highlight())
+            .rewind(true)
+            .title(" Remember last played position: ", Alignment::Left)
+            .value(save_last_position);
 
-        // drop(config_tui);
-        // Self { component, config: config.tui }
+        drop(config_tui);
+        Self {
+            component,
+            config: config.tui,
+        }
     }
 }
 
@@ -648,28 +658,31 @@ pub struct ConfigSeekStep {
 }
 
 impl ConfigSeekStep {
-    pub fn new(_config: CombinedSettings) -> Self {
-        todo!();
-        // let config_tui = config.tui.read();
+    pub fn new(config: CombinedSettings) -> Self {
+        let config_tui = config.tui.read();
         // let seek_step = match config.server.read().settings.player.seek_step {
         //     SeekStep::Auto => 0,
         //     SeekStep::Short => 1,
         //     SeekStep::Long => 2,
         // };
-        // let component = Radio::default()
-        //     .borders(
-        //         Borders::default()
-        //             .color(config_tui.settings.theme.library_border())
-        //             .modifiers(BorderType::Rounded),
-        //     )
-        //     .choices(&["Auto", "Short(5)", "Long(30)"])
-        //     .foreground(config_tui.settings.theme.library_highlight())
-        //     .rewind(true)
-        //     .title(" Seek step in seconds: ", Alignment::Left)
-        //     .value(seek_step);
+        let seek_step = 0;
+        let component = Radio::default()
+            .borders(
+                Borders::default()
+                    .color(config_tui.settings.theme.library_border())
+                    .modifiers(BorderType::Rounded),
+            )
+            .choices(&["Unsupported"])
+            .foreground(config_tui.settings.theme.library_highlight())
+            .rewind(true)
+            .title(" Seek step in seconds: ", Alignment::Left)
+            .value(seek_step);
 
-        // drop(config_tui);
-        // Self { component, config: config.tui }
+        drop(config_tui);
+        Self {
+            component,
+            config: config.tui,
+        }
     }
 }
 

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1131,8 +1131,8 @@ impl KEModifierSelect {
     /// Returns `(mod_list_index, key_str)`
     fn init_modifier_select(id: IdKey, keys: &Keys) -> (usize, String) {
         let mod_key = match id {
-            // TODO: add DatabaseAddSelected
             IdKey::DatabaseAddAll => keys.database_keys.add_all.mod_key(),
+            IdKey::DatabaseAddSelected => keys.database_keys.add_selected.mod_key(),
             IdKey::GlobalConfig => keys.select_view_keys.open_config.mod_key(),
             IdKey::GlobalDown => keys.navigation_keys.down.mod_key(),
             IdKey::GlobalGotoBottom => keys.navigation_keys.goto_bottom.mod_key(),
@@ -2371,6 +2371,7 @@ impl Component<Msg, NoUserEvent> for ConfigPlaylistSwapUp {
         self.component.on(ev)
     }
 }
+
 #[derive(MockComponent)]
 pub struct ConfigDatabaseAddAll {
     component: KEModifierSelect,
@@ -2391,6 +2392,33 @@ impl ConfigDatabaseAddAll {
 }
 
 impl Component<Msg, NoUserEvent> for ConfigDatabaseAddAll {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(ev)
+    }
+}
+
+#[derive(MockComponent)]
+pub struct ConfigDatabaseAddSelected {
+    component: KEModifierSelect,
+}
+
+impl ConfigDatabaseAddSelected {
+    pub fn new(config: SharedTuiSettings) -> Self {
+        Self {
+            component: KEModifierSelect::new(
+                " Database Add Selected ",
+                IdKey::DatabaseAddSelected,
+                config,
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(
+                    KFMsg::DatabaseAddSelectedBlurDown,
+                )),
+                Msg::ConfigEditor(ConfigEditorMsg::KeyFocus(KFMsg::DatabaseAddSelectedBlurUp)),
+            ),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for ConfigDatabaseAddSelected {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         self.component.on(ev)
     }

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -27,14 +27,13 @@ mod key_combo;
 mod update;
 mod view;
 
-use crate::config::Settings;
 use crate::ui::model::ConfigEditorLayout;
 use crate::ui::{ConfigEditorMsg, Msg};
 pub use color::*;
 pub use general::*;
 pub use key_combo::*;
 
-use termusiclib::config::SharedSettings;
+use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use tui_realm_stdlib::{Radio, Span};
 use tuirealm::props::{Alignment, BorderSides, BorderType, Borders, Style, TextSpan};
 use tuirealm::{event::NoUserEvent, Component, Event, MockComponent};
@@ -47,7 +46,7 @@ pub struct CEHeader {
 }
 
 impl CEHeader {
-    pub fn new(layout: ConfigEditorLayout, config: &Settings) -> Self {
+    pub fn new(layout: ConfigEditorLayout, config: &TuiOverlay) -> Self {
         Self {
             component: Radio::default()
                 .borders(
@@ -61,8 +60,8 @@ impl CEHeader {
                     "Keys Global",
                     "Keys Other",
                 ])
-                .foreground(config.style_color_symbol.library_highlight())
-                .inactive(Style::default().fg(config.style_color_symbol.library_highlight()))
+                .foreground(config.settings.theme.library_highlight())
+                .inactive(Style::default().fg(config.settings.theme.library_highlight()))
                 .value(match layout {
                     ConfigEditorLayout::General => 0,
                     ConfigEditorLayout::Color => 1,
@@ -85,28 +84,28 @@ pub struct Footer {
 }
 
 impl Footer {
-    pub fn new(config: &Settings) -> Self {
+    pub fn new(config: &TuiOverlay) -> Self {
         Self {
             component: Span::default().spans(&[
-                TextSpan::new(format!("<{}>", config.keys.config_save))
+                TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
                     .bold()
-                    .fg(config.style_color_symbol.library_highlight()),
+                    .fg(config.settings.theme.library_highlight()),
                 TextSpan::new(" Save parameters ").bold(),
-                TextSpan::new(format!("<{}>", config.keys.global_esc))
+                TextSpan::new(format!("<{}>", config.settings.keys.escape))
                     .bold()
-                    .fg(config.style_color_symbol.library_highlight()),
+                    .fg(config.settings.theme.library_highlight()),
                 TextSpan::new(" Exit ").bold(),
                 TextSpan::new("<TAB>")
                     .bold()
-                    .fg(config.style_color_symbol.library_highlight()),
+                    .fg(config.settings.theme.library_highlight()),
                 TextSpan::new(" Change panel ").bold(),
                 TextSpan::new("<UP/DOWN>")
                     .bold()
-                    .fg(config.style_color_symbol.library_highlight()),
+                    .fg(config.settings.theme.library_highlight()),
                 TextSpan::new(" Change field ").bold(),
                 TextSpan::new("<ENTER>")
                     .bold()
-                    .fg(config.style_color_symbol.library_highlight()),
+                    .fg(config.settings.theme.library_highlight()),
                 TextSpan::new(" Select theme/Preview symbol ").bold(),
             ]),
         }
@@ -125,13 +124,13 @@ pub struct ConfigSavePopup {
 }
 
 impl ConfigSavePopup {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         let component =
             YNConfirm::new_with_cb(config, " Config changed. Do you want to save? ", |config| {
                 YNConfirmStyle {
-                    foreground_color: config.style_color_symbol.important_popup_foreground(),
-                    background_color: config.style_color_symbol.important_popup_background(),
-                    border_color: config.style_color_symbol.important_popup_border(),
+                    foreground_color: config.settings.theme.important_popup_foreground(),
+                    background_color: config.settings.theme.important_popup_background(),
+                    border_color: config.settings.theme.important_popup_border(),
                     title_alignment: Alignment::Center,
                 }
             });

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -731,7 +731,7 @@ impl Model {
                     .ok();
             }
 
-            KFMsg::PlaylistSwapUpBlurDown | KFMsg::PlaylistAddRandomAlbumBlurUp => {
+            KFMsg::PlaylistSwapUpBlurDown | KFMsg::DatabaseAddSelectedBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
                         IdKey::DatabaseAddAll,
@@ -739,7 +739,15 @@ impl Model {
                     .ok();
             }
 
-            KFMsg::DatabaseAddAllBlurDown | KFMsg::PlaylistAddRandomTracksBlurUp => {
+            KFMsg::DatabaseAddAllBlurDown | KFMsg::PlaylistAddRandomAlbumBlurUp => {
+                self.app
+                    .active(&Id::ConfigEditor(IdConfigEditor::Key(
+                        IdKey::DatabaseAddSelected,
+                    )))
+                    .ok();
+            }
+
+            KFMsg::DatabaseAddSelectedBlurDown | KFMsg::PlaylistAddRandomTracksBlurUp => {
                 self.app
                     .active(&Id::ConfigEditor(IdConfigEditor::Key(
                         IdKey::PlaylistAddRandomAlbum,
@@ -850,6 +858,7 @@ impl Model {
         self.config_changed = true;
         match id {
             IdKey::DatabaseAddAll => self.ke_key_config.database_keys.add_all = binding,
+            IdKey::DatabaseAddSelected => self.ke_key_config.database_keys.add_selected = binding,
             IdKey::GlobalConfig => self.ke_key_config.select_view_keys.open_config = binding,
             IdKey::GlobalDown => self.ke_key_config.navigation_keys.down = binding,
             IdKey::GlobalGotoBottom => self.ke_key_config.navigation_keys.goto_bottom = binding,

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -1,4 +1,3 @@
-use crate::config::{Alacritty, BindingForEvent, ColorTermusic};
 /**
  * MIT License
  *
@@ -23,18 +22,24 @@ use crate::config::{Alacritty, BindingForEvent, ColorTermusic};
  * SOFTWARE.
  */
 use crate::ui::Model;
+use anyhow::Context;
 use std::path::PathBuf;
-use termusiclib::config::new_shared_settings;
+use termusiclib::config::new_shared_tui_settings;
+use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
+use termusiclib::config::v2::tui::config_extra::TuiConfigVersionedDefaulted;
+use termusiclib::config::v2::tui::keys::KeyBinding;
+use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
+use termusiclib::config::v2::tui::theme::ThemeColors;
 use termusiclib::types::{ConfigEditorMsg, Id, IdConfigEditor, IdKey, KFMsg, Msg};
 use termusicplayback::PlayerCmd;
 
 impl Model {
     #[allow(clippy::too_many_lines)]
-    pub fn update_config_editor(&mut self, msg: &ConfigEditorMsg) -> Option<Msg> {
+    pub fn update_config_editor(&mut self, msg: ConfigEditorMsg) -> Option<Msg> {
         match msg {
             ConfigEditorMsg::Open => {
-                self.ce_style_color_symbol = self.config.read().style_color_symbol.clone();
-                self.ke_key_config = self.config.read().keys.clone();
+                self.ce_theme = self.config_tui.read().settings.theme.clone();
+                self.ke_key_config = self.config_tui.read().settings.keys.clone();
                 self.mount_config_editor();
             }
             ConfigEditorMsg::CloseCancel => {
@@ -145,16 +150,31 @@ impl Model {
                     .ok();
                 match self.collect_config_data() {
                     Ok(()) => {
-                        let res = self.config.write().save();
-                        match res {
-                            Ok(()) => {
-                                self.command(&PlayerCmd::ReloadConfig);
-                            }
-                            Err(e) => {
-                                self.mount_error_popup(e.context("save config"));
-                            }
+                        let res_server = ServerConfigVersionedDefaulted::save_config_path(
+                            &self.config_server.read().settings,
+                        )
+                        .context("config editor save server settings");
+                        let res_tui = TuiConfigVersionedDefaulted::save_config_path(
+                            &self.config_tui.read().settings,
+                        )
+                        .context("config editor save tui settings");
+
+                        let both_ok = res_server.is_ok() && res_tui.is_ok();
+
+                        if let Err(err) = res_server {
+                            self.mount_error_popup(err);
                         }
-                        self.umount_config_editor();
+
+                        if let Err(err) = res_tui {
+                            self.mount_error_popup(err);
+                        }
+
+                        if both_ok {
+                            self.command(&PlayerCmd::ReloadConfig);
+
+                            // only exit config editor if saving was successful
+                            self.umount_config_editor();
+                        }
                     }
                     Err(e) => {
                         self.mount_error_popup(e.context("collect config data"));
@@ -319,47 +339,46 @@ impl Model {
             }
 
             ConfigEditorMsg::ThemeSelectLoad(index) => {
-                if let Some(theme_path_str) = self.ce_themes.get(*index) {
+                if let Some(theme_path_str) = self.ce_themes.get(index) {
                     let theme_path = PathBuf::from(theme_path_str);
                     if let Some(theme_file_stem) = theme_path.file_stem() {
-                        self.config.write().theme_selected =
+                        self.config_tui.write().settings.theme.theme.name =
                             theme_file_stem.to_string_lossy().to_string();
-                        if let Ok(theme) = Alacritty::from_yaml_file(&theme_path) {
-                            self.ce_style_color_symbol.alacritty_theme = theme;
+                        if let Ok(theme) = ThemeColors::from_yaml_file(&theme_path) {
+                            self.ce_theme.theme = theme;
                         }
                     }
                 }
                 self.config_changed = true;
-                let mut config = self.config.read().clone();
+                let mut config = self.config_tui.read().clone();
                 // This is for preview the theme colors
-                config.style_color_symbol = self.ce_style_color_symbol.clone();
-                let config = new_shared_settings(config);
+                config.settings.theme = self.ce_theme.clone();
+                let config = new_shared_tui_settings(config);
                 self.remount_config_color(&config);
             }
             ConfigEditorMsg::ColorChanged(id, color_config) => {
                 self.config_changed = true;
-                self.update_config_editor_color_changed(*id, *color_config);
+                self.update_config_editor_color_changed(id, color_config);
             }
             ConfigEditorMsg::SymbolChanged(id, symbol) => {
                 self.config_changed = true;
 
                 match id {
                     IdConfigEditor::LibraryHighlightSymbol => {
-                        self.ce_style_color_symbol.library_highlight_symbol = symbol.to_string();
+                        self.ce_theme.style.library.highlight_symbol = symbol.to_string();
                     }
                     IdConfigEditor::PlaylistHighlightSymbol => {
-                        self.ce_style_color_symbol.playlist_highlight_symbol = symbol.to_string();
+                        self.ce_theme.style.playlist.highlight_symbol = symbol.to_string();
                     }
                     IdConfigEditor::CurrentlyPlayingTrackSymbol => {
-                        self.ce_style_color_symbol.currently_playing_track_symbol =
-                            symbol.to_string();
+                        self.ce_theme.style.playlist.current_track_symbol = symbol.to_string();
                     }
                     _ => {}
                 };
             }
 
-            ConfigEditorMsg::KeyChange(id, binding) => self.update_key(*id, binding),
-            ConfigEditorMsg::KeyFocus(msg) => self.update_key_focus(*msg),
+            ConfigEditorMsg::KeyChange(id, binding) => self.update_key(id, binding),
+            ConfigEditorMsg::KeyFocus(msg) => self.update_key_focus(msg),
         }
         None
     }
@@ -825,89 +844,109 @@ impl Model {
         }
     }
 
-    fn update_key(&mut self, id: IdKey, binding: &BindingForEvent) {
+    // cannot reduce a match statement
+    #[allow(clippy::too_many_lines)]
+    fn update_key(&mut self, id: IdKey, binding: KeyBinding) {
         self.config_changed = true;
         match id {
-            IdKey::DatabaseAddAll => self.ke_key_config.database_add_all = *binding,
-            IdKey::GlobalConfig => self.ke_key_config.global_config_open = *binding,
-            IdKey::GlobalDown => self.ke_key_config.global_down = *binding,
-            IdKey::GlobalGotoBottom => self.ke_key_config.global_goto_bottom = *binding,
-            IdKey::GlobalGotoTop => self.ke_key_config.global_goto_top = *binding,
-            IdKey::GlobalHelp => self.ke_key_config.global_help = *binding,
-            IdKey::GlobalLayoutTreeview => self.ke_key_config.global_layout_treeview = *binding,
-            IdKey::GlobalLayoutDatabase => self.ke_key_config.global_layout_database = *binding,
-            IdKey::GlobalLeft => self.ke_key_config.global_left = *binding,
+            IdKey::DatabaseAddAll => self.ke_key_config.database_keys.add_all = binding,
+            IdKey::GlobalConfig => self.ke_key_config.select_view_keys.open_config = binding,
+            IdKey::GlobalDown => self.ke_key_config.navigation_keys.down = binding,
+            IdKey::GlobalGotoBottom => self.ke_key_config.navigation_keys.goto_bottom = binding,
+            IdKey::GlobalGotoTop => self.ke_key_config.navigation_keys.goto_top = binding,
+            IdKey::GlobalHelp => self.ke_key_config.select_view_keys.open_help = binding,
+            IdKey::GlobalLayoutTreeview => {
+                self.ke_key_config.select_view_keys.view_library = binding;
+            }
+            IdKey::GlobalLayoutDatabase => {
+                self.ke_key_config.select_view_keys.view_database = binding;
+            }
+            IdKey::GlobalLeft => self.ke_key_config.navigation_keys.left = binding,
             IdKey::GlobalLyricAdjustForward => {
-                self.ke_key_config.global_lyric_adjust_forward = *binding;
+                self.ke_key_config.lyric_keys.adjust_offset_forwards = binding;
             }
             IdKey::GlobalLyricAdjustBackward => {
-                self.ke_key_config.global_lyric_adjust_backward = *binding;
+                self.ke_key_config.lyric_keys.adjust_offset_backwards = binding;
             }
-            IdKey::GlobalLyricCycle => self.ke_key_config.global_lyric_cycle = *binding,
+            IdKey::GlobalLyricCycle => self.ke_key_config.lyric_keys.cycle_frames = binding,
             IdKey::GlobalPlayerToggleGapless => {
-                self.ke_key_config.global_player_toggle_gapless = *binding;
+                self.ke_key_config.player_keys.toggle_prefetch = binding;
             }
             IdKey::GlobalPlayerTogglePause => {
-                self.ke_key_config.global_player_toggle_pause = *binding;
+                self.ke_key_config.player_keys.toggle_pause = binding;
             }
-            IdKey::GlobalPlayerNext => self.ke_key_config.global_player_next = *binding,
-            IdKey::GlobalPlayerPrevious => self.ke_key_config.global_player_previous = *binding,
+            IdKey::GlobalPlayerNext => self.ke_key_config.player_keys.next_track = binding,
+            IdKey::GlobalPlayerPrevious => self.ke_key_config.player_keys.previous_track = binding,
             IdKey::GlobalPlayerSeekForward => {
-                self.ke_key_config.global_player_seek_forward = *binding;
+                self.ke_key_config.player_keys.seek_forward = binding;
             }
             IdKey::GlobalPlayerSeekBackward => {
-                self.ke_key_config.global_player_seek_backward = *binding;
+                self.ke_key_config.player_keys.seek_backward = binding;
             }
-            IdKey::GlobalPlayerSpeedUp => self.ke_key_config.global_player_speed_up = *binding,
-            IdKey::GlobalPlayerSpeedDown => self.ke_key_config.global_player_speed_down = *binding,
-            IdKey::GlobalQuit => self.ke_key_config.global_quit = *binding,
-            IdKey::GlobalRight => self.ke_key_config.global_right = *binding,
-            IdKey::GlobalUp => self.ke_key_config.global_up = *binding,
-            IdKey::GlobalVolumeDown => self.ke_key_config.global_player_volume_minus_2 = *binding,
-            IdKey::GlobalVolumeUp => self.ke_key_config.global_player_volume_plus_2 = *binding,
-            IdKey::GlobalSavePlaylist => self.ke_key_config.global_save_playlist = *binding,
-            IdKey::LibraryDelete => self.ke_key_config.library_delete = *binding,
-            IdKey::LibraryLoadDir => self.ke_key_config.library_load_dir = *binding,
-            IdKey::LibraryPaste => self.ke_key_config.library_paste = *binding,
-            IdKey::LibrarySearch => self.ke_key_config.library_search = *binding,
-            IdKey::LibrarySearchYoutube => self.ke_key_config.library_search_youtube = *binding,
-            IdKey::LibraryTagEditor => self.ke_key_config.library_tag_editor_open = *binding,
-            IdKey::LibraryYank => self.ke_key_config.library_yank = *binding,
-            IdKey::PlaylistDelete => self.ke_key_config.playlist_delete = *binding,
-            IdKey::PlaylistDeleteAll => self.ke_key_config.playlist_delete_all = *binding,
-            IdKey::PlaylistShuffle => self.ke_key_config.playlist_shuffle = *binding,
-            IdKey::PlaylistModeCycle => self.ke_key_config.playlist_mode_cycle = *binding,
-            IdKey::PlaylistPlaySelected => self.ke_key_config.playlist_play_selected = *binding,
-            IdKey::PlaylistSearch => self.ke_key_config.playlist_search = *binding,
-            IdKey::PlaylistSwapDown => self.ke_key_config.playlist_swap_down = *binding,
-            IdKey::PlaylistSwapUp => self.ke_key_config.playlist_swap_up = *binding,
+            IdKey::GlobalPlayerSpeedUp => self.ke_key_config.player_keys.speed_up = binding,
+            IdKey::GlobalPlayerSpeedDown => self.ke_key_config.player_keys.speed_down = binding,
+            IdKey::GlobalQuit => self.ke_key_config.quit = binding,
+            IdKey::GlobalRight => self.ke_key_config.navigation_keys.right = binding,
+            IdKey::GlobalUp => self.ke_key_config.navigation_keys.up = binding,
+            IdKey::GlobalVolumeDown => self.ke_key_config.player_keys.volume_down = binding,
+            IdKey::GlobalVolumeUp => self.ke_key_config.player_keys.volume_up = binding,
+            IdKey::GlobalSavePlaylist => self.ke_key_config.player_keys.save_playlist = binding,
+            IdKey::LibraryDelete => self.ke_key_config.library_keys.delete = binding,
+            IdKey::LibraryLoadDir => self.ke_key_config.library_keys.load_dir = binding,
+            IdKey::LibraryPaste => self.ke_key_config.library_keys.paste = binding,
+            IdKey::LibrarySearch => self.ke_key_config.library_keys.search = binding,
+            IdKey::LibrarySearchYoutube => self.ke_key_config.library_keys.youtube_search = binding,
+            IdKey::LibraryTagEditor => self.ke_key_config.library_keys.open_tag_editor = binding,
+            IdKey::LibraryYank => self.ke_key_config.library_keys.yank = binding,
+            IdKey::PlaylistDelete => self.ke_key_config.playlist_keys.delete = binding,
+            IdKey::PlaylistDeleteAll => self.ke_key_config.playlist_keys.delete_all = binding,
+            IdKey::PlaylistShuffle => self.ke_key_config.playlist_keys.shuffle = binding,
+            IdKey::PlaylistModeCycle => self.ke_key_config.playlist_keys.cycle_loop_mode = binding,
+            IdKey::PlaylistPlaySelected => self.ke_key_config.playlist_keys.play_selected = binding,
+            IdKey::PlaylistSearch => self.ke_key_config.playlist_keys.search = binding,
+            IdKey::PlaylistSwapDown => self.ke_key_config.playlist_keys.swap_down = binding,
+            IdKey::PlaylistSwapUp => self.ke_key_config.playlist_keys.swap_up = binding,
             IdKey::PlaylistAddRandomAlbum => {
-                self.ke_key_config.playlist_add_random_album = *binding;
+                self.ke_key_config.playlist_keys.add_random_album = binding;
             }
             IdKey::PlaylistAddRandomTracks => {
-                self.ke_key_config.playlist_add_random_tracks = *binding;
+                self.ke_key_config.playlist_keys.add_random_songs = binding;
             }
-            IdKey::LibrarySwitchRoot => self.ke_key_config.library_switch_root = *binding,
-            IdKey::LibraryAddRoot => self.ke_key_config.library_add_root = *binding,
-            IdKey::LibraryRemoveRoot => self.ke_key_config.library_remove_root = *binding,
-            IdKey::GlobalLayoutPodcast => self.ke_key_config.global_layout_podcast = *binding,
-            IdKey::GlobalXywhMoveLeft => self.ke_key_config.global_xywh_move_left = *binding,
-            IdKey::GlobalXywhMoveRight => self.ke_key_config.global_xywh_move_right = *binding,
-            IdKey::GlobalXywhMoveUp => self.ke_key_config.global_xywh_move_up = *binding,
-            IdKey::GlobalXywhMoveDown => self.ke_key_config.global_xywh_move_down = *binding,
-            IdKey::GlobalXywhZoomIn => self.ke_key_config.global_xywh_zoom_in = *binding,
-            IdKey::GlobalXywhZoomOut => self.ke_key_config.global_xywh_zoom_out = *binding,
-            IdKey::GlobalXywhHide => self.ke_key_config.global_xywh_hide = *binding,
-            IdKey::PodcastMarkPlayed => self.ke_key_config.podcast_mark_played = *binding,
-            IdKey::PodcastMarkAllPlayed => self.ke_key_config.podcast_mark_all_played = *binding,
-            IdKey::PodcastEpDownload => self.ke_key_config.podcast_episode_download = *binding,
-            IdKey::PodcastEpDeleteFile => self.ke_key_config.podcast_episode_delete_file = *binding,
-            IdKey::PodcastDeleteFeed => self.ke_key_config.podcast_delete_feed = *binding,
-            IdKey::PodcastDeleteAllFeeds => self.ke_key_config.podcast_delete_all_feeds = *binding,
-            IdKey::PodcastSearchAddFeed => self.ke_key_config.podcast_search_add_feed = *binding,
-            IdKey::PodcastRefreshFeed => self.ke_key_config.podcast_refresh_feed = *binding,
+            IdKey::LibrarySwitchRoot => self.ke_key_config.library_keys.cycle_root = binding,
+            IdKey::LibraryAddRoot => self.ke_key_config.library_keys.add_root = binding,
+            IdKey::LibraryRemoveRoot => self.ke_key_config.library_keys.remove_root = binding,
+            IdKey::GlobalLayoutPodcast => {
+                self.ke_key_config.select_view_keys.view_podcasts = binding;
+            }
+            IdKey::GlobalXywhMoveLeft => self.ke_key_config.move_cover_art_keys.move_left = binding,
+            IdKey::GlobalXywhMoveRight => {
+                self.ke_key_config.move_cover_art_keys.move_right = binding;
+            }
+            IdKey::GlobalXywhMoveUp => self.ke_key_config.move_cover_art_keys.move_up = binding,
+            IdKey::GlobalXywhMoveDown => self.ke_key_config.move_cover_art_keys.move_down = binding,
+            IdKey::GlobalXywhZoomIn => {
+                self.ke_key_config.move_cover_art_keys.increase_size = binding;
+            }
+            IdKey::GlobalXywhZoomOut => {
+                self.ke_key_config.move_cover_art_keys.decrease_size = binding;
+            }
+            IdKey::GlobalXywhHide => self.ke_key_config.move_cover_art_keys.toggle_hide = binding,
+            IdKey::PodcastMarkPlayed => self.ke_key_config.podcast_keys.mark_played = binding,
+            IdKey::PodcastMarkAllPlayed => {
+                self.ke_key_config.podcast_keys.mark_all_played = binding;
+            }
+            IdKey::PodcastEpDownload => self.ke_key_config.podcast_keys.download_episode = binding,
+            IdKey::PodcastEpDeleteFile => {
+                self.ke_key_config.podcast_keys.delete_local_episode = binding;
+            }
+            IdKey::PodcastDeleteFeed => self.ke_key_config.podcast_keys.delete_feed = binding,
+            IdKey::PodcastDeleteAllFeeds => {
+                self.ke_key_config.podcast_keys.delete_all_feeds = binding;
+            }
+            IdKey::PodcastSearchAddFeed => self.ke_key_config.podcast_keys.search = binding,
+            IdKey::PodcastRefreshFeed => self.ke_key_config.podcast_keys.refresh_feed = binding,
             IdKey::PodcastRefreshAllFeeds => {
-                self.ke_key_config.podcast_refresh_all_feeds = *binding;
+                self.ke_key_config.podcast_keys.refresh_all_feeds = binding;
             }
         }
     }
@@ -919,46 +958,46 @@ impl Model {
     ) {
         match id {
             IdConfigEditor::LibraryForeground => {
-                self.ce_style_color_symbol.library_foreground = color_config;
+                self.ce_theme.style.library.foreground_color = color_config;
             }
             IdConfigEditor::LibraryBackground => {
-                self.ce_style_color_symbol.library_background = color_config;
+                self.ce_theme.style.library.background_color = color_config;
             }
             IdConfigEditor::LibraryBorder => {
-                self.ce_style_color_symbol.library_border = color_config;
+                self.ce_theme.style.library.border_color = color_config;
             }
             IdConfigEditor::LibraryHighlight => {
-                self.ce_style_color_symbol.library_highlight = color_config;
+                self.ce_theme.style.library.highlight_color = color_config;
             }
             IdConfigEditor::PlaylistForeground => {
-                self.ce_style_color_symbol.playlist_foreground = color_config;
+                self.ce_theme.style.playlist.foreground_color = color_config;
             }
             IdConfigEditor::PlaylistBackground => {
-                self.ce_style_color_symbol.playlist_background = color_config;
+                self.ce_theme.style.playlist.background_color = color_config;
             }
             IdConfigEditor::PlaylistBorder => {
-                self.ce_style_color_symbol.playlist_border = color_config;
+                self.ce_theme.style.playlist.border_color = color_config;
             }
             IdConfigEditor::PlaylistHighlight => {
-                self.ce_style_color_symbol.playlist_highlight = color_config;
+                self.ce_theme.style.playlist.highlight_color = color_config;
             }
             IdConfigEditor::ProgressForeground => {
-                self.ce_style_color_symbol.progress_foreground = color_config;
+                self.ce_theme.style.progress.foreground_color = color_config;
             }
             IdConfigEditor::ProgressBackground => {
-                self.ce_style_color_symbol.progress_background = color_config;
+                self.ce_theme.style.progress.background_color = color_config;
             }
             IdConfigEditor::ProgressBorder => {
-                self.ce_style_color_symbol.progress_border = color_config;
+                self.ce_theme.style.progress.border_color = color_config;
             }
             IdConfigEditor::LyricForeground => {
-                self.ce_style_color_symbol.lyric_foreground = color_config;
+                self.ce_theme.style.lyric.foreground_color = color_config;
             }
             IdConfigEditor::LyricBackground => {
-                self.ce_style_color_symbol.lyric_background = color_config;
+                self.ce_theme.style.lyric.background_color = color_config;
             }
             IdConfigEditor::LyricBorder => {
-                self.ce_style_color_symbol.lyric_border = color_config;
+                self.ce_theme.style.lyric.border_color = color_config;
             }
 
             _ => {}

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,20 +1,21 @@
 use crate::ui::components::{
     AlbumPhotoAlign, CEHeader, CEThemeSelectTable, ConfigCurrentlyPlayingTrackSymbol,
-    ConfigDatabaseAddAll, ConfigFallbackBackground, ConfigFallbackBorder, ConfigFallbackForeground,
-    ConfigFallbackHighlight, ConfigFallbackTitle, ConfigGlobalConfig, ConfigGlobalDown,
-    ConfigGlobalGotoBottom, ConfigGlobalGotoTop, ConfigGlobalHelp, ConfigGlobalLayoutDatabase,
-    ConfigGlobalLayoutPodcast, ConfigGlobalLayoutTreeview, ConfigGlobalLeft,
-    ConfigGlobalLyricAdjustBackward, ConfigGlobalLyricAdjustForward, ConfigGlobalLyricCycle,
-    ConfigGlobalPlayerNext, ConfigGlobalPlayerPrevious, ConfigGlobalPlayerSeekBackward,
-    ConfigGlobalPlayerSeekForward, ConfigGlobalPlayerSpeedDown, ConfigGlobalPlayerSpeedUp,
-    ConfigGlobalPlayerToggleGapless, ConfigGlobalPlayerTogglePause, ConfigGlobalQuit,
-    ConfigGlobalRight, ConfigGlobalSavePlaylist, ConfigGlobalUp, ConfigGlobalVolumeDown,
-    ConfigGlobalVolumeUp, ConfigGlobalXywhHide, ConfigGlobalXywhMoveDown, ConfigGlobalXywhMoveLeft,
-    ConfigGlobalXywhMoveRight, ConfigGlobalXywhMoveUp, ConfigGlobalXywhZoomIn,
-    ConfigGlobalXywhZoomOut, ConfigImportantPopupBackground, ConfigImportantPopupBorder,
-    ConfigImportantPopupForeground, ConfigImportantPopupTitle, ConfigLibraryAddRoot,
-    ConfigLibraryBackground, ConfigLibraryBorder, ConfigLibraryDelete, ConfigLibraryForeground,
-    ConfigLibraryHighlight, ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
+    ConfigDatabaseAddAll, ConfigDatabaseAddSelected, ConfigFallbackBackground,
+    ConfigFallbackBorder, ConfigFallbackForeground, ConfigFallbackHighlight, ConfigFallbackTitle,
+    ConfigGlobalConfig, ConfigGlobalDown, ConfigGlobalGotoBottom, ConfigGlobalGotoTop,
+    ConfigGlobalHelp, ConfigGlobalLayoutDatabase, ConfigGlobalLayoutPodcast,
+    ConfigGlobalLayoutTreeview, ConfigGlobalLeft, ConfigGlobalLyricAdjustBackward,
+    ConfigGlobalLyricAdjustForward, ConfigGlobalLyricCycle, ConfigGlobalPlayerNext,
+    ConfigGlobalPlayerPrevious, ConfigGlobalPlayerSeekBackward, ConfigGlobalPlayerSeekForward,
+    ConfigGlobalPlayerSpeedDown, ConfigGlobalPlayerSpeedUp, ConfigGlobalPlayerToggleGapless,
+    ConfigGlobalPlayerTogglePause, ConfigGlobalQuit, ConfigGlobalRight, ConfigGlobalSavePlaylist,
+    ConfigGlobalUp, ConfigGlobalVolumeDown, ConfigGlobalVolumeUp, ConfigGlobalXywhHide,
+    ConfigGlobalXywhMoveDown, ConfigGlobalXywhMoveLeft, ConfigGlobalXywhMoveRight,
+    ConfigGlobalXywhMoveUp, ConfigGlobalXywhZoomIn, ConfigGlobalXywhZoomOut,
+    ConfigImportantPopupBackground, ConfigImportantPopupBorder, ConfigImportantPopupForeground,
+    ConfigImportantPopupTitle, ConfigLibraryAddRoot, ConfigLibraryBackground, ConfigLibraryBorder,
+    ConfigLibraryDelete, ConfigLibraryForeground, ConfigLibraryHighlight,
+    ConfigLibraryHighlightSymbol, ConfigLibraryLoadDir, ConfigLibraryPaste,
     ConfigLibraryRemoveRoot, ConfigLibrarySearch, ConfigLibrarySearchYoutube,
     ConfigLibrarySwitchRoot, ConfigLibraryTagEditor, ConfigLibraryTitle, ConfigLibraryYank,
     ConfigLyricBackground, ConfigLyricBorder, ConfigLyricForeground, ConfigLyricTitle,
@@ -1345,6 +1346,13 @@ impl Model {
             _ => 8,
         };
 
+        let select_database_add_selected_len = match self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::Key(IdKey::DatabaseAddSelected),
+        )) {
+            Ok(State::One(_)) => 3,
+            _ => 8,
+        };
+
         let select_playlist_random_album_len = match self.app.state(&Id::ConfigEditor(
             IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum),
         )) {
@@ -1504,6 +1512,7 @@ impl Model {
                             Constraint::Length(select_playlist_swap_down_len),
                             Constraint::Length(select_playlist_swap_up_len),
                             Constraint::Length(select_database_add_all_len),
+                            Constraint::Length(select_database_add_selected_len),
                             Constraint::Length(select_playlist_random_album_len),
                             Constraint::Min(0),
                         ]
@@ -1637,9 +1646,14 @@ impl Model {
                     chunks_middle_column2[6],
                 );
                 self.app.view(
-                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum)),
+                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::DatabaseAddSelected)),
                     f,
                     chunks_middle_column2[7],
+                );
+                self.app.view(
+                    &Id::ConfigEditor(IdConfigEditor::Key(IdKey::PlaylistAddRandomAlbum)),
+                    f,
+                    chunks_middle_column2[8],
                 );
 
                 self.app.view(
@@ -2478,6 +2492,15 @@ impl Model {
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Key(IdKey::DatabaseAddAll)),
                 Box::new(ConfigDatabaseAddAll::new(config.clone())),
+                vec![],
+            )
+            .is_ok());
+
+        assert!(self
+            .app
+            .remount(
+                Id::ConfigEditor(IdConfigEditor::Key(IdKey::DatabaseAddSelected)),
+                Box::new(ConfigDatabaseAddSelected::new(config.clone())),
                 vec![],
             )
             .is_ok());

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -32,6 +32,7 @@ use crate::ui::components::{
     PlaylistRandomTrack, PodcastDir, PodcastMaxRetries, PodcastSimulDownload, SaveLastPosition,
 };
 use include_dir::DirEntry;
+use termusiclib::config::v2::server::{PositionYesNo, PositionYesNoLower, RememberLastPosition};
 use termusiclib::config::SharedTuiSettings;
 /**
  * MIT License
@@ -3394,7 +3395,18 @@ impl Model {
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::SaveLastPosition))
         {
-            todo!();
+            // NOTE: value "0" means to not save the value
+            if save_last_position != 0 {
+                let new_val = match save_last_position {
+                    1 => RememberLastPosition::All(PositionYesNo::Simple(PositionYesNoLower::No)),
+                    2 => RememberLastPosition::All(PositionYesNo::Simple(PositionYesNoLower::Yes)),
+                    // only 0,1,2 exist here
+                    _ => unreachable!(),
+                };
+
+                config_server.settings.player.remember_position = new_val;
+            }
+
             // let save_last_position = match save_last_position {
             //     0 => LastPosition::Auto,
             //     1 => LastPosition::No,
@@ -3407,7 +3419,9 @@ impl Model {
         if let Ok(State::One(StateValue::Usize(seek_step))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::SeekStep))
         {
-            todo!();
+            // NOTE: seek_step is currently unsupported to be set
+            let _ = seek_step;
+
             // let seek_step = match seek_step {
             //     0 => SeekStep::Auto,
             //     1 => SeekStep::Short,

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -32,7 +32,7 @@ use crate::ui::components::{
     PlaylistRandomTrack, PodcastDir, PodcastMaxRetries, PodcastSimulDownload, SaveLastPosition,
 };
 use include_dir::DirEntry;
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 /**
  * MIT License
  *
@@ -56,7 +56,6 @@ use termusiclib::config::SharedSettings;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use termusiclib::config::{LastPosition, SeekStep};
 use termusiclib::utils::{get_app_config_path, get_pin_yin};
 use termusiclib::THEME_DIR;
 
@@ -64,8 +63,9 @@ use crate::ui::model::{ConfigEditorLayout, Model};
 use crate::ui::utils::draw_area_in_absolute;
 use crate::ui::{Application, Id, IdConfigEditor, IdKey, Msg};
 use anyhow::{bail, Result};
+use std::num::{NonZeroU32, NonZeroU8};
 use std::path::PathBuf;
-use termusiclib::config::Alignment as XywhAlign;
+use termusiclib::config::v2::tui::Alignment as XywhAlign;
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{PropPayload, PropValue, TableBuilder, TextSpan};
 use tuirealm::tui::layout::{Constraint, Direction, Layout};
@@ -1723,7 +1723,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(self.config_layout, &self.config.read())),
+                Box::new(CEHeader::new(self.config_layout, &self.config_tui.read())),
                 vec![]
             )
             .is_ok());
@@ -1731,7 +1731,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Footer),
-                Box::new(Footer::new(&self.config.read())),
+                Box::new(Footer::new(&self.config_tui.read())),
                 vec![]
             )
             .is_ok());
@@ -1741,7 +1741,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::MusicDir),
-                Box::new(MusicDir::new(self.config.clone())),
+                Box::new(MusicDir::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1750,7 +1750,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ExitConfirmation),
-                Box::new(ExitConfirmation::new(self.config.clone())),
+                Box::new(ExitConfirmation::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -1759,7 +1759,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol),
-                Box::new(PlaylistDisplaySymbol::new(self.config.clone())),
+                Box::new(PlaylistDisplaySymbol::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -1768,7 +1768,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack),
-                Box::new(PlaylistRandomTrack::new(self.config.clone())),
+                Box::new(PlaylistRandomTrack::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1777,7 +1777,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum),
-                Box::new(PlaylistRandomAlbum::new(self.config.clone())),
+                Box::new(PlaylistRandomAlbum::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1786,7 +1786,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastDir),
-                Box::new(PodcastDir::new(self.config.clone())),
+                Box::new(PodcastDir::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1795,7 +1795,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload),
-                Box::new(PodcastSimulDownload::new(self.config.clone())),
+                Box::new(PodcastSimulDownload::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1804,7 +1804,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries),
-                Box::new(PodcastMaxRetries::new(self.config.clone())),
+                Box::new(PodcastMaxRetries::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1813,7 +1813,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign),
-                Box::new(AlbumPhotoAlign::new(self.config.clone())),
+                Box::new(AlbumPhotoAlign::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -1822,7 +1822,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::SaveLastPosition),
-                Box::new(SaveLastPosition::new(self.config.clone())),
+                Box::new(SaveLastPosition::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1831,7 +1831,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::SeekStep),
-                Box::new(ConfigSeekStep::new(self.config.clone())),
+                Box::new(ConfigSeekStep::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1840,7 +1840,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::KillDamon),
-                Box::new(KillDaemon::new(self.config.clone())),
+                Box::new(KillDaemon::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -1849,7 +1849,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerUseMpris),
-                Box::new(PlayerUseMpris::new(self.config.clone())),
+                Box::new(PlayerUseMpris::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1858,7 +1858,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord),
-                Box::new(PlayerUseDiscord::new(self.config.clone())),
+                Box::new(PlayerUseDiscord::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
@@ -1867,11 +1867,11 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::PlayerPort),
-                Box::new(PlayerPort::new(self.config.clone())),
+                Box::new(PlayerPort::new(self.get_combined_settings())),
                 vec![]
             )
             .is_ok());
-        let config = self.config.clone();
+        let config = self.config_tui.clone();
         self.remount_config_color(&config);
 
         // Active Config Editor
@@ -1890,7 +1890,7 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn remount_config_color(&mut self, config: &SharedSettings) {
+    pub fn remount_config_color(&mut self, config: &SharedTuiSettings) {
         // Mount color page
         assert!(self
             .app
@@ -3219,8 +3219,8 @@ impl Model {
             .app
             .remount(
                 Id::GlobalListener,
-                Box::new(GlobalListener::new(self.config.clone())),
-                Self::subscribe(&self.config.read().keys),
+                Box::new(GlobalListener::new(self.config_tui.clone())),
+                Self::subscribe(&self.config_tui.read().settings.keys),
             )
             .is_ok());
 
@@ -3242,7 +3242,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Header),
-                Box::new(CEHeader::new(self.config_layout, &self.config.read())),
+                Box::new(CEHeader::new(self.config_layout, &self.config_tui.read())),
                 vec![]
             )
             .is_ok());
@@ -3274,7 +3274,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::ConfigSavePopup),
-                Box::new(ConfigSavePopup::new(self.config.clone())),
+                Box::new(ConfigSavePopup::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -3286,13 +3286,15 @@ impl Model {
 
     #[allow(clippy::too_many_lines)]
     pub fn collect_config_data(&mut self) -> Result<()> {
-        let mut config = self.config.write();
-        if self.ke_key_config.has_unique_elements() {
-            config.keys = self.ke_key_config.clone();
-        } else {
-            bail!("Duplicate key found in config, changes were not saved.");
+        let mut config_tui = self.config_tui.write();
+        match self.ke_key_config.check_keys() {
+            Ok(()) => config_tui.settings.keys = self.ke_key_config.clone(),
+            Err(err) => bail!(err),
         }
-        config.style_color_symbol = self.ce_style_color_symbol.clone();
+        config_tui.settings.theme = self.ce_theme.clone();
+
+        let mut config_server = self.config_server.write();
+
         if let Ok(State::One(StateValue::String(music_dir))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::MusicDir))
         {
@@ -3306,29 +3308,34 @@ impl Model {
                     absolute_dir.exists()
                 })
                 .collect();
-            config.music_dir = vec;
+            config_server.settings.player.music_dirs = vec;
         }
 
         if let Ok(State::One(StateValue::Usize(exit_confirmation))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::ExitConfirmation))
         {
-            config.enable_exit_confirmation = matches!(exit_confirmation, 0);
+            config_tui.settings.behavior.confirm_quit = matches!(exit_confirmation, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(display_symbol))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol))
         {
-            config.playlist_display_symbol = matches!(display_symbol, 0);
+            config_tui
+                .settings
+                .theme
+                .style
+                .playlist
+                .use_loop_mode_symbol = matches!(display_symbol, 0);
         }
 
         if let Ok(State::One(StateValue::String(random_track_quantity_str))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack))
         {
-            if let Ok(quantity) = random_track_quantity_str.parse::<u32>() {
-                config.playlist_select_random_track_quantity = quantity;
+            if let Ok(quantity) = random_track_quantity_str.parse::<NonZeroU32>() {
+                config_server.settings.player.random_track_quantity = quantity;
             }
         }
 
@@ -3336,8 +3343,8 @@ impl Model {
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum))
         {
-            if let Ok(quantity) = random_album_quantity_str.parse::<u32>() {
-                config.playlist_select_random_album_quantity = quantity;
+            if let Ok(quantity) = random_album_quantity_str.parse::<NonZeroU32>() {
+                config_server.settings.player.random_album_min_quantity = quantity;
             }
         }
 
@@ -3347,28 +3354,24 @@ impl Model {
         {
             let absolute_dir = shellexpand::path::tilde(&podcast_dir);
             if absolute_dir.exists() {
-                config.podcast_dir = absolute_dir.into_owned();
+                config_server.settings.podcast.download_dir = absolute_dir.into_owned();
             }
         }
         if let Ok(State::One(StateValue::String(podcast_simul_download))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload))
         {
-            if let Ok(quantity) = podcast_simul_download.parse::<usize>() {
-                if (1..101).contains(&quantity) {
-                    config.podcast_simultanious_download = quantity;
-                } else {
-                    bail!(" It's not recommended to set simultanious download to more than 100. ");
-                }
+            if let Ok(quantity) = podcast_simul_download.parse::<NonZeroU8>() {
+                config_server.settings.podcast.concurrent_downloads_max = quantity;
             }
         }
         if let Ok(State::One(StateValue::String(podcast_max_retries))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries))
         {
-            if let Ok(quantity) = podcast_max_retries.parse::<usize>() {
+            if let Ok(quantity) = podcast_max_retries.parse::<u8>() {
                 if (1..11).contains(&quantity) {
-                    config.podcast_max_retries = quantity;
+                    config_server.settings.podcast.max_download_retries = quantity;
                 } else {
                     bail!(" It's not recommended to set max retries to more than 10. ");
                 }
@@ -3384,52 +3387,54 @@ impl Model {
                 2 => XywhAlign::TopRight,
                 _ => XywhAlign::TopLeft,
             };
-            config.album_photo_xywh.align = align;
+            config_tui.settings.coverart.align = align;
         }
 
         if let Ok(State::One(StateValue::Usize(save_last_position))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::SaveLastPosition))
         {
-            let save_last_position = match save_last_position {
-                0 => LastPosition::Auto,
-                1 => LastPosition::No,
-                2 => LastPosition::Yes,
-                _ => bail!(" Save last position must be set to auto, yes or no."),
-            };
-            config.player_remember_last_played_position = save_last_position;
+            todo!();
+            // let save_last_position = match save_last_position {
+            //     0 => LastPosition::Auto,
+            //     1 => LastPosition::No,
+            //     2 => LastPosition::Yes,
+            //     _ => bail!(" Save last position must be set to auto, yes or no."),
+            // };
+            // config_server.settings.player.remember_position = save_last_position;
         }
 
         if let Ok(State::One(StateValue::Usize(seek_step))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::SeekStep))
         {
-            let seek_step = match seek_step {
-                0 => SeekStep::Auto,
-                1 => SeekStep::Short,
-                2 => SeekStep::Long,
-                _ => bail!(" Unknown player step length provided."),
-            };
-            config.player_seek_step = seek_step;
+            todo!();
+            // let seek_step = match seek_step {
+            //     0 => SeekStep::Auto,
+            //     1 => SeekStep::Short,
+            //     2 => SeekStep::Long,
+            //     _ => bail!(" Unknown player step length provided."),
+            // };
+            // config_server.settings.player.seek_step = seek_step;
         }
 
         if let Ok(State::One(StateValue::Usize(kill_daemon))) =
             self.app.state(&Id::ConfigEditor(IdConfigEditor::KillDamon))
         {
-            config.kill_daemon_when_quit = matches!(kill_daemon, 0);
+            config_tui.settings.behavior.quit_server_on_exit = matches!(kill_daemon, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(player_use_mpris))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseMpris))
         {
-            config.player_use_mpris = matches!(player_use_mpris, 0);
+            config_server.settings.player.use_mediacontrols = matches!(player_use_mpris, 0);
         }
 
         if let Ok(State::One(StateValue::Usize(player_use_discord))) = self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord))
         {
-            config.player_use_discord = matches!(player_use_discord, 0);
+            config_server.settings.player.set_discord_status = matches!(player_use_discord, 0);
         }
 
         if let Ok(State::One(StateValue::String(player_port))) = self
@@ -3437,10 +3442,10 @@ impl Model {
             .state(&Id::ConfigEditor(IdConfigEditor::PlayerPort))
         {
             if let Ok(port) = player_port.parse::<u16>() {
-                if (1000..u16::MAX).contains(&port) {
-                    config.player_port = port;
+                if (1024..u16::MAX).contains(&port) {
+                    config_server.settings.com.port = port;
                 } else {
-                    bail!(" It's not recommended to use ports below 1000 for the player. ");
+                    bail!(" It's not recommended to use ports below 1024 for the player. ");
                 }
             }
         }
@@ -3480,8 +3485,15 @@ impl Model {
             let mut paths: Vec<_> = paths.filter_map(std::result::Result::ok).collect();
 
             paths.sort_by_cached_key(|k| get_pin_yin(&k.file_name().to_string_lossy()));
-            for p in paths {
-                self.ce_themes.push(p.path().to_string_lossy().to_string());
+            for entry in paths {
+                let path = entry.path();
+                let Some(stem) = path.file_stem() else {
+                    warn!("Theme {:#?} does not have a filestem!", path.display());
+
+                    continue;
+                };
+
+                self.ce_themes.push(stem.to_string_lossy().to_string());
             }
         }
 
@@ -3496,14 +3508,9 @@ impl Model {
                 table.add_row();
             }
 
-            let path = PathBuf::from(record);
-            let name = path.file_stem();
-
-            if let Some(n) = name {
-                table
-                    .add_col(TextSpan::new(idx.to_string()))
-                    .add_col(TextSpan::new(n.to_string_lossy()));
-            }
+            table
+                .add_col(TextSpan::new(idx.to_string()))
+                .add_col(TextSpan::new(record));
         }
         if self.ce_themes.is_empty() {
             table.add_col(TextSpan::from("0"));
@@ -3520,8 +3527,8 @@ impl Model {
             .ok();
         // select theme currently used
         let mut index = 0;
-        for (idx, v) in self.ce_themes.iter().enumerate() {
-            if *v == self.ce_style_color_symbol.alacritty_theme.path {
+        for (idx, name) in self.ce_themes.iter().enumerate() {
+            if name == &self.ce_theme.theme.name {
                 index = idx;
                 break;
             }

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -1,6 +1,6 @@
 use crate::ui::Model;
 use std::path::Path;
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 use termusiclib::sqlite::SearchCriteria;
 use termusiclib::types::{DBMsg, Id, Msg};
 use termusiclib::utils::{is_playlist, playlist_get_vec};
@@ -18,25 +18,25 @@ pub struct DBListCriteria {
     component: List,
     on_key_tab: Msg,
     on_key_backtab: Msg,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl DBListCriteria {
-    pub fn new(config: SharedSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
+    pub fn new(config: SharedTuiSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
         let component = {
             let config = config.read();
             List::default()
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Rounded)
-                        .color(config.style_color_symbol.library_border()),
+                        .color(config.settings.theme.library_border()),
                 )
-                .background(config.style_color_symbol.library_background())
-                .foreground(config.style_color_symbol.library_foreground())
+                .background(config.settings.theme.library_background())
+                .foreground(config.settings.theme.library_foreground())
                 .title(" DataBase ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config.style_color_symbol.library_highlight())
-                .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config.settings.theme.library_highlight())
+                .highlighted_str(&config.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .scroll(true)
@@ -67,7 +67,7 @@ impl DBListCriteria {
 impl Component<Msg, NoUserEvent> for DBListCriteria {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -86,7 +86,7 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
                 code: Key::Up,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Move(Direction::Up)),
-            Event::Keyboard(key) if key == keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.down.get() => {
                 if let Some(AttrValue::Table(t)) = self.query(Attribute::Content) {
                     if let State::One(StateValue::Usize(index)) = self.state() {
                         if index >= t.len() - 1 {
@@ -96,7 +96,7 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
                 }
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(key) if key == keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.up.get() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -107,10 +107,10 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -140,7 +140,7 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(self.on_key_backtab.clone()),
 
-            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_keys.search.get() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowDatabase))
             }
             _ => CmdResult::None,
@@ -154,25 +154,25 @@ pub struct DBListSearchResult {
     component: List,
     on_key_tab: Msg,
     on_key_backtab: Msg,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl DBListSearchResult {
-    pub fn new(config: SharedSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
+    pub fn new(config: SharedTuiSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
         let component = {
             let config = config.read();
             List::default()
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Rounded)
-                        .color(config.style_color_symbol.library_border()),
+                        .color(config.settings.theme.library_border()),
                 )
-                .background(config.style_color_symbol.library_background())
-                .foreground(config.style_color_symbol.library_foreground())
+                .background(config.settings.theme.library_background())
+                .foreground(config.settings.theme.library_foreground())
                 .title(" Result ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config.style_color_symbol.library_highlight())
-                .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config.settings.theme.library_highlight())
+                .highlighted_str(&config.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .scroll(true)
@@ -195,7 +195,7 @@ impl DBListSearchResult {
 impl Component<Msg, NoUserEvent> for DBListSearchResult {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -221,7 +221,7 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
                 }
                 self.perform(Cmd::Move(Direction::Up))
             }
-            Event::Keyboard(key) if key == keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.down.get() => {
                 if let Some(AttrValue::Table(t)) = self.query(Attribute::Content) {
                     if let State::One(StateValue::Usize(index)) = self.state() {
                         if index >= t.len() - 1 {
@@ -231,7 +231,7 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
                 }
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(key) if key == keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.up.get() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     if index == 0 {
                         return Some(self.on_key_backtab.clone());
@@ -247,10 +247,10 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -280,7 +280,7 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(self.on_key_backtab.clone()),
 
-            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_keys.search.get() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowDatabase))
             }
 
@@ -295,25 +295,25 @@ pub struct DBListSearchTracks {
     component: List,
     on_key_tab: Msg,
     on_key_backtab: Msg,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl DBListSearchTracks {
-    pub fn new(config: SharedSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
+    pub fn new(config: SharedTuiSettings, on_key_tab: Msg, on_key_backtab: Msg) -> Self {
         let component = {
             let config = config.read();
             List::default()
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Rounded)
-                        .color(config.style_color_symbol.library_border()),
+                        .color(config.settings.theme.library_border()),
                 )
-                .background(config.style_color_symbol.library_background())
-                .foreground(config.style_color_symbol.library_foreground())
+                .background(config.settings.theme.library_background())
+                .foreground(config.settings.theme.library_foreground())
                 .title(" Tracks ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config.style_color_symbol.library_highlight())
-                .highlighted_str(&config.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config.settings.theme.library_highlight())
+                .highlighted_str(&config.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .scroll(true)
@@ -336,7 +336,7 @@ impl DBListSearchTracks {
 impl Component<Msg, NoUserEvent> for DBListSearchTracks {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
@@ -353,10 +353,10 @@ impl Component<Msg, NoUserEvent> for DBListSearchTracks {
                 }
                 self.perform(Cmd::Move(Direction::Up))
             }
-            Event::Keyboard(key) if key == keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.down.get() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(key) if key == keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.up.get() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     if index == 0 {
                         return Some(self.on_key_backtab.clone());
@@ -372,10 +372,10 @@ impl Component<Msg, NoUserEvent> for DBListSearchTracks {
                 code: Key::PageUp,
                 modifiers: KeyModifiers::NONE,
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(key) if key == keys.global_goto_top.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(key) if key == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent {
@@ -396,17 +396,17 @@ impl Component<Msg, NoUserEvent> for DBListSearchTracks {
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(self.on_key_backtab.clone()),
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.database_keys.add_selected.get() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::DataBase(DBMsg::AddPlaylist(index)));
                 }
                 CmdResult::None
             }
-            Event::Keyboard(keyevent) if keyevent == keys.database_add_all.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.database_keys.add_all.get() => {
                 return Some(Msg::DataBase(DBMsg::AddAllToPlaylist))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.library_search.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.library_keys.search.get() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowDatabase))
             }
 
@@ -580,7 +580,7 @@ impl Model {
             .remount(
                 Id::DBListCriteria,
                 Box::new(DBListCriteria::new(
-                    self.config.clone(),
+                    self.config_tui.clone(),
                     Msg::DataBase(DBMsg::CriteriaBlurDown),
                     Msg::DataBase(DBMsg::CriteriaBlurUp)
                 )),
@@ -593,7 +593,7 @@ impl Model {
             .remount(
                 Id::DBListSearchResult,
                 Box::new(DBListSearchResult::new(
-                    self.config.clone(),
+                    self.config_tui.clone(),
                     Msg::DataBase(DBMsg::SearchResultBlurDown),
                     Msg::DataBase(DBMsg::SearchResultBlurUp)
                 )),
@@ -605,7 +605,7 @@ impl Model {
             .remount(
                 Id::DBListSearchTracks,
                 Box::new(DBListSearchTracks::new(
-                    self.config.clone(),
+                    self.config_tui.clone(),
                     Msg::DataBase(DBMsg::SearchTracksBlurDown),
                     Msg::DataBase(DBMsg::SearchTracksBlurUp)
                 )),

--- a/tui/src/ui/components/labels.rs
+++ b/tui/src/ui/components/labels.rs
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
 use super::Msg;
-use crate::config::Settings;
 use std::time::Instant;
+use termusiclib::config::TuiOverlay;
 use tui_realm_stdlib::{Label, Span, Spinner};
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::NoUserEvent;
@@ -39,13 +39,13 @@ pub struct LabelGeneric {
 }
 
 impl LabelGeneric {
-    pub fn new(config: &Settings, text: &str) -> Self {
+    pub fn new(config: &TuiOverlay, text: &str) -> Self {
         Self {
             component: Label::default()
                 .text(text)
                 .alignment(Alignment::Left)
-                .background(config.style_color_symbol.library_background())
-                .foreground(config.style_color_symbol.library_highlight())
+                .background(config.settings.theme.library_background())
+                .foreground(config.settings.theme.library_highlight())
                 .modifiers(TextModifiers::BOLD),
         }
     }
@@ -66,13 +66,13 @@ pub struct LabelSpan {
 }
 
 impl LabelSpan {
-    pub fn new(config: &Settings, span: &[TextSpan]) -> Self {
+    pub fn new(config: &TuiOverlay, span: &[TextSpan]) -> Self {
         Self {
             component: Span::default()
                 .spans(span)
                 .alignment(Alignment::Left)
-                .background(config.style_color_symbol.library_background())
-                .foreground(config.style_color_symbol.library_highlight())
+                .background(config.settings.theme.library_background())
+                .foreground(config.settings.theme.library_highlight())
                 .modifiers(TextModifiers::BOLD),
             default_span: span.to_vec(),
             active_message_start_time: None,
@@ -137,11 +137,11 @@ pub struct DownloadSpinner {
 }
 
 impl DownloadSpinner {
-    pub fn new(config: &Settings) -> Self {
+    pub fn new(config: &TuiOverlay) -> Self {
         Self {
             component: Spinner::default()
-                .foreground(config.style_color_symbol.library_highlight())
-                .background(config.style_color_symbol.library_background())
+                .foreground(config.settings.theme.library_highlight())
+                .background(config.settings.theme.library_background())
                 // .sequence("⣾⣽⣻⢿⡿⣟⣯⣷"),
                 // .sequence("▉▊▋▌▍▎▏▎▍▌▋▊▉"),
                 .sequence("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -52,9 +52,9 @@ pub use podcast::{EpisodeList, FeedsList};
 pub use popups::general_search::{GSInputPopup, GSTablePopup, Source};
 pub use progress::Progress;
 pub use tag_editor::*;
-use termusiclib::config::SharedSettings;
+use termusiclib::config::v2::tui::keys::Keys;
+use termusiclib::config::SharedTuiSettings;
 
-use crate::config::Keys;
 use crate::ui::{ConfigEditorMsg, Id, IdConfigEditor, IdTagEditor, Model, Msg, PLMsg, XYWHMsg};
 use tui_realm_stdlib::Phantom;
 use tuirealm::event::NoUserEvent;
@@ -63,11 +63,11 @@ use tuirealm::{Component, Event, MockComponent, Sub, SubClause, SubEventClause};
 #[derive(MockComponent)]
 pub struct GlobalListener {
     component: Phantom,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl GlobalListener {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: Phantom::default(),
             config,
@@ -78,124 +78,112 @@ impl GlobalListener {
 impl Component<Msg, NoUserEvent> for GlobalListener {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = &self.config.read().keys;
+        let keys = &self.config.read().settings.keys;
         match ev {
             Event::WindowResize(..) => Some(Msg::UpdatePhoto),
-            Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
-                Some(Msg::QuitPopupShow)
-            }
-            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
-                Some(Msg::QuitPopupShow)
-            }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_toggle_pause.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.escape.get() => Some(Msg::QuitPopupShow),
+            Event::Keyboard(keyevent) if keyevent == keys.quit.get() => Some(Msg::QuitPopupShow),
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.toggle_pause.get() => {
                 Some(Msg::PlayerTogglePause)
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_player_next.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.next_track.get() => {
                 Some(Msg::Playlist(PLMsg::NextSong))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_player_previous.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.previous_track.get() => {
                 Some(Msg::Playlist(PLMsg::PrevSong))
             }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_volume_minus_1.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.volume_down.get() => {
                 Some(Msg::PlayerVolumeDown)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_volume_minus_2.key_event() =>
-            {
-                Some(Msg::PlayerVolumeDown)
-            }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_volume_plus_1.key_event() =>
-            {
+            // Event::Keyboard(keyevent)
+            //     if keyevent == keys.player_keys.volume_minus_2.get() =>
+            // {
+            //     Some(Msg::PlayerVolumeDown)
+            // }
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.volume_up.get() => {
                 Some(Msg::PlayerVolumeUp)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_volume_plus_2.key_event() =>
-            {
-                Some(Msg::PlayerVolumeUp)
-            }
-            Event::Keyboard(keyevent) if keyevent == keys.global_help.key_event() => {
+            // Event::Keyboard(keyevent)
+            //     if keyevent == keys.player_keys.volume_plus_2.get() =>
+            // {
+            //     Some(Msg::PlayerVolumeUp)
+            // }
+            Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.open_help.get() => {
                 Some(Msg::HelpPopupShow)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_seek_forward.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.seek_forward.get() => {
                 Some(Msg::PlayerSeekForward)
             }
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_seek_backward.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.seek_backward.get() => {
                 Some(Msg::PlayerSeekBackward)
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_player_speed_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.speed_up.get() => {
                 Some(Msg::PlayerSpeedUp)
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_player_speed_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.speed_down.get() => {
                 Some(Msg::PlayerSpeedDown)
             }
 
             Event::Keyboard(keyevent)
-                if keyevent == keys.global_lyric_adjust_forward.key_event() =>
+                if keyevent == keys.lyric_keys.adjust_offset_forwards.get() =>
             {
                 Some(Msg::LyricAdjustDelay(1000))
             }
             Event::Keyboard(keyevent)
-                if keyevent == keys.global_lyric_adjust_backward.key_event() =>
+                if keyevent == keys.lyric_keys.adjust_offset_backwards.get() =>
             {
                 Some(Msg::LyricAdjustDelay(-1000))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_lyric_cycle.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.lyric_keys.cycle_frames.get() => {
                 Some(Msg::LyricCycle)
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_layout_treeview.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.view_library.get() => {
                 Some(Msg::LayoutTreeView)
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_layout_database.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.view_database.get() => {
                 Some(Msg::LayoutDataBase)
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_layout_podcast.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.view_podcasts.get() => {
                 Some(Msg::LayoutPodCast)
             }
 
-            Event::Keyboard(keyevent)
-                if keyevent == keys.global_player_toggle_gapless.key_event() =>
-            {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.toggle_prefetch.get() => {
                 Some(Msg::PlayerToggleGapless)
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_config_open.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.open_config.get() => {
                 Some(Msg::ConfigEditor(ConfigEditorMsg::Open))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_save_playlist.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.save_playlist.get() => {
                 Some(Msg::SavePlaylistPopupShow)
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_left.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.move_left.get() => {
                 Some(Msg::Xywh(XYWHMsg::MoveLeft))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.move_right.get() => {
                 Some(Msg::Xywh(XYWHMsg::MoveRight))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.move_up.get() => {
                 Some(Msg::Xywh(XYWHMsg::MoveUp))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_move_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.move_down.get() => {
                 Some(Msg::Xywh(XYWHMsg::MoveDown))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_zoom_in.key_event() => {
+            Event::Keyboard(keyevent)
+                if keyevent == keys.move_cover_art_keys.increase_size.get() =>
+            {
                 Some(Msg::Xywh(XYWHMsg::ZoomIn))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_zoom_out.key_event() => {
+            Event::Keyboard(keyevent)
+                if keyevent == keys.move_cover_art_keys.decrease_size.get() =>
+            {
                 Some(Msg::Xywh(XYWHMsg::ZoomOut))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_xywh_hide.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.toggle_hide.get() => {
                 Some(Msg::Xywh(XYWHMsg::Hide))
             }
             _ => None,
@@ -209,123 +197,123 @@ impl Model {
     pub fn subscribe(keys: &Keys) -> Vec<Sub<Id, NoUserEvent>> {
         vec![
             Sub::new(
-                SubEventClause::Keyboard(keys.global_esc.key_event()),
+                SubEventClause::Keyboard(keys.escape.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_quit.key_event()),
+                SubEventClause::Keyboard(keys.quit.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_toggle_pause.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.toggle_pause.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_next.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.next_track.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_previous.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.previous_track.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_speed_up.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.speed_up.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_speed_down.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.speed_down.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_volume_minus_1.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.volume_down.get()),
+                Self::no_popup_mounted_clause(),
+            ),
+            // Sub::new(
+            //     SubEventClause::Keyboard(keys.player_keys.volume_minus_2.get()),
+            //     Self::no_popup_mounted_clause(),
+            // ),
+            Sub::new(
+                SubEventClause::Keyboard(keys.player_keys.volume_up.get()),
+                Self::no_popup_mounted_clause(),
+            ),
+            // Sub::new(
+            //     SubEventClause::Keyboard(keys.player_keys.volume_plus_2.get()),
+            //     Self::no_popup_mounted_clause(),
+            // ),
+            Sub::new(
+                SubEventClause::Keyboard(keys.select_view_keys.open_help.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_volume_minus_2.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.seek_forward.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_volume_plus_1.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.seek_backward.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_volume_plus_2.key_event()),
+                SubEventClause::Keyboard(keys.lyric_keys.adjust_offset_forwards.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_help.key_event()),
+                SubEventClause::Keyboard(keys.lyric_keys.adjust_offset_backwards.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_seek_forward.key_event()),
+                SubEventClause::Keyboard(keys.lyric_keys.cycle_frames.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_seek_backward.key_event()),
+                SubEventClause::Keyboard(keys.select_view_keys.view_library.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_lyric_adjust_forward.key_event()),
+                SubEventClause::Keyboard(keys.select_view_keys.view_database.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_lyric_adjust_backward.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.toggle_prefetch.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_lyric_cycle.key_event()),
+                SubEventClause::Keyboard(keys.select_view_keys.open_config.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_layout_treeview.key_event()),
+                SubEventClause::Keyboard(keys.player_keys.save_playlist.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_layout_database.key_event()),
+                SubEventClause::Keyboard(keys.select_view_keys.view_podcasts.get()),
                 Self::no_popup_mounted_clause(),
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_player_toggle_gapless.key_event()),
-                Self::no_popup_mounted_clause(),
-            ),
-            Sub::new(
-                SubEventClause::Keyboard(keys.global_config_open.key_event()),
-                Self::no_popup_mounted_clause(),
-            ),
-            Sub::new(
-                SubEventClause::Keyboard(keys.global_save_playlist.key_event()),
-                Self::no_popup_mounted_clause(),
-            ),
-            Sub::new(
-                SubEventClause::Keyboard(keys.global_layout_podcast.key_event()),
-                Self::no_popup_mounted_clause(),
-            ),
-            Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_move_left.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.move_left.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_move_right.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.move_right.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_move_up.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.move_up.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_move_down.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.move_down.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_zoom_in.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.increase_size.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_zoom_out.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.decrease_size.get()),
                 SubClause::Always,
             ),
             Sub::new(
-                SubEventClause::Keyboard(keys.global_xywh_hide.key_event()),
+                SubEventClause::Keyboard(keys.move_cover_art_keys.toggle_hide.get()),
                 SubClause::Always,
             ),
             Sub::new(SubEventClause::WindowResize, SubClause::Always),

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -1,8 +1,5 @@
-use termusiclib::config::SharedSettings;
-use termusiclib::{
-    config::StyleColorSymbol,
-    types::{Id, Msg},
-};
+use termusiclib::config::{SharedTuiSettings, TuiOverlay};
+use termusiclib::types::{Id, Msg};
 use tui_realm_stdlib::Input;
 use tuirealm::{
     command::{Cmd, CmdResult, Direction, Position},
@@ -21,13 +18,13 @@ pub struct DeleteConfirmRadioPopup {
 }
 
 impl DeleteConfirmRadioPopup {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         let component =
             YNConfirm::new_with_cb(config, " Are sure you want to delete? ", |config| {
                 YNConfirmStyle {
-                    foreground_color: config.style_color_symbol.important_popup_foreground(),
-                    background_color: config.style_color_symbol.important_popup_background(),
-                    border_color: config.style_color_symbol.important_popup_border(),
+                    foreground_color: config.settings.theme.important_popup_foreground(),
+                    background_color: config.settings.theme.important_popup_background(),
+                    border_color: config.settings.theme.important_popup_border(),
                     title_alignment: Alignment::Left,
                 }
             });
@@ -49,14 +46,15 @@ pub struct DeleteConfirmInputPopup {
 }
 
 impl DeleteConfirmInputPopup {
-    pub fn new(style_color_symbol: &StyleColorSymbol) -> Self {
+    pub fn new(config: &TuiOverlay) -> Self {
+        let config = &config.settings;
         Self {
             component: Input::default()
-                .foreground(style_color_symbol.important_popup_foreground())
-                .background(style_color_symbol.important_popup_background())
+                .foreground(config.theme.important_popup_foreground())
+                .background(config.theme.important_popup_background())
                 .borders(
                     Borders::default()
-                        .color(style_color_symbol.important_popup_border())
+                        .color(config.theme.important_popup_border())
                         .modifiers(BorderType::Rounded),
                 )
                 // .invalid_style(Style::default().fg(Color::Red))
@@ -124,7 +122,7 @@ impl Model {
             .app
             .remount(
                 Id::DeleteConfirmRadioPopup,
-                Box::new(DeleteConfirmRadioPopup::new(self.config.clone())),
+                Box::new(DeleteConfirmRadioPopup::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());
@@ -136,9 +134,7 @@ impl Model {
             .app
             .remount(
                 Id::DeleteConfirmInputPopup,
-                Box::new(DeleteConfirmInputPopup::new(
-                    &self.config.read().style_color_symbol
-                )),
+                Box::new(DeleteConfirmInputPopup::new(&self.config_tui.read())),
                 vec![]
             )
             .is_ok());

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use crate::config::Settings;
 use crate::ui::Model;
 use anyhow::{anyhow, bail, Result};
-use termusiclib::config::SharedSettings;
+use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use termusiclib::types::{GSMsg, Id, Msg};
 use tui_realm_stdlib::{Input, Table};
 use tui_realm_treeview::TREE_INITIAL_NODE;
@@ -40,15 +39,15 @@ pub struct GSInputPopup {
 }
 
 impl GSInputPopup {
-    pub fn new(source: Source, config: &Settings) -> Self {
+    pub fn new(source: Source, config: &TuiOverlay) -> Self {
         match source {
             Source::Episode => Self {
                 component: Input::default()
-                    .background(config.style_color_symbol.fallback_background())
-                    .foreground(config.style_color_symbol.fallback_foreground())
+                    .background(config.settings.theme.fallback_background())
+                    .foreground(config.settings.theme.fallback_foreground())
                     .borders(
                         Borders::default()
-                            .color(config.style_color_symbol.fallback_border())
+                            .color(config.settings.theme.fallback_border())
                             .modifiers(BorderType::Rounded),
                     )
                     .input_type(InputType::Text)
@@ -60,11 +59,11 @@ impl GSInputPopup {
             },
             _ => Self {
                 component: Input::default()
-                    .background(config.style_color_symbol.fallback_background())
-                    .foreground(config.style_color_symbol.fallback_foreground())
+                    .background(config.settings.theme.fallback_background())
+                    .foreground(config.settings.theme.fallback_foreground())
                     .borders(
                         Borders::default()
-                            .color(config.style_color_symbol.fallback_border())
+                            .color(config.settings.theme.fallback_border())
                             .modifiers(BorderType::Rounded),
                     )
                     .input_type(InputType::Text)
@@ -141,7 +140,7 @@ impl Component<Msg, NoUserEvent> for GSInputPopup {
 pub struct GSTablePopup {
     component: Table,
     source: Source,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -154,23 +153,24 @@ pub enum Source {
 }
 impl GSTablePopup {
     #[allow(clippy::too_many_lines)]
-    pub fn new(source: Source, config: SharedSettings) -> Self {
+    pub fn new(source: Source, config: SharedTuiSettings) -> Self {
         let config_r = config.read();
+        // TODO: fix this up to be the proper keys
         let title_library = format!(
             " Results: (Enter: locate/{}: load to playlist) ",
-            config_r.keys.global_right
+            config_r.settings.keys.navigation_keys.right
         );
         let title_playlist = format!(
             " Results: (Enter: locate/{}: play selected) ",
-            config_r.keys.global_right
+            config_r.settings.keys.navigation_keys.right
         );
         let title_database = format!(
             " Results: ({}: load to playlist) ",
-            config_r.keys.global_right
+            config_r.settings.keys.navigation_keys.right
         );
         let title_episode = format!(
             " Results: (Enter: locate/{}: load to playlist) ",
-            config_r.keys.global_right
+            config_r.settings.keys.navigation_keys.right
         );
 
         let title_podcast = " Results: (Enter: locate) ";
@@ -178,15 +178,15 @@ impl GSTablePopup {
             Source::Library => Table::default()
                 .borders(
                     Borders::default()
-                        .color(config_r.style_color_symbol.fallback_border())
+                        .color(config_r.settings.theme.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(config_r.style_color_symbol.fallback_background())
-                .foreground(config_r.style_color_symbol.fallback_foreground())
+                .background(config_r.settings.theme.fallback_background())
+                .foreground(config_r.settings.theme.fallback_foreground())
                 .title(title_library, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
-                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config_r.settings.theme.fallback_highlight())
+                .highlighted_str(&config_r.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .row_height(1)
@@ -203,15 +203,15 @@ impl GSTablePopup {
             Source::Playlist => Table::default()
                 .borders(
                     Borders::default()
-                        .color(config_r.style_color_symbol.fallback_border())
+                        .color(config_r.settings.theme.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(config_r.style_color_symbol.fallback_background())
-                .foreground(config_r.style_color_symbol.fallback_foreground())
+                .background(config_r.settings.theme.fallback_background())
+                .foreground(config_r.settings.theme.fallback_foreground())
                 .title(title_playlist, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
-                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config_r.settings.theme.fallback_highlight())
+                .highlighted_str(&config_r.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .row_height(1)
@@ -227,15 +227,15 @@ impl GSTablePopup {
             Source::Database => Table::default()
                 .borders(
                     Borders::default()
-                        .color(config_r.style_color_symbol.fallback_border())
+                        .color(config_r.settings.theme.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(config_r.style_color_symbol.fallback_background())
-                .foreground(config_r.style_color_symbol.fallback_foreground())
+                .background(config_r.settings.theme.fallback_background())
+                .foreground(config_r.settings.theme.fallback_foreground())
                 .title(title_database, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
-                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config_r.settings.theme.fallback_highlight())
+                .highlighted_str(&config_r.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .row_height(1)
@@ -251,15 +251,15 @@ impl GSTablePopup {
             Source::Episode => Table::default()
                 .borders(
                     Borders::default()
-                        .color(config_r.style_color_symbol.fallback_border())
+                        .color(config_r.settings.theme.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(config_r.style_color_symbol.fallback_background())
-                .foreground(config_r.style_color_symbol.fallback_foreground())
+                .background(config_r.settings.theme.fallback_background())
+                .foreground(config_r.settings.theme.fallback_foreground())
                 .title(title_episode, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
-                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config_r.settings.theme.fallback_highlight())
+                .highlighted_str(&config_r.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .row_height(1)
@@ -275,15 +275,15 @@ impl GSTablePopup {
             Source::Podcast => Table::default()
                 .borders(
                     Borders::default()
-                        .color(config_r.style_color_symbol.fallback_border())
+                        .color(config_r.settings.theme.fallback_border())
                         .modifiers(BorderType::Rounded),
                 )
-                .background(config_r.style_color_symbol.fallback_background())
-                .foreground(config_r.style_color_symbol.fallback_foreground())
+                .background(config_r.settings.theme.fallback_background())
+                .foreground(config_r.settings.theme.fallback_foreground())
                 .title(title_podcast, Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config_r.style_color_symbol.fallback_highlight())
-                .highlighted_str(&config_r.style_color_symbol.library_highlight_symbol)
+                .highlighted_color(config_r.settings.theme.fallback_highlight())
+                .highlighted_str(&config_r.settings.theme.style.library.highlight_symbol)
                 .rewind(false)
                 .step(4)
                 .row_height(1)
@@ -310,12 +310,12 @@ impl GSTablePopup {
 impl Component<Msg, NoUserEvent> for GSTablePopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupCloseCancel))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.quit.get() => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupCloseCancel))
             }
 
@@ -326,11 +326,11 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
                 code: Key::Down, ..
             }) => self.perform(Cmd::Move(Direction::Down)),
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.down.get() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.up.get() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -340,10 +340,10 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
             Event::Keyboard(KeyEvent {
                 code: Key::PageUp, ..
             }) => self.perform(Cmd::Scroll(Direction::Up)),
-            Event::Keyboard(keyevent) if keyevent == keys.global_goto_top.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
@@ -353,7 +353,7 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
                 return Some(Msg::GeneralSearch(GSMsg::TableBlur))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_right.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.right.get() => {
                 match self.source {
                     Source::Library => {
                         return Some(Msg::GeneralSearch(GSMsg::PopupCloseLibraryAddPlaylist))

--- a/tui/src/ui/components/popups/mock_yn_confirm.rs
+++ b/tui/src/ui/components/popups/mock_yn_confirm.rs
@@ -1,5 +1,5 @@
-use termusiclib::config::SharedSettings;
-use termusiclib::{config::Settings, types::Msg};
+use termusiclib::config::{SharedTuiSettings, TuiOverlay};
+use termusiclib::types::Msg;
 use tui_realm_stdlib::Radio;
 use tuirealm::{
     command::{Cmd, CmdResult, Direction},
@@ -21,13 +21,13 @@ pub struct YNConfirmStyle {
 #[derive(MockComponent)]
 pub struct YNConfirm {
     component: Radio,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl YNConfirm {
     /// Create a new instance with custom colors
-    pub fn new_with_cb<F: FnOnce(&Settings) -> YNConfirmStyle>(
-        config: SharedSettings,
+    pub fn new_with_cb<F: FnOnce(&TuiOverlay) -> YNConfirmStyle>(
+        config: SharedTuiSettings,
         title: &'static str,
         cb: F,
     ) -> Self {
@@ -57,7 +57,7 @@ impl YNConfirm {
     #[allow(clippy::needless_pass_by_value)]
     pub fn on(&mut self, ev: Event<NoUserEvent>, on_y: Msg, on_n: Msg) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
@@ -66,20 +66,20 @@ impl YNConfirm {
                 code: Key::Right, ..
             }) => self.perform(Cmd::Move(Direction::Right)),
 
-            Event::Keyboard(key) if key == keys.global_left.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.left.get() => {
                 self.perform(Cmd::Move(Direction::Left))
             }
-            Event::Keyboard(key) if key == keys.global_right.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.right.get() => {
                 self.perform(Cmd::Move(Direction::Right))
             }
-            Event::Keyboard(key) if key == keys.global_up.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.up.get() => {
                 self.perform(Cmd::Move(Direction::Left))
             }
-            Event::Keyboard(key) if key == keys.global_down.key_event() => {
+            Event::Keyboard(key) if key == keys.navigation_keys.down.get() => {
                 self.perform(Cmd::Move(Direction::Right))
             }
-            Event::Keyboard(key) if key == keys.global_quit.key_event() => return Some(on_n),
-            Event::Keyboard(key) if key == keys.global_esc.key_event() => return Some(on_n),
+            Event::Keyboard(key) if key == keys.quit.get() => return Some(on_n),
+            Event::Keyboard(key) if key == keys.escape.get() => return Some(on_n),
             Event::Keyboard(KeyEvent {
                 code: Key::Char('y'),
                 ..

--- a/tui/src/ui/components/popups/quit.rs
+++ b/tui/src/ui/components/popups/quit.rs
@@ -1,4 +1,4 @@
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 /**
  * MIT License
  *
@@ -35,12 +35,12 @@ pub struct QuitPopup {
 }
 
 impl QuitPopup {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         let component = YNConfirm::new_with_cb(config, " Are sure you want to quit? ", |config| {
             YNConfirmStyle {
-                foreground_color: config.style_color_symbol.important_popup_foreground(),
-                background_color: config.style_color_symbol.important_popup_background(),
-                border_color: config.style_color_symbol.important_popup_border(),
+                foreground_color: config.settings.theme.important_popup_foreground(),
+                background_color: config.settings.theme.important_popup_background(),
+                border_color: config.settings.theme.important_popup_border(),
                 title_alignment: Alignment::Center,
             }
         });
@@ -63,7 +63,7 @@ impl Model {
             .app
             .remount(
                 Id::QuitPopup,
-                Box::new(QuitPopup::new(self.config.clone())),
+                Box::new(QuitPopup::new(self.config_tui.clone())),
                 vec![]
             )
             .is_ok());

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -1,3 +1,4 @@
+use termusiclib::config::SharedTuiSettings;
 /*
  * MIT License
  *
@@ -21,7 +22,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-use termusiclib::config::SharedSettings;
 use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -196,24 +196,24 @@ impl OwnStates {
 #[derive(MockComponent)]
 pub struct TECounterDelete {
     component: Counter,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl TECounterDelete {
-    pub fn new(initial_value: isize, config: SharedSettings) -> Self {
+    pub fn new(initial_value: isize, config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Counter::default()
                 .alignment(Alignment::Center)
-                .background(config.style_color_symbol.library_background())
+                .background(config.settings.theme.library_background())
                 .borders(
                     Borders::default()
-                        .color(config.style_color_symbol.library_border())
+                        .color(config.settings.theme.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 .foreground(
                     // config
-                    //     .style_color_symbol
+                    //     .settings.theme
                     //     .library_highlight(),
                     Color::Red,
                 )
@@ -227,10 +227,10 @@ impl TECounterDelete {
 
 impl Component<Msg, NoUserEvent> for TECounterDelete {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let keys = &self.config.read().keys;
+        let keys = &self.config.read().settings.keys;
         // Get command
         let _cmd = match ev {
-            Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
@@ -247,17 +247,17 @@ impl Component<Msg, NoUserEvent> for TECounterDelete {
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurUp)))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_quit.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.quit.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.escape.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(keyevent) if keyevent == keys.global_up.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.up.get() => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurUp)))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.global_down.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.navigation_keys.down.get() => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::CounterDeleteBlurDown)))
             }
 

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 use crate::ui::{Msg, TEMsg, TFMsg};
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 use tui_realm_stdlib::Input;
 use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -33,20 +33,20 @@ use tuirealm::{Component, Event, MockComponent};
 #[derive(MockComponent)]
 struct EditField {
     component: Input,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl EditField {
     #[inline]
-    pub fn new(config: SharedSettings, title: &'static str) -> Self {
+    pub fn new(config: SharedTuiSettings, title: &'static str) -> Self {
         let component = {
             let config = config.read();
             Input::default()
-                .foreground(config.style_color_symbol.library_foreground())
-                .background(config.style_color_symbol.library_background())
+                .foreground(config.settings.theme.library_foreground())
+                .background(config.settings.theme.library_background())
                 .borders(
                     Borders::default()
-                        .color(config.style_color_symbol.library_border())
+                        .color(config.settings.theme.library_border())
                         .modifiers(BorderType::Rounded),
                 )
                 .input_type(InputType::Text)
@@ -60,10 +60,10 @@ impl EditField {
     #[allow(clippy::needless_pass_by_value)]
     pub fn on(&mut self, ev: Event<NoUserEvent>, on_key_down: Msg, on_key_up: Msg) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         match ev {
             // Global Hotkeys
-            Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 Some(Msg::TagEditor(TEMsg::TERename))
             }
             Event::Keyboard(KeyEvent {
@@ -77,7 +77,7 @@ impl EditField {
                     modifiers: KeyModifiers::SHIFT,
                 },
             ) => Some(on_key_up),
-            Event::Keyboard(keyevent) if keyevent == keys.global_esc.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.escape.get() => {
                 Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
 
@@ -140,7 +140,7 @@ pub struct TEInputArtist {
 }
 
 impl TEInputArtist {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: EditField::new(config, " Search artist "),
         }
@@ -163,7 +163,7 @@ pub struct TEInputTitle {
 }
 
 impl TEInputTitle {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: EditField::new(config, " Search track name "),
         }
@@ -186,7 +186,7 @@ pub struct TEInputAlbum {
 }
 
 impl TEInputAlbum {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: EditField::new(config, " Album "),
         }
@@ -209,7 +209,7 @@ pub struct TEInputGenre {
 }
 
 impl TEInputGenre {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: EditField::new(config, " Genre "),
         }

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -1,7 +1,7 @@
 use crate::ui::Model;
 use anyhow::{anyhow, Context, Result};
 use std::path::Path;
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 /**
  * MIT License
  *
@@ -37,24 +37,24 @@ use tuirealm::{Component, Event, MockComponent, State, StateValue};
 #[derive(MockComponent)]
 pub struct TETableLyricOptions {
     component: Table,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl TETableLyricOptions {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Table::default()
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Rounded)
-                        .color(config.style_color_symbol.library_border()),
+                        .color(config.settings.theme.library_border()),
                 )
-                .foreground(config.style_color_symbol.library_foreground())
-                .background(config.style_color_symbol.library_background())
+                .foreground(config.settings.theme.library_foreground())
+                .background(config.settings.theme.library_background())
                 .title(" Search Results ", Alignment::Left)
                 .scroll(true)
-                .highlighted_color(config.style_color_symbol.library_highlight())
+                .highlighted_color(config.settings.theme.library_highlight())
                 .highlighted_str("\u{1f680}")
                 // .highlighted_str("🚀")
                 .rewind(false)
@@ -79,7 +79,7 @@ impl TETableLyricOptions {
 impl Component<Msg, NoUserEvent> for TETableLyricOptions {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(
@@ -95,14 +95,14 @@ impl Component<Msg, NoUserEvent> for TETableLyricOptions {
                 )))
             }
 
-            Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
 
-            Event::Keyboard(k) if k == keys.global_quit.key_event() => {
+            Event::Keyboard(k) if k == keys.quit.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(k) if k == keys.global_esc.key_event() => {
+            Event::Keyboard(k) if k == keys.escape.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
             Event::Keyboard(KeyEvent {
@@ -111,10 +111,10 @@ impl Component<Msg, NoUserEvent> for TETableLyricOptions {
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
                 self.perform(Cmd::Move(Direction::Up))
             }
-            Event::Keyboard(k) if k == keys.global_down.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.down.get() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(k) if k == keys.global_up.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.up.get() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -131,14 +131,14 @@ impl Component<Msg, NoUserEvent> for TETableLyricOptions {
                 self.perform(Cmd::GoTo(Position::End))
             }
 
-            Event::Keyboard(k) if k == keys.global_goto_top.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
 
-            Event::Keyboard(k) if k == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
-            Event::Keyboard(k) if k == keys.library_search_youtube.key_event() => {
+            Event::Keyboard(k) if k == keys.library_keys.youtube_search.get() => {
                 if let State::One(StateValue::Usize(index)) = self.state() {
                     return Some(Msg::TagEditor(TEMsg::TEDownload(index)));
                 }

--- a/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
@@ -24,7 +24,7 @@
 
 use crate::ui::{Msg, TEMsg, TFMsg};
 
-use termusiclib::config::SharedSettings;
+use termusiclib::config::SharedTuiSettings;
 use tui_realm_stdlib::Textarea;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
@@ -34,20 +34,20 @@ use tuirealm::{Component, Event, MockComponent};
 #[derive(MockComponent)]
 pub struct TETextareaLyric {
     component: Textarea,
-    config: SharedSettings,
+    config: SharedTuiSettings,
 }
 
 impl TETextareaLyric {
-    pub fn new(config: SharedSettings) -> Self {
+    pub fn new(config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Textarea::default()
                 .borders(
                     Borders::default()
                         .modifiers(BorderType::Rounded)
-                        .color(config.style_color_symbol.library_border()),
+                        .color(config.settings.theme.library_border()),
                 )
-                .foreground(config.style_color_symbol.library_foreground())
+                .foreground(config.settings.theme.library_foreground())
                 .title(" Lyrics ", Alignment::Left)
                 .step(4)
                 .highlighted_str("\u{1f3b5}")
@@ -61,9 +61,9 @@ impl TETextareaLyric {
 impl Component<Msg, NoUserEvent> for TETextareaLyric {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
-        let keys = &config.read().keys;
+        let keys = &config.read().settings.keys;
         let _cmd_result = match ev {
-            Event::Keyboard(keyevent) if keyevent == keys.config_save.key_event() => {
+            Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
@@ -73,10 +73,10 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
                 code: Key::BackTab,
                 modifiers: KeyModifiers::SHIFT,
             }) => return Some(Msg::TagEditor(TEMsg::TEFocus(TFMsg::TextareaLyricBlurUp))),
-            Event::Keyboard(k) if k == keys.global_quit.key_event() => {
+            Event::Keyboard(k) if k == keys.quit.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
-            Event::Keyboard(k) if k == keys.global_esc.key_event() => {
+            Event::Keyboard(k) if k == keys.escape.get() => {
                 return Some(Msg::TagEditor(TEMsg::TagEditorClose(None)))
             }
             Event::Keyboard(KeyEvent {
@@ -85,10 +85,10 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
                 self.perform(Cmd::Move(Direction::Up))
             }
-            Event::Keyboard(k) if k == keys.global_down.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.down.get() => {
                 self.perform(Cmd::Move(Direction::Down))
             }
-            Event::Keyboard(k) if k == keys.global_up.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.up.get() => {
                 self.perform(Cmd::Move(Direction::Up))
             }
             Event::Keyboard(KeyEvent {
@@ -102,7 +102,7 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
                 code: Key::Home, ..
             }) => self.perform(Cmd::GoTo(Position::Begin)),
 
-            Event::Keyboard(k) if k == keys.global_goto_top.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.goto_top.get() => {
                 self.perform(Cmd::GoTo(Position::Begin))
             }
 
@@ -110,7 +110,7 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
                 self.perform(Cmd::GoTo(Position::End))
             }
 
-            Event::Keyboard(k) if k == keys.global_goto_bottom.key_event() => {
+            Event::Keyboard(k) if k == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
             _ => CmdResult::None,

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -187,7 +187,7 @@ impl Model {
                     .remount(
                         Id::TagEditor(IdTagEditor::LabelHint),
                         Box::new(LabelGeneric::new(
-                            &self.config.read(),
+                            &self.config_tui.read(),
                             "Press <ENTER> to search:"
                         )),
                         vec![]
@@ -197,7 +197,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputArtist),
-                        Box::new(TEInputArtist::new(self.config.clone())),
+                        Box::new(TEInputArtist::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -205,7 +205,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputTitle),
-                        Box::new(TEInputTitle::new(self.config.clone())),
+                        Box::new(TEInputTitle::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -213,7 +213,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputAlbum),
-                        Box::new(TEInputAlbum::new(self.config.clone())),
+                        Box::new(TEInputAlbum::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -221,7 +221,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::InputGenre),
-                        Box::new(TEInputGenre::new(self.config.clone())),
+                        Box::new(TEInputGenre::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -229,7 +229,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::TableLyricOptions),
-                        Box::new(TETableLyricOptions::new(self.config.clone())),
+                        Box::new(TETableLyricOptions::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -237,7 +237,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::SelectLyric),
-                        Box::new(TESelectLyric::new(self.config.clone())),
+                        Box::new(TESelectLyric::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -245,7 +245,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::CounterDelete),
-                        Box::new(TECounterDelete::new(5, self.config.clone())),
+                        Box::new(TECounterDelete::new(5, self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -253,7 +253,7 @@ impl Model {
                     .app
                     .remount(
                         Id::TagEditor(IdTagEditor::TextareaLyric),
-                        Box::new(TETextareaLyric::new(self.config.clone())),
+                        Box::new(TETextareaLyric::new(self.config_tui.clone())),
                         vec![]
                     )
                     .is_ok());
@@ -462,7 +462,7 @@ impl Model {
     }
 
     pub fn remount_tag_editor_label_help(&mut self) {
-        let config = self.config.read();
+        let config = self.config_tui.read();
         assert!(self
             .app
             .remount(
@@ -470,30 +470,31 @@ impl Model {
                 Box::new(LabelSpan::new(
                     &config,
                     &[
-                        TextSpan::new(format!("<{}>", config.keys.config_save))
+                        TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
                             .bold()
-                            .fg(config.style_color_symbol.library_highlight()),
-                        TextSpan::new(" Save tag ")
-                            .fg(config.style_color_symbol.library_foreground()),
-                        TextSpan::new(format!("<{}>", config.keys.global_esc))
+                            .fg(config.settings.theme.library_highlight()),
+                        TextSpan::new(" Save tag ").fg(config.settings.theme.library_foreground()),
+                        TextSpan::new(format!("<{}>", config.settings.keys.escape))
                             .bold()
-                            .fg(config.style_color_symbol.library_highlight()),
-                        TextSpan::new(" Exit ").fg(config.style_color_symbol.library_foreground()),
+                            .fg(config.settings.theme.library_highlight()),
+                        TextSpan::new(" Exit ").fg(config.settings.theme.library_foreground()),
                         TextSpan::new("<Tab/ShiftTab>")
                             .bold()
-                            .fg(config.style_color_symbol.library_highlight()),
+                            .fg(config.settings.theme.library_highlight()),
                         TextSpan::new(" Change field ")
-                            .fg(config.style_color_symbol.library_foreground()),
+                            .fg(config.settings.theme.library_foreground()),
                         TextSpan::new("<ENTER>")
                             .bold()
-                            .fg(config.style_color_symbol.library_highlight()),
+                            .fg(config.settings.theme.library_highlight()),
                         TextSpan::new(" Search/Embed tag ")
-                            .fg(config.style_color_symbol.library_foreground()),
-                        TextSpan::new(format!("<{}>", config.keys.library_search_youtube))
-                            .bold()
-                            .fg(config.style_color_symbol.library_highlight()),
-                        TextSpan::new(" download ")
-                            .fg(config.style_color_symbol.library_foreground()),
+                            .fg(config.settings.theme.library_foreground()),
+                        TextSpan::new(format!(
+                            "<{}>",
+                            config.settings.keys.library_keys.youtube_search
+                        ))
+                        .bold()
+                        .fg(config.settings.theme.library_highlight()),
+                        TextSpan::new(" download ").fg(config.settings.theme.library_foreground()),
                     ]
                 )),
                 Vec::default(),

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -39,37 +39,37 @@ use tokio::runtime::Handle;
 
 impl Model {
     pub fn xywh_move_left(&mut self) {
-        self.config.write().album_photo_xywh.move_left();
+        self.xywh.move_left();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_right(&mut self) {
-        self.config.write().album_photo_xywh.move_right();
+        self.xywh.move_right();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_up(&mut self) {
-        self.config.write().album_photo_xywh.move_up();
+        self.xywh.move_up();
         self.update_photo().ok();
     }
 
     pub fn xywh_move_down(&mut self) {
-        self.config.write().album_photo_xywh.move_down();
+        self.xywh.move_down();
         self.update_photo().ok();
     }
     pub fn xywh_zoom_in(&mut self) {
-        self.config.write().album_photo_xywh.zoom_in();
+        self.xywh.zoom_in();
         self.update_photo().ok();
     }
     pub fn xywh_zoom_out(&mut self) {
-        self.config.write().album_photo_xywh.zoom_out();
+        self.xywh.zoom_out();
         self.update_photo().ok();
     }
     pub fn xywh_toggle_hide(&mut self) {
         self.clear_photo().ok();
-        let mut config = self.config.write();
-        config.disable_album_art_from_cli = !config.disable_album_art_from_cli;
-        drop(config);
+        let mut config_tui = self.config_tui.write();
+        config_tui.disable_tui_images = !config_tui.disable_tui_images;
+        drop(config_tui);
         self.update_photo().ok();
     }
     fn should_not_show_photo(&self) -> bool {
@@ -108,7 +108,7 @@ impl Model {
     /// Requires that the current thread has a entered runtime
     #[allow(clippy::cast_possible_truncation)]
     pub fn update_photo(&mut self) -> Result<()> {
-        if self.config.read().disable_album_art_from_cli {
+        if self.config_tui.read().disable_tui_images {
             return Ok(());
         }
         self.clear_photo()?;
@@ -222,7 +222,7 @@ impl Model {
     #[allow(clippy::cast_possible_truncation, clippy::unnecessary_wraps)]
     pub fn show_image(&mut self, img: &DynamicImage) -> Result<()> {
         #[allow(unused_variables)]
-        let xywh = self.config.read().album_photo_xywh.update_size(img)?;
+        let xywh = self.xywh.update_size(img)?;
 
         // error!("{:?}", self.viuer_supported);
         match self.viuer_supported {

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -44,7 +44,7 @@ impl Update<Msg> for Model {
             self.redraw = true;
             // Match message
             match msg {
-                Msg::ConfigEditor(m) => self.update_config_editor(&m),
+                Msg::ConfigEditor(m) => self.update_config_editor(m),
                 Msg::DataBase(m) => self.update_database_list(&m),
 
                 Msg::DeleteConfirmShow
@@ -58,7 +58,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::QuitPopupShow => {
-                    if self.config.read().enable_exit_confirmation {
+                    if self.config_tui.read().settings.behavior.confirm_quit {
                         self.mount_quit_popup();
                     } else {
                         self.quit = true;
@@ -838,7 +838,8 @@ impl Model {
             }
             PLMsg::LoopModeCycle => {
                 self.command(&PlayerCmd::CycleLoop);
-                self.config.write().player_loop_mode = self.playlist.cycle_loop_mode().into();
+                self.config_server.write().settings.player.loop_mode =
+                    self.playlist.cycle_loop_mode();
                 self.playlist_update_title();
             }
             PLMsg::PlaylistTableBlurDown => match self.layout {

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -838,7 +838,7 @@ impl Model {
             }
             PLMsg::LoopModeCycle => {
                 self.command(&PlayerCmd::CycleLoop);
-                self.config.write().player_loop_mode = self.playlist.cycle_loop_mode();
+                self.config.write().player_loop_mode = self.playlist.cycle_loop_mode().into();
                 self.playlist_update_title();
             }
             PLMsg::PlaylistTableBlurDown => match self.layout {


### PR DESCRIPTION
This PR is the final entry in the Config V2 series, where all places v1 config is used is switched over to v2, making it 3 / 3 PRs.

Note that this PR has some *slight* problems:
- fully disabled TUI config editor for `SeekStep`
- partially working TUI config editor for `SaveLastPosition` (only the simple settings, if others are set config editor is ignored and not saved)
- i might have forgot to change some places from `navigation_keys.right` (`L`) to their respective counterpart (like `playlist_keys.play_selected`) and will have to be changed later

re #319

---

@tramhao i am once again asking to more in-depth review this PR and try it locally before merging.

In addition, once again tagging @myypo for the final time in this series for some additional feedback now that the config is actually in use.