### PR TITLE
Streaming Server Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### next
 - Unreleased
 - Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)
+- Feat: more immediate event changes (Example: updated via mpris)
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 
 ### [V0.9.1]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,6 +4193,7 @@ dependencies = [
  "dirs",
  "escaper",
  "flexi_logger",
+ "futures",
  "id3",
  "image",
  "include_dir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,7 @@ dependencies = [
  "termusic-playback",
  "textwrap 0.16.1",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tui-realm-stdlib",
  "tui-realm-treeview",
@@ -4330,6 +4331,7 @@ dependencies = [
  "termusic-lib",
  "termusic-playback",
  "tokio",
+ "tokio-stream",
  "tonic",
 ]
 
@@ -4489,6 +4491,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tempfile = "3.10"
 textwrap = "0.16"
 tokio = { version = "1.37", features = ["sync", "macros", "rt","rt-multi-thread"] }
 tokio-util = "0.7"
+tokio-stream = { version = "0.1", features = ["sync"] }
 toml = "0.8"
 # only update prost and tonic major versions together
 prost = "0.13"

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -17,6 +17,8 @@ service MusicPlayer {
   rpc ReloadPlaylist(ReloadPlaylistRequest) returns (EmptyReply);
   rpc PlaySelected(PlaySelectedRequest) returns (EmptyReply);
   rpc SkipPrevious(SkipPreviousRequest) returns (EmptyReply);
+
+  rpc SubscribeServerUpdates(EmptyReply) returns (stream StreamUpdates);
 }
 
 message TogglePauseRequest {}
@@ -83,3 +85,37 @@ message Duration {
   uint64 secs = 1;
   uint32 nanos = 2;
 }
+
+// all updates that can happen from the server side, without the client to have to ask explicitly
+// naming convention for the stream update specific messages is to add the "Update" prefix, even if it already exists
+message StreamUpdates {
+  oneof type {
+    UpdateVolumeChanged volume_changed = 1;
+    // UpdateTrackChanged track_changed = 2;
+    // UpdateSpeedChanged speed_changed = 3;
+    // UpdatePlayStateChanged play_state_changed = 4;
+  }
+}
+
+// The Volume changed, send new information
+message UpdateVolumeChanged {
+  // reuse the existing message
+  VolumeReply msg = 1;
+}
+
+// // The track changed, send new information
+// message UpdateTrackChanged {
+//   // TODO: do track changed information
+// }
+
+// // The Speed changed, send new information
+// message UpdateSpeedChanged {
+//   // reuse the existing message
+//   SpeedReply msg = 1;
+// }
+
+// // TODO: is play-state (playing / paused / ??) the only things this should do?
+// message UpdatePlayStateChanged {
+//   // reuse the existing message
+//   TogglePauseResponse msg = 1;
+// }

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -91,8 +91,8 @@ message Duration {
 message StreamUpdates {
   oneof type {
     UpdateVolumeChanged volume_changed = 1;
-    // UpdateTrackChanged track_changed = 2;
-    // UpdateSpeedChanged speed_changed = 3;
+    UpdateSpeedChanged speed_changed = 2;
+    // UpdateTrackChanged track_changed = 3;
     // UpdatePlayStateChanged play_state_changed = 4;
   }
 }
@@ -103,15 +103,15 @@ message UpdateVolumeChanged {
   VolumeReply msg = 1;
 }
 
+// The Speed changed, send new information
+message UpdateSpeedChanged {
+  // reuse the existing message
+  SpeedReply msg = 1;
+}
+
 // // The track changed, send new information
 // message UpdateTrackChanged {
 //   // TODO: do track changed information
-// }
-
-// // The Speed changed, send new information
-// message UpdateSpeedChanged {
-//   // reuse the existing message
-//   SpeedReply msg = 1;
 // }
 
 // // TODO: is play-state (playing / paused / ??) the only things this should do?

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -92,8 +92,8 @@ message StreamUpdates {
   oneof type {
     UpdateVolumeChanged volume_changed = 1;
     UpdateSpeedChanged speed_changed = 2;
-    // UpdateTrackChanged track_changed = 3;
-    // UpdatePlayStateChanged play_state_changed = 4;
+    UpdatePlayStateChanged play_state_changed = 3;
+    // UpdateTrackChanged track_changed = 4;
   }
 }
 
@@ -109,13 +109,13 @@ message UpdateSpeedChanged {
   SpeedReply msg = 1;
 }
 
+// TODO: is play-state (playing / paused / ??) the only things this should do?
+message UpdatePlayStateChanged {
+  // reuse the existing message
+  TogglePauseResponse msg = 1;
+}
+
 // // The track changed, send new information
 // message UpdateTrackChanged {
 //   // TODO: do track changed information
-// }
-
-// // TODO: is play-state (playing / paused / ??) the only things this should do?
-// message UpdatePlayStateChanged {
-//   // reuse the existing message
-//   TogglePauseResponse msg = 1;
 // }

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -133,6 +133,11 @@ message UpdateTrackChanged {
   // all values below should be moved into their own "Track" message at some point
   // instead of having the TUI fetch everything from the file itself
   // radio title, track title
-  optional string title = 3;
+  // the following is (linux protobuf) 3.15, ubuntu 2204 still has (linux protobuf) 3.12
+  // optional string title = 3;
+  // the following "oneof" is wire equivalent to the above "optional"
+  oneof optional_title {
+    string title = 3;
+  }
   PlayerTime progress = 4;
 }

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -94,7 +94,7 @@ message StreamUpdates {
     UpdateVolumeChanged volume_changed = 2;
     UpdateSpeedChanged speed_changed = 3;
     UpdatePlayStateChanged play_state_changed = 4;
-    // UpdateTrackChanged track_changed = 5;
+    UpdateTrackChanged track_changed = 5;
   }
 }
 
