### PR TITLE
chore(workflows/build): windows: dont install llvm for clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
       - name: Install dependencies
-        run: choco install protoc && choco install llvm --version=18.1.2
+        run: choco install protoc
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Because something changed and chocolatey fails if a newer version is already there and does not allow setting version ranges.

excerpt:
```txt
By installing, you accept licenses for the packages.
A newer version of llvm (v18.1.6) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - llvm - A newer version of llvm (v18.1.6) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
```
[full log, likely gone in a few months](https://github.com/tramhao/termusic/actions/runs/9514627773/job/26227184965?pr=336)

PS: i still have no clue why that was a problem in the first place for a week