### PR TITLE
More `lib::playlist` refactoring

### DIFF
--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -3,19 +3,21 @@ use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 
+use super::PlaylistValue;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ASXItem {
     /// According to the spec, a `entry` SHOULD contain exactly one `title` (all after the first are ignored)
     pub title: String,
     /// According to the spec, a `entry` SHOULD contain exactly one `ref` (all after the first are ignored for our purposes)
-    pub url: String,
+    pub location: PlaylistValue,
 }
 
 /// A temporary storage to build a [`ASXItem`] while still being in a element and not having all values
 #[derive(Debug, Clone, PartialEq, Default)]
 struct PrivateItem {
     pub title: Option<String>,
-    pub ref_href: Option<String>,
+    pub ref_href: Option<PlaylistValue>,
 }
 
 impl PrivateItem {
@@ -25,7 +27,7 @@ impl PrivateItem {
             return Some(ASXItem {
                 // SAFETY: unwrap is safe here because it is checked by `check_required_values` to be `Some`
                 title: self.title.take().unwrap(),
-                url: self.ref_href.take().unwrap(),
+                location: self.ref_href.take().unwrap(),
             });
         }
 
@@ -79,7 +81,9 @@ pub fn decode(content: &str) -> Result<Vec<ASXItem>> {
                     let key = decoder.decode(a.key.as_ref())?.to_lowercase();
                     let value = decoder.decode(&a.value)?;
                     if path == "asx/entry/ref" && key == "href" && item.ref_href.is_none() {
-                        item.ref_href.replace(value.to_string());
+                        let mut p_value = PlaylistValue::try_from_str(&value)?;
+                        p_value.file_url_to_path()?;
+                        item.ref_href.replace(p_value);
                     }
                 }
 
@@ -94,7 +98,9 @@ pub fn decode(content: &str) -> Result<Vec<ASXItem>> {
                     let key = decoder.decode(a.key.as_ref())?.to_lowercase();
                     let value = decoder.decode(&a.value)?;
                     if path == "asx/entry/ref" && key == "href" && item.ref_href.is_none() {
-                        item.ref_href.replace(value.to_string());
+                        let mut p_value = PlaylistValue::try_from_str(&value)?;
+                        p_value.file_url_to_path()?;
+                        item.ref_href.replace(p_value);
                     }
                 }
             }
@@ -131,6 +137,8 @@ pub fn decode(content: &str) -> Result<Vec<ASXItem>> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -151,9 +159,15 @@ mod tests {
         assert!(items.is_ok());
         let items = items.unwrap();
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].url, "ref1");
+        assert_eq!(
+            items[0].location,
+            PlaylistValue::Path(PathBuf::from("ref1"))
+        );
         assert_eq!(items[0].title, "title1");
-        assert_eq!(items[1].url, "ref2");
+        assert_eq!(
+            items[1].location,
+            PlaylistValue::Path(PathBuf::from("ref2"))
+        );
         assert_eq!(items[1].title, "title2");
     }
 

