### PR TITLE
 chore(workflows/build): windows: dont install llvm for clang again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
-      - name: Install dependencies
-        run: choco install protoc && choco install llvm --version=18.1.2 --allow-downgrade 
 
+      - name: Install dependencies
+        run: choco install protoc
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
PR #337 again but with fixed merge conflicts, do we really want to downgrade if it is already available?

Sadly either installing and downgrading or not installing are the only options as chocolatey still does not support installing ranges, only exact versions.