### PR TITLE
chore(workflows/build): windows: install llvm for clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Install dependencies
-        run: choco install protoc
+        run: choco install protoc && choco install llvm --version=18.1.2
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
This PR tries fixing the recent windows CI builds failing by explicitly installing llvm (using the version that rust also installs).

I do not know enough about the windows build system to know if this is the correct fix or what has changed to lead to the failures.

Currently the Windows CI is failing with:
```txt
error: failed to run custom build command for `soundtouch-ffi v0.2.0`

Caused by:
  process didn't exit successfully: `D:\a\termusic\termusic\target\debug\build\soundtouch-ffi-92939d6b2fb188a5\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64-pc-windows-msvc
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_msvc
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS

  --- stderr
  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h:898:1: error: static assertion failed: error STL1000: Unexpected compiler version, expected Clang 17.0.0 or newer.
  thread 'main' panicked at C:\Users\runneradmin/.cargo\registry\src\index.crates.io-6f17d22bba15001f\soundtouch-ffi-0.2.0\build.rs:126:48:
  Unable to generate bindings: ClangDiagnostic("C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.40.33807\\include\\yvals_core.h:898:1: error: static assertion failed: error STL1000: Unexpected compiler version, expected Clang 17.0.0 or newer.\n")
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

downside of this change being that the CI build times for windows are now quite a lot longer (install dependencies previously was ~41s, now ~1m43s)