--- a/lib/src/playlist/asx.rs
+++ b/lib/src/playlist/asx.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use std::error::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ASXItem {
@@ -58,7 +58,7 @@ impl PrivateItem {
 ///
 /// <https://en.wikipedia.org/wiki/Advanced_Stream_Redirector>
 /// <https://learn.microsoft.com/en-us/windows/win32/wmp/asx-element>
-pub fn decode(content: &str) -> Result<Vec<ASXItem>, Box<dyn Error>> {
+pub fn decode(content: &str) -> Result<Vec<ASXItem>> {
     let mut list: Vec<ASXItem> = vec![];
     let mut item = PrivateItem::default();
 

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -43,25 +43,29 @@ pub fn decode(content: &str) -> Result<Vec<String>> {
     let content_small = content.to_lowercase();
 
     if content_small.contains("<playlist") {
-        let xspf_items = xspf::decode(content)?;
-        for item in xspf_items {
+        let items = xspf::decode(content)?;
+        set.reserve(items.len());
+        for item in items {
             if !item.url.is_empty() {
                 set.push(item.url);
             }
         }
     } else if content_small.contains("<asx") {
-        let pls_items = asx::decode(content)?;
-        for item in pls_items {
+        let items = asx::decode(content)?;
+        set.reserve(items.len());
+        for item in items {
             set.push(item.url);
         }
     } else if content_small.contains("[playlist]") {
-        let pls_items = pls::decode(content);
-        for item in pls_items {
+        let items = pls::decode(content);
+        set.reserve(items.len());
+        for item in items {
             set.push(item.url);
         }
     } else {
-        let m3u_items = m3u::decode(content);
-        for item in m3u_items {
+        let items = m3u::decode(content);
+        set.reserve(items.len());
+        for item in items {
             set.push(item.url);
         }
     }

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -7,7 +7,7 @@ mod m3u;
 mod pls;
 mod xspf;
 
-use std::error::Error;
+use anyhow::Result;
 
 /// Decode playlist content string. It checks for M3U, PLS, XSPF and ASX content in the string.
 ///
@@ -38,7 +38,7 @@ use std::error::Error;
 ///     println!("{:?}", item);
 /// }
 /// ```
-pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
+pub fn decode(content: &str) -> Result<Vec<String>> {
     let mut set: Vec<String> = vec![];
     let content_small = content.to_lowercase();
 
@@ -47,9 +47,6 @@ pub fn decode(content: &str) -> Result<Vec<String>, Box<dyn Error>> {
         for item in xspf_items {
             if !item.url.is_empty() {
                 set.push(item.url);
-            }
-            if let Some(identifier) = item.identifier {
-                set.push(identifier);
             }
         }
     } else if content_small.contains("<asx") {
@@ -90,10 +87,8 @@ mod tests {
             </trackList>
         </playlist>"#;
         let items = decode(s).unwrap();
-        assert_eq!(items.len(), 2);
+        assert_eq!(items.len(), 1);
         assert_eq!(items[0], "http://this.is.an.example");
-        // this is weird
-        assert_eq!(items[1], "Identifier");
     }
 
     #[test]

--- a/lib/src/playlist/xspf.rs
+++ b/lib/src/playlist/xspf.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use std::error::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct XSPFItem {
@@ -47,7 +47,7 @@ impl PrivateItem {
 /// XSPF or "XML Shareable Playlist Format", based on XML (as the name implies).
 ///
 /// <https://www.xspf.org/spec>
-pub fn decode(content: &str) -> Result<Vec<XSPFItem>, Box<dyn Error>> {
+pub fn decode(content: &str) -> Result<Vec<XSPFItem>> {
     let mut list: Vec<XSPFItem> = vec![];
     let mut current_item = PrivateItem::default();
 

--- a/lib/src/sqlite.rs
+++ b/lib/src/sqlite.rs
@@ -58,6 +58,8 @@ pub struct TrackForDB {
 pub enum SearchCriteria {
     Artist,
     Album,
+
+    // TODO: the values below are current unused
     Genre,
     Directory,
     Playlist,
@@ -70,8 +72,7 @@ impl From<usize> for SearchCriteria {
             2 => Self::Genre,
             3 => Self::Directory,
             4 => Self::Playlist,
-            _ => Self::Artist,
-            // 0 | _ => Self::Artist,
+            /* 0 | */ _ => Self::Artist,
         }
     }
 }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -117,37 +117,18 @@ pub fn create_podcast_dir(config: &Settings, pod_title: String) -> Result<PathBu
 
 pub fn playlist_get_vec(current_node: &str) -> Result<Vec<String>> {
     let p = Path::new(current_node);
-    let p_base = p.parent().ok_or_else(|| anyhow!("cannot find path root"))?;
+    let p_base = absolute_path(p.parent().ok_or_else(|| anyhow!("cannot find path root"))?)?;
     let str = std::fs::read_to_string(p)?;
     let items =
         crate::playlist::decode(&str).map_err(|e| anyhow!("playlist decode error: {}", e))?;
     let mut vec = vec![];
-    for item in items {
-        if let Ok(pathbuf) = playlist_get_absolute_pathbuf(&item, p_base) {
-            vec.push(pathbuf.to_string_lossy().to_string());
-        }
+    for mut item in items {
+        item.absoluteize(&p_base);
+
+        // TODO: refactor to return better values
+        vec.push(item.to_string());
     }
     Ok(vec)
-}
-
-fn playlist_get_absolute_pathbuf(item: &str, p_base: &Path) -> Result<PathBuf> {
-    let mut url = urlencoding::decode(item)?.into_owned();
-    if url.starts_with("http") {
-        return Ok(PathBuf::from(url));
-        // bail!("http not supported");
-    }
-    if url.starts_with("file") {
-        url = url.replace("file://", "");
-    }
-    let pathbuf = if Path::new(&url).is_relative() {
-        let mut pathbuf = PathBuf::from(p_base);
-        pathbuf.push(url);
-
-        pathbuf
-    } else {
-        PathBuf::from(url)
-    };
-    Ok(pathbuf)
 }
 
 /// Some helper functions for dealing with Unicode strings.
@@ -213,6 +194,25 @@ pub fn absolute_path(path: &Path) -> std::io::Result<Cow<'_, Path>> {
         Ok(Cow::Borrowed(path))
     } else {
         Ok(Cow::Owned(std::env::current_dir()?.join(path)))
+    }
+}
+
+/// Absolutize a given path with the given base.
+///
+/// `base` is expected to be absoulte!
+///
+/// This function, unlike [`std::fs::canonicalize`] does *not* hit the filesystem and so does not require the input path to exist yet.
+///
+/// Examples:
+/// `./somewhere` -> `/absolute/./somewhere`
+/// `.\somewhere` -> `C:\somewhere`
+///
+/// in the future consider replacing with [`std::path::absolute`] once stable
+pub fn absolute_path_base<'a>(path: &'a Path, base: &Path) -> Cow<'a, Path> {
+    if path.is_absolute() {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(base.join(path))
     }
 }
 


### PR DESCRIPTION
Continuation of #330, changes:
- (unrelated) add some comments to `lib::sqlite`
- replace the manual `Result<_, Box<dyn Error>>` with `anyhow::Result`
- reserve the length of the returned vector in the new vector
- directly parse into `PathBuf` and `Url` instead of using one `String` type
- ^ also be more robust in conversion
- fix to not include the identifier in `xspf` output anymore (why was it there?)