### PR TITLE
Move "no backend selected" compile error to sever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog
 
+### next
+- Unreleased
+- Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)
+
 ### [V0.9.1]
 - Released on: August 21, 2024.
 - Change: enable `log-to-file` by default.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "termusic"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "termusic-lib"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "termusic-playback"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "termusic-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -136,7 +136,7 @@ impl Backend {
         return Self::new_mpv(config, cmd_tx);
 
         #[cfg(not(any(feature = "rusty", feature = "gst", feature = "mpv")))]
-        compile_error!("No useable backend feature!");
+        unimplemented!("No compiled backend!");
     }
 
     /// Explicitly choose Backend [`RustyBackend`](rusty_backend::RustyBackend)
@@ -169,6 +169,8 @@ impl Backend {
             Backend::Rusty(v) => v,
             #[cfg(feature = "gst")]
             Backend::GStreamer(v) => v,
+            #[cfg(not(any(feature = "rusty", feature = "gst", feature = "mpv")))]
+            _ => unimplemented!("No compiled backend!"),
         }
     }
 
@@ -181,6 +183,8 @@ impl Backend {
             Backend::Rusty(v) => v,
             #[cfg(feature = "gst")]
             Backend::GStreamer(v) => v,
+            #[cfg(not(any(feature = "rusty", feature = "gst", feature = "mpv")))]
+            _ => unimplemented!("No compiled backend!"),
         }
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,6 +36,7 @@ clap.workspace = true
 
 
 [features]
+# NOTE: this package fails to compile if not one of the backends (rusty, gst, mpv) are compiled in!
 default = ["rusty", "rusty-soundtouch"]
 # # left for debug
 # default = ["mpv"]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -102,6 +102,9 @@ async fn actual_main() -> Result<()> {
         return execute_action(action, &config);
     }
 
+    #[cfg(not(any(feature = "rusty", feature = "gst", feature = "mpv")))]
+    compile_error!("No useable backend feature!");
+
     info!("Server starting...");
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
 


### PR DESCRIPTION
This PR moves the "no backend selected" compile error to the server package instead of the playback package (and does a runtime panic instead).
This is because currently the TUI makes use of the playback package without needing any backends, which makes the release process bad.

re https://github.com/tramhao/termusic/issues/259#issuecomment-2301443314
re https://github.com/tramhao/termusic/issues/358#issuecomment-2301646206

PS: also update the Cargo.lock for the new version as it had not been updated