### PR TITLE
Change Footer layout to be consistent

### DIFF
--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -79,11 +79,11 @@ impl Component<Msg, NoUserEvent> for CEHeader {
 }
 
 #[derive(MockComponent)]
-pub struct Footer {
+pub struct CEFooter {
     component: Span,
 }
 
-impl Footer {
+impl CEFooter {
     pub fn new(config: &TuiOverlay) -> Self {
         Self {
             component: Span::default().spans(&[
@@ -112,7 +112,7 @@ impl Footer {
     }
 }
 
-impl Component<Msg, NoUserEvent> for Footer {
+impl Component<Msg, NoUserEvent> for CEFooter {
     fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
         None
     }

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -87,26 +87,26 @@ impl Footer {
     pub fn new(config: &TuiOverlay) -> Self {
         Self {
             component: Span::default().spans(&[
+                TextSpan::new(" Save parameters: ").bold(),
                 TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
                     .bold()
                     .fg(config.settings.theme.library_highlight()),
-                TextSpan::new(" Save parameters ").bold(),
+                TextSpan::new(" Exit: ").bold(),
                 TextSpan::new(format!("<{}>", config.settings.keys.escape))
                     .bold()
                     .fg(config.settings.theme.library_highlight()),
-                TextSpan::new(" Exit ").bold(),
+                TextSpan::new(" Change panel: ").bold(),
                 TextSpan::new("<TAB>")
                     .bold()
                     .fg(config.settings.theme.library_highlight()),
-                TextSpan::new(" Change panel ").bold(),
+                TextSpan::new(" Change field: ").bold(),
                 TextSpan::new("<UP/DOWN>")
                     .bold()
                     .fg(config.settings.theme.library_highlight()),
-                TextSpan::new(" Change field ").bold(),
+                TextSpan::new(" Select theme/Preview symbol: ").bold(),
                 TextSpan::new("<ENTER>")
                     .bold()
                     .fg(config.settings.theme.library_highlight()),
-                TextSpan::new(" Select theme/Preview symbol ").bold(),
             ]),
         }
     }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,5 +1,5 @@
 use crate::ui::components::{
-    AlbumPhotoAlign, CEHeader, CEThemeSelectTable, ConfigCurrentlyPlayingTrackSymbol,
+    AlbumPhotoAlign, CEFooter, CEHeader, CEThemeSelectTable, ConfigCurrentlyPlayingTrackSymbol,
     ConfigDatabaseAddAll, ConfigDatabaseAddSelected, ConfigFallbackBackground,
     ConfigFallbackBorder, ConfigFallbackForeground, ConfigFallbackHighlight, ConfigFallbackTitle,
     ConfigGlobalConfig, ConfigGlobalDown, ConfigGlobalGotoBottom, ConfigGlobalGotoTop,
@@ -28,7 +28,7 @@ use crate::ui::components::{
     ConfigPodcastMarkAllPlayed, ConfigPodcastMarkPlayed, ConfigPodcastRefreshAllFeeds,
     ConfigPodcastRefreshFeed, ConfigPodcastSearchAddFeed, ConfigProgressBackground,
     ConfigProgressBorder, ConfigProgressForeground, ConfigProgressTitle, ConfigSavePopup,
-    ConfigSeekStep, ExitConfirmation, CEFooter, GlobalListener, KillDaemon, MusicDir, PlayerPort,
+    ConfigSeekStep, ExitConfirmation, GlobalListener, KillDaemon, MusicDir, PlayerPort,
     PlayerUseDiscord, PlayerUseMpris, PlaylistDisplaySymbol, PlaylistRandomAlbum,
     PlaylistRandomTrack, PodcastDir, PodcastMaxRetries, PodcastSimulDownload, SaveLastPosition,
 };

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -28,7 +28,7 @@ use crate::ui::components::{
     ConfigPodcastMarkAllPlayed, ConfigPodcastMarkPlayed, ConfigPodcastRefreshAllFeeds,
     ConfigPodcastRefreshFeed, ConfigPodcastSearchAddFeed, ConfigProgressBackground,
     ConfigProgressBorder, ConfigProgressForeground, ConfigProgressTitle, ConfigSavePopup,
-    ConfigSeekStep, ExitConfirmation, Footer, GlobalListener, KillDaemon, MusicDir, PlayerPort,
+    ConfigSeekStep, ExitConfirmation, CEFooter, GlobalListener, KillDaemon, MusicDir, PlayerPort,
     PlayerUseDiscord, PlayerUseMpris, PlaylistDisplaySymbol, PlaylistRandomAlbum,
     PlaylistRandomTrack, PodcastDir, PodcastMaxRetries, PodcastSimulDownload, SaveLastPosition,
 };
@@ -1749,7 +1749,7 @@ impl Model {
             .app
             .remount(
                 Id::ConfigEditor(IdConfigEditor::Footer),
-                Box::new(Footer::new(&self.config_tui.read())),
+                Box::new(CEFooter::new(&self.config_tui.read())),
                 vec![]
             )
             .is_ok());

--- a/tui/src/ui/components/footer.rs
+++ b/tui/src/ui/components/footer.rs
@@ -1,0 +1,79 @@
+use termusiclib::{config::TuiOverlay, types::Msg};
+use tuirealm::{props::TextSpan, Component, Event, MockComponent, NoUserEvent};
+
+use crate::ui::components::LabelSpan;
+
+#[derive(MockComponent)]
+pub struct Footer {
+    component: LabelSpan,
+}
+
+impl Footer {
+    pub fn new(config: &TuiOverlay) -> Self {
+        Self {
+            component: (LabelSpan::new(
+                config,
+                &[
+                    TextSpan::new(" Help: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.select_view_keys.open_help
+                    ))
+                    .fg(config.settings.theme.fallback_highlight())
+                    .bold(),
+                    TextSpan::new(" Config: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.select_view_keys.open_config
+                    ))
+                    .fg(config.settings.theme.fallback_highlight())
+                    .bold(),
+                    TextSpan::new(" Library: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.select_view_keys.view_library
+                    ))
+                    .fg(config.settings.theme.fallback_highlight())
+                    .bold(),
+                    TextSpan::new(" Database: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.select_view_keys.view_database
+                    ))
+                    .fg(config.settings.theme.fallback_highlight())
+                    .bold(),
+                    TextSpan::new(" Podcasts: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.select_view_keys.view_podcasts
+                    ))
+                    .fg(config.settings.theme.fallback_highlight())
+                    .bold(),
+                    TextSpan::new(" Version: ")
+                        .fg(config.settings.theme.fallback_foreground())
+                        .bold(),
+                    // maybe consider moving version into Help or Config or its own popup (like a About)
+                    TextSpan::new(env!("TERMUSIC_VERSION"))
+                        .fg(config.settings.theme.fallback_highlight())
+                        .bold(),
+                ],
+            )),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for Footer {
+    fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
+        None
+    }
+}

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -24,6 +24,7 @@
 // -- modules
 mod config_editor;
 mod database;
+mod footer;
 mod labels;
 mod lyric;
 mod music_library;
@@ -44,6 +45,7 @@ mod xywh;
 // -- export
 pub use config_editor::*;
 pub use database::{DBListCriteria, DBListSearchResult, DBListSearchTracks};
+pub use footer::Footer;
 pub use labels::{DownloadSpinner, LabelGeneric, LabelSpan};
 pub use lyric::Lyric;
 pub use music_library::MusicLibrary;

--- a/tui/src/ui/components/tag_editor/mod.rs
+++ b/tui/src/ui/components/tag_editor/mod.rs
@@ -24,6 +24,7 @@
 
 /// -- modules
 mod te_counter_delete_lyric;
+mod te_footer;
 mod te_input;
 mod te_select_lyric;
 mod te_table_lyric_options;

--- a/tui/src/ui/components/tag_editor/te_footer.rs
+++ b/tui/src/ui/components/tag_editor/te_footer.rs
@@ -1,0 +1,51 @@
+use termusiclib::{config::TuiOverlay, types::Msg};
+use tuirealm::{props::TextSpan, Component, Event, MockComponent, NoUserEvent};
+
+use crate::ui::components::LabelSpan;
+
+#[derive(MockComponent)]
+pub struct TEFooter {
+    component: LabelSpan,
+}
+
+impl TEFooter {
+    pub fn new(config: &TuiOverlay) -> Self {
+        Self {
+            component: (LabelSpan::new(
+                config,
+                &[
+                    TextSpan::new(" Save tag: ").fg(config.settings.theme.library_foreground()),
+                    TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
+                        .bold()
+                        .fg(config.settings.theme.library_highlight()),
+                    TextSpan::new(" Exit: ").fg(config.settings.theme.library_foreground()),
+                    TextSpan::new(format!("<{}>", config.settings.keys.escape))
+                        .bold()
+                        .fg(config.settings.theme.library_highlight()),
+                    TextSpan::new(" Change field: ").fg(config.settings.theme.library_foreground()),
+                    TextSpan::new("<Tab/ShiftTab>")
+                        .bold()
+                        .fg(config.settings.theme.library_highlight()),
+                    TextSpan::new(" Search/Embed tag: ")
+                        .fg(config.settings.theme.library_foreground()),
+                    TextSpan::new("<ENTER>")
+                        .bold()
+                        .fg(config.settings.theme.library_highlight()),
+                    TextSpan::new(" Download: ").fg(config.settings.theme.library_foreground()),
+                    TextSpan::new(format!(
+                        "<{}>",
+                        config.settings.keys.library_keys.youtube_search
+                    ))
+                    .bold()
+                    .fg(config.settings.theme.library_highlight()),
+                ],
+            )),
+        }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for TEFooter {
+    fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
+        None
+    }
+}

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -470,31 +470,31 @@ impl Model {
                 Box::new(LabelSpan::new(
                     &config,
                     &[
+                        TextSpan::new(" Save tag: ").fg(config.settings.theme.library_foreground()),
                         TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
                             .bold()
                             .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Save tag ").fg(config.settings.theme.library_foreground()),
+                        TextSpan::new(" Exit: ").fg(config.settings.theme.library_foreground()),
                         TextSpan::new(format!("<{}>", config.settings.keys.escape))
                             .bold()
                             .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Exit ").fg(config.settings.theme.library_foreground()),
+                        TextSpan::new(" Change field: ")
+                            .fg(config.settings.theme.library_foreground()),
                         TextSpan::new("<Tab/ShiftTab>")
                             .bold()
                             .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Change field ")
+                        TextSpan::new(" Search/Embed tag: ")
                             .fg(config.settings.theme.library_foreground()),
                         TextSpan::new("<ENTER>")
                             .bold()
                             .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Search/Embed tag ")
-                            .fg(config.settings.theme.library_foreground()),
+                        TextSpan::new(" Download: ").fg(config.settings.theme.library_foreground()),
                         TextSpan::new(format!(
                             "<{}>",
                             config.settings.keys.library_keys.youtube_search
                         ))
                         .bold()
                         .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" download ").fg(config.settings.theme.library_foreground()),
                     ]
                 )),
                 Vec::default(),

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -1,3 +1,4 @@
+use crate::ui::components::tag_editor::te_footer::TEFooter;
 /**
  * MIT License
  *
@@ -22,8 +23,8 @@
  * SOFTWARE.
  */
 use crate::ui::components::{
-    LabelGeneric, LabelSpan, TECounterDelete, TEInputAlbum, TEInputArtist, TEInputGenre,
-    TEInputTitle, TESelectLyric, TETableLyricOptions, TETextareaLyric,
+    LabelGeneric, TECounterDelete, TEInputAlbum, TEInputArtist, TEInputGenre, TEInputTitle,
+    TESelectLyric, TETableLyricOptions, TETextareaLyric,
 };
 use crate::ui::model::Model;
 use crate::ui::utils::{draw_area_in_absolute, draw_area_top_right_absolute};
@@ -181,7 +182,14 @@ impl Model {
         let p = p.to_string_lossy();
         match Track::read_from_path(p.as_ref(), false) {
             Ok(s) => {
-                self.remount_tag_editor_label_help();
+                assert!(self
+                    .app
+                    .remount(
+                        Id::Label,
+                        Box::new(TEFooter::new(&self.config_tui.read())),
+                        Vec::default(),
+                    )
+                    .is_ok());
                 assert!(self
                     .app
                     .remount(
@@ -457,47 +465,6 @@ impl Model {
                 AttrValue::Payload(PropPayload::Vec(vec![PropValue::TextSpan(TextSpan::from(
                     "No Lyrics."
                 )),]))
-            )
-            .is_ok());
-    }
-
-    pub fn remount_tag_editor_label_help(&mut self) {
-        let config = self.config_tui.read();
-        assert!(self
-            .app
-            .remount(
-                Id::Label,
-                Box::new(LabelSpan::new(
-                    &config,
-                    &[
-                        TextSpan::new(" Save tag: ").fg(config.settings.theme.library_foreground()),
-                        TextSpan::new(format!("<{}>", config.settings.keys.config_keys.save))
-                            .bold()
-                            .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Exit: ").fg(config.settings.theme.library_foreground()),
-                        TextSpan::new(format!("<{}>", config.settings.keys.escape))
-                            .bold()
-                            .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Change field: ")
-                            .fg(config.settings.theme.library_foreground()),
-                        TextSpan::new("<Tab/ShiftTab>")
-                            .bold()
-                            .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Search/Embed tag: ")
-                            .fg(config.settings.theme.library_foreground()),
-                        TextSpan::new("<ENTER>")
-                            .bold()
-                            .fg(config.settings.theme.library_highlight()),
-                        TextSpan::new(" Download: ").fg(config.settings.theme.library_foreground()),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.library_keys.youtube_search
-                        ))
-                        .bold()
-                        .fg(config.settings.theme.library_highlight()),
-                    ]
-                )),
-                Vec::default(),
             )
             .is_ok());
     }

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -172,113 +172,116 @@ impl Model {
             .expect("Expected to draw without error");
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn mount_tageditor(&mut self, node_id: &str) {
-        let p: &Path = Path::new(node_id);
-        if p.is_dir() {
-            self.mount_error_popup(anyhow::anyhow!("{p:?} directory doesn't have tag!"));
+        let node_path: &Path = Path::new(node_id);
+        if node_path.is_dir() {
+            self.mount_error_popup(anyhow::anyhow!("{node_path:?} directory doesn't have tag!"));
             return;
         }
 
-        let p = p.to_string_lossy();
-        match Track::read_from_path(p.as_ref(), false) {
-            Ok(s) => {
-                assert!(self
-                    .app
-                    .remount(
-                        Id::Label,
-                        Box::new(TEFooter::new(&self.config_tui.read())),
-                        Vec::default(),
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::LabelHint),
-                        Box::new(LabelGeneric::new(
-                            &self.config_tui.read(),
-                            "Press <ENTER> to search:"
-                        )),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::InputArtist),
-                        Box::new(TEInputArtist::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::InputTitle),
-                        Box::new(TEInputTitle::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::InputAlbum),
-                        Box::new(TEInputAlbum::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::InputGenre),
-                        Box::new(TEInputGenre::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::TableLyricOptions),
-                        Box::new(TETableLyricOptions::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::SelectLyric),
-                        Box::new(TESelectLyric::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::CounterDelete),
-                        Box::new(TECounterDelete::new(5, self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-                assert!(self
-                    .app
-                    .remount(
-                        Id::TagEditor(IdTagEditor::TextareaLyric),
-                        Box::new(TETextareaLyric::new(self.config_tui.clone())),
-                        vec![]
-                    )
-                    .is_ok());
-
-                self.app
-                    .active(&Id::TagEditor(IdTagEditor::InputArtist))
-                    .ok();
-                self.init_by_song(&s);
-            }
-            Err(e) => {
-                self.mount_error_popup(e.context("track parse"));
+        let track = match Track::read_from_path(node_path, false) {
+            Ok(v) => v,
+            Err(err) => {
+                self.mount_error_popup(err.context("track parse"));
+                return;
             }
         };
-        if let Err(e) = self.update_photo() {
-            self.mount_error_popup(e.context("update_photo"));
+
+        assert!(self
+            .app
+            .remount(
+                Id::Label,
+                Box::new(TEFooter::new(&self.config_tui.read())),
+                Vec::default(),
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::LabelHint),
+                Box::new(LabelGeneric::new(
+                    &self.config_tui.read(),
+                    "Press <ENTER> to search:"
+                )),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::InputArtist),
+                Box::new(TEInputArtist::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::InputTitle),
+                Box::new(TEInputTitle::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::InputAlbum),
+                Box::new(TEInputAlbum::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::InputGenre),
+                Box::new(TEInputGenre::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::TableLyricOptions),
+                Box::new(TETableLyricOptions::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::SelectLyric),
+                Box::new(TESelectLyric::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::CounterDelete),
+                Box::new(TECounterDelete::new(5, self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+        assert!(self
+            .app
+            .remount(
+                Id::TagEditor(IdTagEditor::TextareaLyric),
+                Box::new(TETextareaLyric::new(self.config_tui.clone())),
+                Vec::new()
+            )
+            .is_ok());
+
+        self.app
+            .active(&Id::TagEditor(IdTagEditor::InputArtist))
+            .ok();
+        self.init_by_song(&track);
+
+        if let Err(err) = self.update_photo() {
+            self.mount_error_popup(err.context("update_photo"));
         }
     }
+
     pub fn umount_tageditor(&mut self) {
         self.mount_label_help();
         self.app.umount(&Id::TagEditor(IdTagEditor::LabelHint)).ok();

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -1,6 +1,6 @@
 use crate::ui::components::{
     DBListCriteria, DBListSearchResult, DBListSearchTracks, DownloadSpinner, EpisodeList,
-    FeedsList, GSInputPopup, GSTablePopup, GlobalListener, LabelSpan, Lyric, MusicLibrary,
+    FeedsList, Footer, GSInputPopup, GSTablePopup, GlobalListener, LabelSpan, Lyric, MusicLibrary,
     Playlist, Progress, Source,
 };
 use crate::ui::model::{ConfigEditorLayout, Model, TermusicLayout};
@@ -566,67 +566,7 @@ impl Model {
     pub fn mount_label_help(&mut self) {
         let config = self.config_tui.read();
         self.app
-            .remount(
-                Id::Label,
-                Box::new(LabelSpan::new(
-                    &config,
-                    &[
-                        TextSpan::new(" Help: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.select_view_keys.open_help
-                        ))
-                        .fg(config.settings.theme.fallback_highlight())
-                        .bold(),
-                        TextSpan::new(" Config: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.select_view_keys.open_config
-                        ))
-                        .fg(config.settings.theme.fallback_highlight())
-                        .bold(),
-                        TextSpan::new(" Library: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.select_view_keys.view_library
-                        ))
-                        .fg(config.settings.theme.fallback_highlight())
-                        .bold(),
-                        TextSpan::new(" Database: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.select_view_keys.view_database
-                        ))
-                        .fg(config.settings.theme.fallback_highlight())
-                        .bold(),
-                        TextSpan::new(" Podcasts: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        TextSpan::new(format!(
-                            "<{}>",
-                            config.settings.keys.select_view_keys.view_podcasts
-                        ))
-                        .fg(config.settings.theme.fallback_highlight())
-                        .bold(),
-                        TextSpan::new(" Version: ")
-                            .fg(config.settings.theme.fallback_foreground())
-                            .bold(),
-                        // maybe consider moving version into Help or Config or its own popup (like a About)
-                        TextSpan::new(env!("TERMUSIC_VERSION"))
-                            .fg(config.settings.theme.fallback_highlight())
-                            .bold(),
-                    ],
-                )),
-                Vec::default(),
-            )
+            .remount(Id::Label, Box::new(Footer::new(&config)), Vec::default())
             .expect("Expected to remount without error");
     }
 


### PR DESCRIPTION
This PR changes the footer layout to be a consistent `TEXT: <KEY> TEXT: <KEY>` instead of the previous `<KEY> TEXT <KEY> TEXT` in tag-editor and config-editor to be consistent with the main footer layout.
Additionally this also moves all footers to be their own components that were not already.

re https://github.com/tramhao/termusic/discussions/347#discussioncomment-10059747

PS: i have no clue why no tests are running