### PR TITLE
feat: allow configuring coverart hidden via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Feat: Add new V2 Config Layout, old v1 config is automatically migrated to v2.
 - Feat(tui): allow Sixel to be used for covers.
 - Feat(tui): allow all cover providers to not be compiled in.
+- Feat(tui): allow disabling the coverart display in config (previously the only options were to not compile it in or disable via cli).
 - Fix: update the build scripts to check that the repository is actually the `termusic` repository before using the git version.
 - Fix: allow backends to be compiled in for `termusic-playback` but not in `termusic-server`.
 - Fix: on backend mpv, clear media-title on EndOfFile.

--- a/lib/src/config/tui_overlay.rs
+++ b/lib/src/config/tui_overlay.rs
@@ -7,6 +7,21 @@ pub struct TuiOverlay {
 
     /// Disable TUI images (like cover-art) from being displayed in the terminal
     ///
+    /// This option will not be saved to the config and prevent saving to the config value
+    ///
     /// (disables ueberzug, sixel, iterm, kitty image displaying)
-    pub disable_tui_images: bool,
+    pub coverart_hidden_overwrite: Option<bool>,
+}
+
+impl TuiOverlay {
+    /// Get whether the coverart should be hidden or not, either the overwrite if present, otherwise the config itself
+    ///
+    /// true => hidden
+    pub fn get_coverart_hidden(&self) -> bool {
+        if let Some(overwrite) = self.coverart_hidden_overwrite {
+            overwrite
+        } else {
+            self.settings.coverart.hidden
+        }
+    }
 }

--- a/lib/src/config/v2/tui/mod.rs
+++ b/lib/src/config/v2/tui/mod.rs
@@ -96,6 +96,8 @@ pub struct CoverArtPosition {
     pub align: Alignment,
     /// Scale of the image
     pub size_scale: i8,
+    /// Whether to show or hide the coverart if it is compiled in
+    pub hidden: bool,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq)]
@@ -133,6 +135,7 @@ mod v1_interop {
                 align: value.align.into(),
                 // the value is named "width", but more use like a scale on both axis
                 size_scale: value.width_between_1_100.clamp(0, i8::MAX as u32) as i8,
+                hidden: Self::default().hidden,
             }
         }
     }
@@ -176,7 +179,8 @@ mod v1_interop {
                 converted.coverart,
                 CoverArtPosition {
                     align: Alignment::BottomRight,
-                    size_scale: 20
+                    size_scale: 20,
+                    hidden: false
                 }
             );
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -255,9 +255,11 @@ fn get_config(args: &cli::Args) -> Result<CombinedSettings> {
 
     let config_tui = TuiConfigVersionedDefaulted::from_config_path()?.into_settings();
 
+    let coverart_hidden_overwrite = if args.disable_cover { Some(true) } else { None };
+
     let overlay_tui = TuiOverlay {
         settings: config_tui,
-        disable_tui_images: args.disable_cover,
+        coverart_hidden_overwrite,
     };
 
     Ok(CombinedSettings {

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -68,7 +68,15 @@ impl Model {
     pub fn xywh_toggle_hide(&mut self) {
         self.clear_photo().ok();
         let mut config_tui = self.config_tui.write();
-        config_tui.disable_tui_images = !config_tui.disable_tui_images;
+
+        // dont save value if cli has overwritten it, but still allow runtime changing
+        if let Some(current) = config_tui.coverart_hidden_overwrite {
+            config_tui.coverart_hidden_overwrite = Some(!current);
+            info!("Not saving coverart.hidden as it is overwritten by cli!");
+        } else {
+            config_tui.settings.coverart.hidden = !config_tui.settings.coverart.hidden;
+        }
+
         drop(config_tui);
         self.update_photo().ok();
     }
@@ -108,7 +116,7 @@ impl Model {
     /// Requires that the current thread has a entered runtime
     #[allow(clippy::cast_possible_truncation)]
     pub fn update_photo(&mut self) -> Result<()> {
-        if self.config_tui.read().disable_tui_images {
+        if self.config_tui.read().get_coverart_hidden() {
             return Ok(());
         }
         self.clear_photo()?;


### PR DESCRIPTION
previously it could only be configured via compile options(features) or cli argument.

Known issues:
- changing the hidden status via keybindings does not save the config to disk as the only time the tui config is saves is when using the config editor