@@ -122,7 +122,17 @@ message UpdatePlayStateChanged {
   TogglePauseResponse msg = 1;
 }
 
-// // The track changed, send new information
-// message UpdateTrackChanged {
-//   // TODO: do track changed information
-// }
+// The track changed in some way, send new information
+// This includes everything from changing to a new track, new radio title, etc
+// This is *not* used for regular track progress updates
+// NOTE: this may or may not be sent for the initial track after startup as the client may connect after the track started
+message UpdateTrackChanged {
+  uint32 current_track_index = 1;
+  bool current_track_updated = 2;
+
+  // all values below should be moved into their own "Track" message at some point
+  // instead of having the TUI fetch everything from the file itself
+  // radio title, track title
+  optional string title = 3;
+  PlayerTime progress = 4;
+}

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -90,11 +90,18 @@ message Duration {
 // naming convention for the stream update specific messages is to add the "Update" prefix, even if it already exists
 message StreamUpdates {
   oneof type {
-    UpdateVolumeChanged volume_changed = 1;
-    UpdateSpeedChanged speed_changed = 2;
-    UpdatePlayStateChanged play_state_changed = 3;
-    // UpdateTrackChanged track_changed = 4;
+    UpdateMissedEvents missed_events = 1;
+    UpdateVolumeChanged volume_changed = 2;
+    UpdateSpeedChanged speed_changed = 3;
+    UpdatePlayStateChanged play_state_changed = 4;
+    // UpdateTrackChanged track_changed = 5;
   }
+}
+
+// Indicate that some events could not be send
+// Like a "Lagged" Error from tokio-stream
+message UpdateMissedEvents {
+  uint64 amount = 1;
 }
 
 // The Volume changed, send new information

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -57,8 +57,8 @@ impl From<PlayerProgress> for protobuf::PlayerTime {
 #[derive(Debug, Clone, PartialEq)]
 pub enum UpdateEvents {
     VolumeChanged { volume: u16 },
+    SpeedChanged { speed: i32 },
     // TrackChanged,
-    // SpeedChanged { speed: i32 },
     // PlayStateChanged { playing: bool },
 }
 
@@ -74,17 +74,17 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
                         volume: u32::from(volume),
                     }),
                 })
