### PR TITLE
fix(lib): change default ip address to "::1" instead of "::"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog
 
+### next
+- Unreleased
+- Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
+
 ### [V0.9.1]
 - Released on: August 21, 2024.
 - Change: enable `log-to-file` by default.

--- a/lib/src/config/v1/mod.rs
+++ b/lib/src/config/v1/mod.rs
@@ -340,7 +340,7 @@ impl Default for Settings {
             player_use_mpris: true,
             player_use_discord: true,
             player_port: 50101,
-            player_interface: "::".parse().unwrap(),
+            player_interface: "::1".parse().unwrap(),
         }
     }
 }

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -339,7 +339,7 @@ impl Default for ComSettings {
     fn default() -> Self {
         Self {
             port: 50101,
-            address: "::".parse().unwrap(),
+            address: "::1".parse().unwrap(),
         }
     }
 }
@@ -525,7 +525,7 @@ mod v1_interop {
                 converted.com,
                 ComSettings {
                     port: 50101,
-                    address: "::".parse().unwrap()
+                    address: "::1".parse().unwrap()
                 }
             );
 


### PR DESCRIPTION
fixes #356