### PR TITLE
Fix v1 to v2 volume key translation

### DIFF
--- a/lib/src/config/v1/key.rs
+++ b/lib/src/config/v1/key.rs
@@ -619,11 +619,11 @@ impl Default for Keys {
                 modifier: KeyModifiers::NONE,
             },
             global_player_volume_minus_1: BindingForEvent {
-                code: Key::Char('_'),
+                code: Key::Char('-'),
                 modifier: KeyModifiers::SHIFT,
             },
             global_player_volume_minus_2: BindingForEvent {
-                code: Key::Char('-'),
+                code: Key::Char('_'),
                 modifier: KeyModifiers::NONE,
             },
             global_help: BindingForEvent {

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -2018,7 +2018,7 @@ mod v1_interop {
                 )
                 .into(),
                 volume_down: tuievents::KeyEvent::new(
-                    tuievents::Key::Char('_'),
+                    tuievents::Key::Char('-'),
                     tuievents::KeyModifiers::SHIFT,
                 )
                 .into(),

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1890,8 +1890,8 @@ mod v1_interop {
                     toggle_pause: value.global_player_toggle_pause.into(),
                     next_track: value.global_player_next.into(),
                     previous_track: value.global_player_previous.into(),
-                    volume_up: value.global_player_volume_plus_1.into(),
-                    volume_down: value.global_player_volume_minus_1.into(),
+                    volume_up: value.global_player_volume_plus_2.into(),
+                    volume_down: value.global_player_volume_minus_2.into(),
                     seek_forward: value.global_player_seek_forward.into(),
                     seek_backward: value.global_player_seek_backward.into(),
                     speed_up: value.global_player_speed_up.into(),
@@ -2013,13 +2013,13 @@ mod v1_interop {
                 .into(),
                 // volume_up and volume_down have different default key-bindings in v2
                 volume_up: tuievents::KeyEvent::new(
-                    tuievents::Key::Char('+'),
-                    tuievents::KeyModifiers::SHIFT,
+                    tuievents::Key::Char('='),
+                    tuievents::KeyModifiers::NONE,
                 )
                 .into(),
                 volume_down: tuievents::KeyEvent::new(
-                    tuievents::Key::Char('-'),
-                    tuievents::KeyModifiers::SHIFT,
+                    tuievents::Key::Char('_'),
+                    tuievents::KeyModifiers::NONE,
                 )
                 .into(),
                 seek_forward: tuievents::Key::Char('f').into(),

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1868,6 +1868,21 @@ mod v1_interop {
                 value.podcast_episode_delete_file.into()
             };
 
+            // fixup the old broken way where volume down 1 was by default set to "shift+_", which actually never fires and only fires "_"
+            let player_volume_down_key = {
+                let old = value.global_player_volume_minus_2;
+                if old.code == tuievents::Key::Char('_')
+                    && old.modifier.intersects(tuievents::KeyModifiers::SHIFT)
+                {
+                    KeyBinding::from(tuievents::KeyEvent::new(
+                        tuievents::Key::Char('_'),
+                        tuievents::KeyModifiers::NONE,
+                    ))
+                } else {
+                    old.into()
+                }
+            };
+
             Self {
                 escape: value.global_esc.into(),
                 quit: value.global_quit.into(),
@@ -1891,7 +1906,7 @@ mod v1_interop {
                     next_track: value.global_player_next.into(),
                     previous_track: value.global_player_previous.into(),
                     volume_up: value.global_player_volume_plus_2.into(),
-                    volume_down: value.global_player_volume_minus_2.into(),
+                    volume_down: player_volume_down_key,
                     seek_forward: value.global_player_seek_forward.into(),
                     seek_backward: value.global_player_seek_backward.into(),
                     speed_up: value.global_player_speed_up.into(),

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1868,6 +1868,7 @@ mod v1_interop {
                 value.podcast_episode_delete_file.into()
             };
 
+            // this only really applies to volume_down_1 had "_+SHIFT", but now volume_down_2 is actually used instead
             // fixup the old broken way where volume down 1 was by default set to "shift+_", which actually never fires and only fires "_"
             let player_volume_down_key = {
                 let old = value.global_player_volume_minus_2;
@@ -1981,6 +1982,7 @@ mod v1_interop {
     mod test {
         use super::*;
         use pretty_assertions::assert_eq;
+        use v1::BindingForEvent;
 
         #[test]
         fn should_convert_default_without_error() {
@@ -2239,6 +2241,63 @@ mod v1_interop {
             assert_eq!(converted, expected_keys);
 
             assert_eq!(Ok(()), expected_keys.check_keys());
+        }
+
+        #[test]
+        fn should_fixup_old_volume_default() {
+            let converted: Keys = {
+                let mut v1 = v1::Keys::default();
+                v1.global_player_volume_minus_2 = BindingForEvent {
+                    code: tuievents::Key::Char('_'),
+                    modifier: tuievents::KeyModifiers::SHIFT,
+                };
+
+                v1.into()
+            };
+
+            let expected_player_keys = KeysPlayer {
+                toggle_pause: tuievents::Key::Char(' ').into(),
+                next_track: tuievents::Key::Char('n').into(),
+                previous_track: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('N'),
+                    tuievents::KeyModifiers::SHIFT,
+                )
+                .into(),
+                // volume_up and volume_down have different default key-bindings in v2
+                volume_up: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('='),
+                    tuievents::KeyModifiers::NONE,
+                )
+                .into(),
+                volume_down: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('_'),
+                    tuievents::KeyModifiers::NONE,
+                )
+                .into(),
+                seek_forward: tuievents::Key::Char('f').into(),
+                seek_backward: tuievents::Key::Char('b').into(),
+                speed_up: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('f'),
+                    tuievents::KeyModifiers::CONTROL,
+                )
+                .into(),
+                speed_down: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('b'),
+                    tuievents::KeyModifiers::CONTROL,
+                )
+                .into(),
+                toggle_prefetch: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('g'),
+                    tuievents::KeyModifiers::CONTROL,
+                )
+                .into(),
+                save_playlist: tuievents::KeyEvent::new(
+                    tuievents::Key::Char('s'),
+                    tuievents::KeyModifiers::CONTROL,
+                )
+                .into(),
+            };
+            assert_eq!(converted.player_keys, expected_player_keys);
         }
     }
 }


### PR DESCRIPTION
This PR changes the transition value from `volume_*_1` to `volume_*_2` as the `1` values were broken as those never actually fired in tuirealm (example `SHIFT++` never actually exists and only `NONE+_` is fired).
In addition i reversed the `volume_down` keys in v1 to be consistent with the `volume_up` keys because otherwise it was `SHIFT+_` which is also never fired.

PS: the default value for volume up / volume down (without transition from v1) in v2 is `+` / `-` (no modifiers)