### PR TITLE
Some small Music-Library widget (and related) changes

### DIFF
--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -325,8 +325,8 @@ pub enum KFMsg {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LIMsg {
-    TreeExtendDir(String),
-    TreeGoToUpperDir,
+    TreeStepInto(String),
+    TreeStepOut,
     TreeBlur,
     Yank,
     Paste,

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -170,7 +170,7 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
             Event::Keyboard(KeyEvent {
                 code: Key::Backspace,
                 modifiers: KeyModifiers::NONE,
-            }) => return Some(Msg::Library(LIMsg::TreeGoToUpperDir)),
+            }) => return Some(Msg::Library(LIMsg::TreeStepOut)),
             Event::Keyboard(
                 KeyEvent {
                     code: Key::Tab,
@@ -218,7 +218,7 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
         };
         match result {
             CmdResult::Submit(State::One(StateValue::String(node))) => {
-                Some(Msg::Library(LIMsg::TreeExtendDir(node)))
+                Some(Msg::Library(LIMsg::TreeStepInto(node)))
             }
             _ => Some(Msg::None),
         }

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -555,8 +555,13 @@ impl Model {
         }
 
         config_server.settings.player.music_dirs = vec;
+        let res = ServerConfigVersionedDefaulted::save_config_path(&config_server.settings);
         drop(config_server);
+
         self.library_switch_root();
+
+        res.context("Error while saving config")?;
+
         Ok(())
     }
 }

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -385,7 +385,7 @@ impl Model {
         }
     }
 
-    pub fn library_delete_song(&mut self) -> Result<()> {
+    pub fn library_delete_node(&mut self) -> Result<()> {
         if let Ok(State::One(StateValue::String(node_id))) = self.app.state(&Id::Library) {
             if let Some(mut route) = self.library.tree.root().route_by_node(&node_id) {
                 let p: &Path = Path::new(node_id.as_str());
@@ -396,7 +396,7 @@ impl Model {
                     remove_dir_all(p)?;
                 }
 
-                // // this is to keep the state of playlist
+                // this is to keep the state of playlist
                 self.library_reload_tree();
                 let tree = self.library.tree.clone();
                 if let Some(new_node) = tree.root().node_by_route(&route) {

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -532,14 +532,9 @@ impl Model {
             .push(current_path.clone());
         let res = ServerConfigVersionedDefaulted::save_config_path(&config_server.settings);
         drop(config_server);
-        match res {
-            Ok(()) => {
-                self.command(&PlayerCmd::ReloadConfig);
-            }
-            Err(e) => {
-                bail!("error when saving config: {e}");
-            }
-        }
+
+        res.context("Error while saving config")?;
+        self.command(&PlayerCmd::ReloadConfig);
         Ok(())
     }
 

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -462,11 +462,10 @@ impl Model {
         let all_items = walkdir::WalkDir::new(p).follow_links(true);
         let mut idx = 0;
         let search = format!("*{}*", input.to_lowercase());
+        let search = wildmatch::WildMatch::new(&search);
         for record in all_items.into_iter().filter_map(std::result::Result::ok) {
             let file_name = record.path();
-            if wildmatch::WildMatch::new(&search)
-                .matches(&file_name.to_string_lossy().to_lowercase())
-            {
+            if search.matches(&file_name.to_string_lossy().to_lowercase()) {
                 if idx > 0 {
                     table.add_row();
                 }

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -258,7 +258,7 @@ impl Model {
             if let Ok(paths) = std::fs::read_dir(p) {
                 let mut paths: Vec<_> = paths
                     .filter_map(std::result::Result::ok)
-                    .filter(|p| !p.file_name().to_string_lossy().to_string().starts_with('.'))
+                    .filter(|p| !p.file_name().to_string_lossy().starts_with('.'))
                     .collect();
 
                 paths.sort_by_cached_key(|k| get_pin_yin(&k.file_name().to_string_lossy()));

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -226,10 +226,10 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
 }
 
 impl Model {
-    pub fn library_scan_dir(&mut self, p: &Path) {
-        self.library.tree_path = p.to_path_buf();
+    pub fn library_scan_dir<P: Into<PathBuf>>(&mut self, p: P) {
+        self.library.tree_path = p.into();
         self.library.tree = Tree::new(Self::library_dir_tree(
-            p,
+            &self.library.tree_path,
             self.config_server.read().get_library_scan_depth(),
         ));
     }
@@ -363,13 +363,13 @@ impl Model {
     //     }
     // }
     pub fn library_stepinto(&mut self, node_id: &str) {
-        self.library_scan_dir(PathBuf::from(node_id).as_path());
+        self.library_scan_dir(PathBuf::from(node_id));
         self.library_reload_tree();
     }
 
     pub fn library_stepout(&mut self) {
         if let Some(p) = self.library_upper_dir() {
-            self.library_scan_dir(p.as_path());
+            self.library_scan_dir(p);
             self.library_reload_tree();
         }
     }
@@ -510,7 +510,7 @@ impl Model {
         }
         if let Some(dir) = vec.get(index) {
             let pathbuf = PathBuf::from(dir);
-            self.library_scan_dir(pathbuf.as_path());
+            self.library_scan_dir(pathbuf);
             self.library_reload_with_node_focus(None);
         }
     }

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -243,7 +243,7 @@ impl HelpPopup {
                         .add_col(TextSpan::new("Podcast").bold().fg(Color::LightYellow))
                         .add_row()
                         .add_col(Self::key(&[&keys.podcast_keys.search]))
-                        .add_col(Self::comment("Feeds: search or add feed"))
+                        .add_col(Self::comment("Feeds: search for new feeds"))
                         .add_row()
                         .add_col(Self::key(&[
                             &keys.podcast_keys.delete_feed,
@@ -268,6 +268,9 @@ impl HelpPopup {
                         .add_row()
                         .add_col(Self::key(&[&keys.podcast_keys.delete_local_episode]))
                         .add_col(Self::comment("Episode: delete episode local file"))
+                        .add_row()
+                        .add_col(Self::key(&[&keys.library_keys.search]))
+                        .add_col(Self::comment("Search through added Feeds / Episodes"))
                         .build(),
                 )
         };

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -809,7 +809,7 @@ impl Model {
                 if self.app.mounted(&Id::DeleteConfirmInputPopup) {
                     let _drop = self.app.umount(&Id::DeleteConfirmInputPopup);
                 }
-                if let Err(e) = self.library_delete_song() {
+                if let Err(e) = self.library_delete_node() {
                     self.mount_error_popup(e.context("library delete song"));
                 };
             }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -600,10 +600,10 @@ impl Model {
             LIMsg::TreeBlur => {
                 assert!(self.app.active(&Id::Playlist).is_ok());
             }
-            LIMsg::TreeExtendDir(path) => {
+            LIMsg::TreeStepInto(path) => {
                 self.library_stepinto(path);
             }
-            LIMsg::TreeGoToUpperDir => {
+            LIMsg::TreeStepOut => {
                 self.library_stepout();
             }
             LIMsg::Yank => {


### PR DESCRIPTION
This PR does a bunch of small changes to the music library widget (or related things), in more details:
- add help entry for `/`(local search) while in podcast view
- rename LIMsg stepin / stepout messages to be consistent
- rename some functions to make more sense
- remove unnecessary convertions and re-allocations where not necessary
- some small changes where less code could be used
- dont repeat handling for "right key" multiple times
- construct search only once, not every loop for `[library_update_search](https://github.com/tramhao/termusic/commit/d8b5be8e7ec8e6e2ca9ebf6762ed3177e6cae2a5)`