-            } // UpdateEvents::TrackChanged => StreamTypes::TrackChanged(UpdateTrackChanged {}),
-              // UpdateEvents::SpeedChanged { speed } => StreamTypes::SpeedChanged(UpdateSpeedChanged {
-              //     msg: Some(SpeedReply { speed: speed }),
-              // }),
-              // UpdateEvents::PlayStateChanged { playing } => {
-              //     StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
-              //         msg: Some(TogglePauseResponse {
-              //             status: playing as u32,
-              //         }),
-              //     })
-              // }
+            }
+            UpdateEvents::SpeedChanged { speed } => StreamTypes::SpeedChanged(UpdateSpeedChanged {
+                msg: Some(SpeedReply { speed }),
+            }), // UpdateEvents::TrackChanged => StreamTypes::TrackChanged(UpdateTrackChanged {}),
+                // UpdateEvents::PlayStateChanged { playing } => {
+                //     StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
+                //         msg: Some(TogglePauseResponse {
+                //             status: playing as u32,
+                //         }),
+                //     })
+                // }
         };
 
         Self { r#type: Some(val) }
@@ -103,6 +103,9 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
                 volume: clamp_u16(
                     unwrap_msg(ev.msg, "StreamUpdates.types.volume_changed.msg")?.volume,
                 ),
+            },
+            stream_updates::Type::SpeedChanged(ev) => Self::SpeedChanged {
+                speed: unwrap_msg(ev.msg, "StreamUpdates.types.speed_changed.msg")?.speed,
             },
         };
 

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -56,6 +56,7 @@ impl From<PlayerProgress> for protobuf::PlayerTime {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum UpdateEvents {
+    MissedEvents { amount: u64 },
     VolumeChanged { volume: u16 },
     SpeedChanged { speed: i32 },
     PlayStateChanged { playing: u32 },
@@ -68,6 +69,9 @@ type StreamTypes = protobuf::stream_updates::Type;
 impl From<UpdateEvents> for protobuf::StreamUpdates {
     fn from(value: UpdateEvents) -> Self {
         let val = match value {
+            UpdateEvents::MissedEvents { amount } => {
+                StreamTypes::MissedEvents(UpdateMissedEvents { amount })
+            }
             UpdateEvents::VolumeChanged { volume } => {
                 StreamTypes::VolumeChanged(UpdateVolumeChanged {
                     msg: Some(VolumeReply {
@@ -108,6 +112,7 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
             stream_updates::Type::PlayStateChanged(ev) => Self::PlayStateChanged {
                 playing: unwrap_msg(ev.msg, "StreamUpdates.types.play_state_changed.msg")?.status,
             },
+            stream_updates::Type::MissedEvents(ev) => Self::MissedEvents { amount: ev.amount },
         };
 
         Ok(res)

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -102,7 +102,9 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
             UpdateEvents::TrackChanged(info) => StreamTypes::TrackChanged(UpdateTrackChanged {
                 current_track_index: info.current_track_index,
                 current_track_updated: info.current_track_updated,
-                title: info.title,
+                optional_title: info
+                    .title
+                    .map(protobuf::update_track_changed::OptionalTitle::Title),
                 progress: info.progress.map(Into::into),
             }),
         };
@@ -134,7 +136,10 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
             stream_updates::Type::TrackChanged(ev) => Self::TrackChanged(TrackChangedInfo {
                 current_track_index: ev.current_track_index,
                 current_track_updated: ev.current_track_updated,
-                title: ev.title,
+                title: ev.optional_title.map(|v| {
+                    let protobuf::update_track_changed::OptionalTitle::Title(v) = v;
+                    v
+                }),
                 progress: ev.progress.map(Into::into),
             }),
         };

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::module_name_repetitions)]
+use anyhow::anyhow;
 
 // using lower mod to restrict clippy
 #[allow(clippy::pedantic)]
@@ -51,4 +52,73 @@ impl From<PlayerProgress> for protobuf::PlayerTime {
             total_duration: value.total_duration.map(Into::into),
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateEvents {
+    VolumeChanged { volume: u16 },
+    // TrackChanged,
+    // SpeedChanged { speed: i32 },
+    // PlayStateChanged { playing: bool },
+}
+
+type StreamTypes = protobuf::stream_updates::Type;
+
+// mainly for server to grpc
+impl From<UpdateEvents> for protobuf::StreamUpdates {
+    fn from(value: UpdateEvents) -> Self {
+        let val = match value {
+            UpdateEvents::VolumeChanged { volume } => {
+                StreamTypes::VolumeChanged(UpdateVolumeChanged {
+                    msg: Some(VolumeReply {
+                        volume: u32::from(volume),
+                    }),
+                })
+            } // UpdateEvents::TrackChanged => StreamTypes::TrackChanged(UpdateTrackChanged {}),
+              // UpdateEvents::SpeedChanged { speed } => StreamTypes::SpeedChanged(UpdateSpeedChanged {
+              //     msg: Some(SpeedReply { speed: speed }),
+              // }),
+              // UpdateEvents::PlayStateChanged { playing } => {
+              //     StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
+              //         msg: Some(TogglePauseResponse {
+              //             status: playing as u32,
+              //         }),
+              //     })
+              // }
+        };
+
+        Self { r#type: Some(val) }
+    }
+}
+
+// mainly for grpc to client(tui)
+impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
+    type Error = anyhow::Error;
+
+    fn try_from(value: protobuf::StreamUpdates) -> Result<Self, Self::Error> {
+        let value = unwrap_msg(value.r#type, "StreamUpdates.type")?;
+
+        let res = match value {
+            stream_updates::Type::VolumeChanged(ev) => Self::VolumeChanged {
+                volume: clamp_u16(
+                    unwrap_msg(ev.msg, "StreamUpdates.types.volume_changed.msg")?.volume,
+                ),
+            },
+        };
+
+        Ok(res)
+    }
+}
+
+/// Easily unwrap a given grpc option and covert it to a result, with a location on None
+fn unwrap_msg<T>(opt: Option<T>, place: &str) -> Result<T, anyhow::Error> {
+    match opt {
+        Some(val) => Ok(val),
+        None => Err(anyhow!("Got \"None\" in grpc \"{place}\"!")),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn clamp_u16(val: u32) -> u16 {
+    val.min(u32::from(u16::MAX)) as u16
 }

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -58,8 +58,8 @@ impl From<PlayerProgress> for protobuf::PlayerTime {
 pub enum UpdateEvents {
     VolumeChanged { volume: u16 },
     SpeedChanged { speed: i32 },
+    PlayStateChanged { playing: u32 },
     // TrackChanged,
-    // PlayStateChanged { playing: bool },
 }
 
 type StreamTypes = protobuf::stream_updates::Type;
@@ -77,14 +77,12 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
             }
             UpdateEvents::SpeedChanged { speed } => StreamTypes::SpeedChanged(UpdateSpeedChanged {
                 msg: Some(SpeedReply { speed }),
-            }), // UpdateEvents::TrackChanged => StreamTypes::TrackChanged(UpdateTrackChanged {}),
-                // UpdateEvents::PlayStateChanged { playing } => {
-                //     StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
-                //         msg: Some(TogglePauseResponse {
-                //             status: playing as u32,
-                //         }),
-                //     })
-                // }
+            }),
+            UpdateEvents::PlayStateChanged { playing } => {
+                StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
+                    msg: Some(TogglePauseResponse { status: playing }),
+                })
+            } // UpdateEvents::TrackChanged => StreamTypes::TrackChanged(UpdateTrackChanged {}),
         };
 
         Self { r#type: Some(val) }
@@ -106,6 +104,9 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
             },
             stream_updates::Type::SpeedChanged(ev) => Self::SpeedChanged {
                 speed: unwrap_msg(ev.msg, "StreamUpdates.types.speed_changed.msg")?.speed,
+            },
+            stream_updates::Type::PlayStateChanged(ev) => Self::PlayStateChanged {
+                playing: unwrap_msg(ev.msg, "StreamUpdates.types.play_state_changed.msg")?.status,
             },
         };
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -615,11 +615,17 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn set_speed(&mut self, speed: Speed) -> Speed {
-        self.get_player_mut().set_speed(speed)
+        let speed = self.get_player_mut().set_speed(speed);
+        self.send_stream_ev(UpdateEvents::SpeedChanged { speed });
+
+        speed
     }
 
     fn add_speed(&mut self, speed: SpeedSigned) -> Speed {
-        self.get_player_mut().add_speed(speed)
+        let speed = self.get_player_mut().add_speed(speed);
+        self.send_stream_ev(UpdateEvents::SpeedChanged { speed });
+
+        speed
     }
 
     fn speed(&self) -> Speed {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -46,11 +46,12 @@ use std::time::Duration;
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::{new_shared_server_settings, ServerOverlay, SharedServerSettings};
 use termusiclib::library_db::DataBase;
-use termusiclib::player::{PlayerProgress, PlayerTimeUnit};
+use termusiclib::player::{PlayerProgress, PlayerTimeUnit, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaType, Track};
 use termusiclib::utils::get_app_config_path;
 use tokio::runtime::Handle;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 #[macro_use]
@@ -178,6 +179,8 @@ pub enum PlayerCmd {
     VolumeUp,
 }
 
+pub type StreamTX = broadcast::Sender<UpdateEvents>;
+
 #[allow(clippy::module_name_repetitions)]
 pub struct GeneralPlayer {
     pub backend: Backend,
@@ -189,6 +192,7 @@ pub struct GeneralPlayer {
     pub db: DataBase,
     pub db_podcast: DBPod,
     pub cmd_tx: PlayerCmdSender,
+    pub stream_tx: StreamTX,
 }
 
 impl GeneralPlayer {
@@ -202,6 +206,7 @@ impl GeneralPlayer {
         backend: BackendSelect,
         config: ServerOverlay,
         cmd_tx: PlayerCmdSender,
+        stream_tx: StreamTX,
     ) -> Result<Self> {
         let backend = Backend::new_select(backend, &config, cmd_tx.clone());
 
@@ -232,6 +237,7 @@ impl GeneralPlayer {
             db,
             db_podcast,
             cmd_tx,
+            stream_tx,
             current_track_updated: false,
         })
     }
@@ -242,8 +248,12 @@ impl GeneralPlayer {
     ///
     /// - if connecting to the database fails
     /// - if config path creation fails
-    pub fn new(config: ServerOverlay, cmd_tx: PlayerCmdSender) -> Result<Self> {
-        Self::new_backend(BackendSelect::Rusty, config, cmd_tx)
+    pub fn new(
+        config: ServerOverlay,
+        cmd_tx: PlayerCmdSender,
+        stream_tx: StreamTX,
+    ) -> Result<Self> {
+        Self::new_backend(BackendSelect::Rusty, config, cmd_tx, stream_tx)
     }
 
     /// Reload the config from file, on fail continue to use the old
@@ -541,6 +551,14 @@ impl GeneralPlayer {
             }
         }
     }
+
+    /// Send stream events with consistent error handling
+    fn send_stream_ev(&self, ev: UpdateEvents) {
+        // there is only one error case: no receivers
+        if self.stream_tx.send(ev).is_err() {
+            debug!("Stream Event not send: No Receivers");
+        }
+    }
 }
 
 #[async_trait]
@@ -552,10 +570,16 @@ impl PlayerTrait for GeneralPlayer {
         self.get_player().volume()
     }
     fn add_volume(&mut self, volume: VolumeSigned) -> Volume {
-        self.get_player_mut().add_volume(volume)
+        let vol = self.get_player_mut().add_volume(volume);
+        self.send_stream_ev(UpdateEvents::VolumeChanged { volume: vol });
+
+        vol
     }
     fn set_volume(&mut self, volume: Volume) -> Volume {
-        self.get_player_mut().set_volume(volume)
+        let vol = self.get_player_mut().set_volume(volume);
+        self.send_stream_ev(UpdateEvents::VolumeChanged { volume: vol });
+
+        vol
     }
     /// This function should not be used directly, use GeneralPlayer::pause
     fn pause(&mut self) {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -591,6 +591,10 @@ impl PlayerTrait for GeneralPlayer {
         if let Some(ref mut discord) = self.discord {
             discord.pause();
         }
+
+        self.send_stream_ev(UpdateEvents::PlayStateChanged {
+            playing: Status::Paused.as_u32(),
+        });
     }
     /// This function should not be used directly, use GeneralPlayer::play
     fn resume(&mut self) {
@@ -603,6 +607,10 @@ impl PlayerTrait for GeneralPlayer {
         if let Some(ref mut discord) = self.discord {
             discord.resume(time_pos);
         }
+
+        self.send_stream_ev(UpdateEvents::PlayStateChanged {
+            playing: Status::Running.as_u32(),
+        });
     }
     fn is_paused(&self) -> bool {
         self.get_player().is_paused()

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ colored.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tonic.workspace = true
 clap.workspace = true
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,14 +4,15 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::{
-    CycleLoopReply, CycleLoopRequest, EmptyReply, GetProgressRequest, GetProgressResponse,
-    PlaySelectedRequest, PlayerTime, ReloadConfigRequest, ReloadPlaylistRequest,
-    SeekBackwardRequest, SeekForwardRequest, SkipNextRequest, SkipNextResponse,
-    SkipPreviousRequest, SpeedDownRequest, SpeedReply, SpeedUpRequest, ToggleGaplessReply,
-    ToggleGaplessRequest, TogglePauseRequest, TogglePauseResponse, VolumeDownRequest, VolumeReply,
-    VolumeUpRequest,
+    stream_updates, CycleLoopReply, CycleLoopRequest, EmptyReply, GetProgressRequest,
+    GetProgressResponse, PlaySelectedRequest, PlayerTime, ReloadConfigRequest,
+    ReloadPlaylistRequest, SeekBackwardRequest, SeekForwardRequest, SkipNextRequest,
+    SkipNextResponse, SkipPreviousRequest, SpeedDownRequest, SpeedReply, SpeedUpRequest,
+    StreamUpdates, ToggleGaplessReply, ToggleGaplessRequest, TogglePauseRequest,
+    TogglePauseResponse, UpdateMissedEvents, VolumeDownRequest, VolumeReply, VolumeUpRequest,
 };
 use termusicplayback::{PlayerCmd, PlayerCmdSender, StreamTX};
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status};
@@ -237,7 +238,17 @@ impl MusicPlayer for MusicPlayerService {
         // map to the grpc types
         let receiver_stream = BroadcastStream::new(rx).map(|res| match res {
             Ok(ev) => Ok(ev.into()),
-            Err(err) => Err(Status::from_error(Box::new(err))),
+            Err(err) => {
+                let BroadcastStreamRecvError::Lagged(amount) = err;
+                Ok(StreamUpdates {
+                    r#type: Some(stream_updates::Type::MissedEvents(UpdateMissedEvents {
+                        amount,
+                    })),
+                })
+
+                // else case if ever necessary
+                // Err(Status::from_error(Box::new(err)))
+            }
         });
         Ok(Response::new(Box::pin(receiver_stream)))
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -8,18 +8,15 @@ use termusiclib::player::{
     PlaySelectedRequest, PlayerTime, ReloadConfigRequest, ReloadPlaylistRequest,
     SeekBackwardRequest, SeekForwardRequest, SkipNextRequest, SkipNextResponse,
     SkipPreviousRequest, SpeedDownRequest, SpeedReply, SpeedUpRequest, ToggleGaplessReply,
-    ToggleGaplessRequest, TogglePauseRequest, TogglePauseResponse, UpdateEvents, VolumeDownRequest,
-    VolumeReply, VolumeUpRequest,
+    ToggleGaplessRequest, TogglePauseRequest, TogglePauseResponse, VolumeDownRequest, VolumeReply,
+    VolumeUpRequest,
 };
-use termusicplayback::{PlayerCmd, PlayerCmdSender};
-use tokio::sync::broadcast;
+use termusicplayback::{PlayerCmd, PlayerCmdSender, StreamTX};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status};
 
 use crate::PlayerStats;
-
-pub type StreamTX = broadcast::Sender<UpdateEvents>;
 
 #[derive(Debug)]
 pub struct MusicPlayerService {

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -55,6 +55,7 @@ percent-encoding.workspace = true #   = "2.2"
 tonic.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+futures.workspace = true
 reqwest.workspace = true
 parking_lot.workspace = true
 

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -54,6 +54,7 @@ sanitize-filename.workspace = true #   = "0.4"
 percent-encoding.workspace = true #   = "2.2"
 tonic.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 reqwest.workspace = true
 parking_lot.workspace = true
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -26,17 +26,21 @@ pub mod model;
 mod playback;
 pub mod utils;
 
+use anyhow::Context;
 use anyhow::Result;
+use futures::future::FutureExt;
 use model::{Model, TermusicLayout};
 use playback::Playback;
 use std::time::Duration;
 use sysinfo::System;
 use termusiclib::player::music_player_client::MusicPlayerClient;
 use termusiclib::player::PlayerProgress;
+use termusiclib::player::StreamUpdates;
 use termusiclib::player::UpdateEvents;
 pub use termusiclib::types::*;
 use termusicplayback::{PlayerCmd, Status};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tokio_stream::Stream;
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tuirealm::application::PollStrategy;
@@ -98,20 +102,6 @@ impl UI {
     async fn run_inner(&mut self) -> Result<()> {
         let mut stream_updates = self.playback.subscribe_to_stream_updates().await?;
 
-        // placeholder showcase that it is working
-        tokio::spawn(async move {
-            while let Some(ev) = stream_updates.next().await {
-                let ev = ev.map(UpdateEvents::try_from);
-
-                debug!("Stream Event: {ev:?}");
-
-                // just exit on first error, but still print it first
-                if ev.is_err() {
-                    break;
-                }
-            }
-        });
-
         // Main loop
         let mut progress_interval = 0;
         while !self.model.quit {
@@ -121,6 +111,7 @@ impl UI {
             if self.model.layout != TermusicLayout::Podcast {
                 self.model.lyric_update();
             }
+            self.handle_stream_events(&mut stream_updates)?;
             if progress_interval == 0 {
                 self.model.run();
             }
@@ -324,6 +315,68 @@ impl UI {
                 _ => {}
             }
         }
+        Ok(())
+    }
+
+    /// Handle Stream updates from the provided stream.
+    ///
+    /// In case of lag, sends a [`PlayerCmd::GetProgress`] to `self.model`.
+    ///
+    /// - Does not wait until the next event (non-blocking).
+    /// - Processess *all* available events.
+    fn handle_stream_events(
+        &mut self,
+        stream: &mut (impl Stream<Item = Result<StreamUpdates, anyhow::Error>> + std::marker::Unpin),
+    ) -> Result<()> {
+        while let Some(ev) = stream.next().now_or_never().flatten() {
+            let ev = ev
+                .map(UpdateEvents::try_from)
+                .context("Conversion from StreamUpdates to UpdateEvents failed!")?;
+
+            debug!("Stream Event: {ev:?}");
+
+            // just exit on first error, but still print it first
+            let Ok(ev) = ev else {
+                break;
+            };
+
+            match ev {
+                UpdateEvents::MissedEvents { amount } => {
+                    warn!("Stream Lagged, missed events: {amount}");
+                    // we know that we missed events, force to get full information from GetProgress endpoint
+                    self.model.command(&PlayerCmd::GetProgress);
+                }
+                UpdateEvents::VolumeChanged { volume } => {
+                    self.model.config_server.write().settings.player.volume = volume;
+                }
+                UpdateEvents::SpeedChanged { speed } => {
+                    self.model.config_server.write().settings.player.speed = speed;
+                }
+                UpdateEvents::PlayStateChanged { playing } => {
+                    self.model.playlist.set_status(Status::from_u32(playing));
+                    self.model.progress_update_title();
+                }
+                UpdateEvents::TrackChanged(track_changed_info) => {
+                    if let Some(progress) = track_changed_info.progress {
+                        self.model.progress_update(
+                            progress.position,
+                            progress.total_duration.unwrap_or_default(),
+                        );
+                    }
+
+                    if track_changed_info.current_track_updated {
+                        self.handle_current_track_index(
+                            track_changed_info.current_track_index as usize,
+                        );
+                    }
+
+                    if let Some(title) = track_changed_info.title {
+                        self.model.lyric_update_for_radio(title);
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This PR implements protobuf streaming for server updates to be more immediate instead of a client(tui) always having to poll.
This helps for example when anything changes via mpris controls (like volume or play/pause), instead of there being a delay of ~1-2 seconds, it is (more or less) immediate now ([the delay without streaming is because of client polling being delayed](https://github.com/tramhao/termusic/blob/a0733aba590e76e9f3f3934cdf939ac8bbc6fd77/tui/src/ui/mod.rs#L106-L108)).

Current events implemented for streaming:
- Play State change (Play / Pause)
- Volume change
- Speed change
- Track information changed (This event is not meant for track progress updates, but title changes or track to track changes)
- Missed Events ("Lagged stream")

PS: this also fixes the issue of setting volume via mpris (`playerctl -p termusic volume 0.1`) and it not being reflected in the TUI until the TUI changes volume (this is because [the handler for GetProgress endpoint](https://github.com/tramhao/termusic/blob/a0733aba590e76e9f3f3934cdf939ac8bbc6fd77/tui/src/ui/mod.rs#L239-L253) does not actually set the volume it was provided)

---

The original idea came from #154, which had since been reverted.