### PR TITLE
Fix new Rust 1.79 warnings

### DIFF
--- a/playback/src/rusty_backend/conversions/sample.rs
+++ b/playback/src/rusty_backend/conversions/sample.rs
@@ -61,9 +61,9 @@ where
 /// This trait is implemented by default on three types: `i16`, `u16` and `f32`.
 ///
 /// - For `i16`, silence corresponds to the value `0`. The minimum and maximum amplitudes are
-///   represented by `i16::min_value()` and `i16::max_value()` respectively.
-/// - For `u16`, silence corresponds to the value `u16::max_value() / 2`. The minimum and maximum
-///   amplitudes are represented by `0` and `u16::max_value()` respectively.
+///   represented by `i16::min_value()` and `i16::MAX` respectively.
+/// - For `u16`, silence corresponds to the value `u16::MAX / 2`. The minimum and maximum
+///   amplitudes are represented by `0` and `u16::MAX` respectively.
 /// - For `f32`, silence corresponds to the value `0.0`. The minimum and maximum amplitudes are
 ///  represented by `-1.0` and `1.0` respectively.
 ///

--- a/playback/src/rusty_backend/stream.rs
+++ b/playback/src/rusty_backend/stream.rs
@@ -277,9 +277,7 @@ impl CpalDeviceExt for cpal::Device {
                 &format.config(),
                 move |data, _| {
                     for d in data.iter_mut() {
-                        *d = mixer_rx
-                            .next()
-                            .map_or(u8::max_value() / 2, Sample::from_sample);
+                        *d = mixer_rx.next().map_or(u8::MAX / 2, Sample::from_sample);
                     }
                 },
                 error_callback,
@@ -289,9 +287,7 @@ impl CpalDeviceExt for cpal::Device {
                 &format.config(),
                 move |data, _| {
                     for d in data.iter_mut() {
-                        *d = mixer_rx
-                            .next()
-                            .map_or(u16::max_value() / 2, Sample::from_sample);
+                        *d = mixer_rx.next().map_or(u16::MAX / 2, Sample::from_sample);
                     }
                 },
                 error_callback,
@@ -301,9 +297,7 @@ impl CpalDeviceExt for cpal::Device {
                 &format.config(),
                 move |data, _| {
                     for d in data.iter_mut() {
-                        *d = mixer_rx
-                            .next()
-                            .map_or(u32::max_value() / 2, Sample::from_sample);
+                        *d = mixer_rx.next().map_or(u32::MAX / 2, Sample::from_sample);
                     }
                 },
                 error_callback,
@@ -313,9 +307,7 @@ impl CpalDeviceExt for cpal::Device {
                 &format.config(),
                 move |data, _| {
                     for d in data.iter_mut() {
-                        *d = mixer_rx
-                            .next()
-                            .map_or(u64::max_value() / 2, Sample::from_sample);
+                        *d = mixer_rx.next().map_or(u64::MAX / 2, Sample::from_sample);
                     }
                 },
                 error_callback,

--- a/tui/src/ui/model/download_tracker.rs
+++ b/tui/src/ui/model/download_tracker.rs
@@ -1,17 +1,17 @@
-use std::{collections::HashSet, time::Instant};
+use std::collections::HashSet;
 
 pub struct DownloadTracker {
     items: HashSet<String>,
-    pub time_stamp_for_cache: Instant,
+    // pub time_stamp_for_cache: Instant,
 }
 
 impl Default for DownloadTracker {
     fn default() -> Self {
         let items = HashSet::new();
-        let time_stamp_for_cache = Instant::now();
+        // let time_stamp_for_cache = Instant::now();
         Self {
             items,
-            time_stamp_for_cache,
+            // time_stamp_for_cache,
         }
     }
 }


### PR DESCRIPTION
This PR fixes the new warnings that pop-up in rust 1.79 (and error in the CI because of settings)