### PR TITLE
Update to tuirealm 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,13 +798,14 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
@@ -986,11 +987,11 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -1002,15 +1003,15 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "mio 1.0.2",
  "parking_lot",
+ "rustix 0.38.34",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2142,6 +2143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,6 +2542,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -3304,22 +3316,23 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "ratatui"
-version = "0.26.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm 0.27.0",
- "itertools 0.12.1",
+ "crossterm 0.28.1",
+ "instability",
+ "itertools 0.13.0",
  "lru",
  "paste",
- "stability",
  "strum",
+ "strum_macros",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -3789,6 +3802,7 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -3912,16 +3926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn 2.0.76",
 ]
 
 [[package]]
@@ -4322,7 +4326,7 @@ dependencies = [
  "tui-realm-stdlib",
  "tui-realm-treeview",
  "tuirealm",
- "unicode-width",
+ "unicode-width 0.1.13",
  "viuer",
  "walkdir",
  "wildmatch",
@@ -4381,7 +4385,7 @@ dependencies = [
  "tonic-build",
  "tuirealm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
  "urlencoding",
  "viuer",
  "walkdir",
@@ -4447,7 +4451,7 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -4771,65 +4775,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "tui-realm-stdlib"
-version = "1.3.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ad506e872692d85265328353d92f4f633dd5add7f73ebd93e8d0368a708447"
+checksum = "78a24d06b8403c57b32a3d3fdac795adf4ef8610e5f9650a3629efc8a9d6c0bb"
 dependencies = [
  "textwrap",
  "tuirealm",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "tui-realm-treeview"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d2d6c059f6adbb2ba7194ab50765dac793cb98fae097e0bb5bf8c23ffaf27c"
+checksum = "4f5efdf354ccbf75ee5e2401b9b32e8a0e1fc6c84f6dda859474cd02fa9f0d94"
 dependencies = [
  "orange-trees",
  "tuirealm",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "tuirealm"
-version = "1.9.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c358c39cb9e1b45702ea46afc77d39589d720ca9cf5f1e11a3106342ea6a4e76"
+checksum = "0d3865c9f0e84c07c991c24c853f095bb764859fa3806fe6e00b559f40f1253f"
 dependencies = [
  "bitflags 2.6.0",
- "crossterm 0.27.0",
+ "crossterm 0.28.1",
  "lazy-regex",
  "ratatui",
  "serde",
  "thiserror",
- "tui",
  "tuirealm_derive",
 ]
 
 [[package]]
 name = "tuirealm_derive"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0adcdaf59881626555558eae08f8a53003c8a1961723b4d7a10c51599abbc81"
+checksum = "caa8b0560f4245acc0bbe0e1d76e1f6a308145dd6e107befce4cf29e7fe32662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4899,7 +4889,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -4907,6 +4897,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"
@@ -608,6 +611,15 @@ name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -782,6 +794,19 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1448,6 +1473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1835,17 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -2212,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "2.5.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff63c423c68ea6814b7da9e88ce585f793c87ddd9e78f646970891769c8235d4"
+checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -2223,14 +2265,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "2.4.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edfc11b8f56ce85e207e62ea21557cfa09bb24a8f6b04ae181b086ff8611c22"
+checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2362,6 +2404,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
+]
 
 [[package]]
 name = "mach2"
@@ -3252,6 +3303,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags 2.6.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.27.0",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,6 +3915,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,6 +3955,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.76",
+]
 
 [[package]]
 name = "subtle"
@@ -4212,7 +4315,7 @@ dependencies = [
  "sysinfo",
  "termusic-lib",
  "termusic-playback",
- "textwrap 0.16.1",
+ "textwrap",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -4270,7 +4373,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
- "textwrap 0.16.1",
+ "textwrap",
  "tokio",
  "tokio-util",
  "toml",
@@ -4334,17 +4437,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width",
 ]
 
 [[package]]
@@ -4693,20 +4785,20 @@ dependencies = [
 
 [[package]]
 name = "tui-realm-stdlib"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f252bf8b07c6fd708ddd6349b5f044ae5b488b26929c745728d9c7e2cebfa6"
+checksum = "50ad506e872692d85265328353d92f4f633dd5add7f73ebd93e8d0368a708447"
 dependencies = [
- "textwrap 0.15.2",
+ "textwrap",
  "tuirealm",
  "unicode-width",
 ]
 
 [[package]]
 name = "tui-realm-treeview"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1897a2074c8a5162968961a1a00b5378b2cdda5ce043cb13920801e91898e672"
+checksum = "f3d2d6c059f6adbb2ba7194ab50765dac793cb98fae097e0bb5bf8c23ffaf27c"
 dependencies = [
  "orange-trees",
  "tuirealm",
@@ -4715,13 +4807,14 @@ dependencies = [
 
 [[package]]
 name = "tuirealm"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265411b5606f400459af94fbc5aae6a7bc0e98094d08cb5868390c932be88e26"
+checksum = "c358c39cb9e1b45702ea46afc77d39589d720ca9cf5f1e11a3106342ea6a4e76"
 dependencies = [
- "bitflags 1.3.2",
- "crossterm 0.25.0",
+ "bitflags 2.6.0",
+ "crossterm 0.27.0",
  "lazy-regex",
+ "ratatui",
  "serde",
  "thiserror",
  "tui",
@@ -4797,6 +4890,17 @@ name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,9 +101,9 @@ toml = "0.8"
 prost = "0.13"
 tonic = "0.12"
 tonic-build = "0.12"
-tuirealm = { version = "~1.8", features = ["serialize"] }
-tui-realm-stdlib = "~1.2"
-tui-realm-treeview = "~1.1"
+tuirealm = { version = "~1.9.2", default-features = false, features = ["derive", "serialize", "tui", "crossterm"] }
+tui-realm-stdlib = { version = "~1.3", default-features = false, features = ["tui", "crossterm"] }
+tui-realm-treeview = { version = "~1.2", default-features = false, features = ["tui", "crossterm"] }
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,9 +101,9 @@ toml = "0.8"
 prost = "0.13"
 tonic = "0.12"
 tonic-build = "0.12"
-tuirealm = { version = "~1.9.2", features = ["serialize"] }
-tui-realm-stdlib = "~1.3"
-tui-realm-treeview = "~1.2"
+tuirealm = { version = "~2.0.3", features = ["serialize"] }
+tui-realm-stdlib = "~2.0"
+tui-realm-treeview = "~2.0"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,9 +101,9 @@ toml = "0.8"
 prost = "0.13"
 tonic = "0.12"
 tonic-build = "0.12"
-tuirealm = { version = "~1.9.2", default-features = false, features = ["derive", "serialize", "tui", "crossterm"] }
-tui-realm-stdlib = { version = "~1.3", default-features = false, features = ["tui", "crossterm"] }
-tui-realm-treeview = { version = "~1.2", default-features = false, features = ["tui", "crossterm"] }
+tuirealm = { version = "~1.9.2", features = ["serialize"] }
+tui-realm-stdlib = "~1.3"
+tui-realm-treeview = "~1.2"
 unicode-segmentation = "1.10"
 unicode-width = "^0.1.8"
 urlencoding = "2.1"

--- a/lib/src/config/v1/key.rs
+++ b/lib/src/config/v1/key.rs
@@ -342,6 +342,22 @@ mod key_serde_code {
                 Key::KeypadBegin => KeySerde::KeypadBegin,
                 Key::Media(v) => KeySerde::Media(v.into()),
                 Key::Esc => KeySerde::Esc,
+
+                // the following are new events with tuirealm 2.0, but only available in backend "termion", which we dont use
+                Key::ShiftLeft
+                | Key::AltLeft
+                | Key::CtrlLeft
+                | Key::ShiftRight
+                | Key::AltRight
+                | Key::CtrlRight
+                | Key::ShiftUp
+                | Key::AltUp
+                | Key::CtrlUp
+                | Key::ShiftDown
+                | Key::AltDown
+                | Key::CtrlDown
+                | Key::CtrlHome
+                | Key::CtrlEnd => unimplemented!(),
             }
         }
     }
@@ -512,6 +528,22 @@ impl BindingForEvent {
             Key::Menu => "Menu".to_string(),
             Key::KeypadBegin => "KeyPadBegin".to_string(),
             Key::Media(media_key) => format!("Media {media_key:?}"),
+
+            // the following are new events with tuirealm 2.0, but only available in backend "termion", which we dont use
+            Key::ShiftLeft
+            | Key::AltLeft
+            | Key::CtrlLeft
+            | Key::ShiftRight
+            | Key::AltRight
+            | Key::CtrlRight
+            | Key::ShiftUp
+            | Key::AltUp
+            | Key::CtrlUp
+            | Key::ShiftDown
+            | Key::AltDown
+            | Key::CtrlDown
+            | Key::CtrlHome
+            | Key::CtrlEnd => unimplemented!(),
         }
     }
 

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1725,6 +1725,22 @@ impl Display for KeyWrap {
 
             // i literally have no clue what key this is supposed to be
             tuievents::Key::KeypadBegin => unimplemented!(),
+
+            // the following are new events with tuirealm 2.0, but only available in backend "termion", which we dont use
+            tuievents::Key::ShiftLeft
+            | tuievents::Key::AltLeft
+            | tuievents::Key::CtrlLeft
+            | tuievents::Key::ShiftRight
+            | tuievents::Key::AltRight
+            | tuievents::Key::CtrlRight
+            | tuievents::Key::ShiftUp
+            | tuievents::Key::AltUp
+            | tuievents::Key::CtrlUp
+            | tuievents::Key::ShiftDown
+            | tuievents::Key::AltDown
+            | tuievents::Key::CtrlDown
+            | tuievents::Key::CtrlHome
+            | tuievents::Key::CtrlEnd => unimplemented!(),
         }
     }
 }

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -32,7 +32,7 @@ use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
     Alignment, BorderType, Borders, Color, InputType, Style, TableBuilder, TextModifiers, TextSpan,
 };
-use tuirealm::tui::style::Modifier;
+use tuirealm::ratatui::style::Modifier;
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
 
 const COLOR_LIST: [ColorTermusic; 19] = [

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -30,7 +30,8 @@ use termusiclib::types::{ConfigEditorMsg, IdKey, KFMsg, Msg};
 use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::tui::widgets::ListDirection;
+use tuirealm::ratatui::layout::Position as LayoutPosition;
+use tuirealm::ratatui::widgets::ListDirection;
 use tuirealm::{Component, Event, Frame, MockComponent, State, StateValue};
 use unicode_width::UnicodeWidthStr;
 
@@ -38,7 +39,7 @@ use tuirealm::props::{
     Alignment, AttrValue, Attribute, BorderSides, BorderType, Borders, Color, PropPayload,
     PropValue, Props, Style, TextModifiers,
 };
-use tuirealm::tui::{
+use tuirealm::ratatui::{
     layout::{Constraint, Direction as LayoutDirection, Layout, Rect},
     text::Span,
     widgets::{Block, List, ListItem, ListState, Paragraph},
@@ -752,7 +753,7 @@ impl KeyCombo {
                 + calc_utf8_cursor_position(
                     &self.states_input.render_value_chars()[0..self.states_input.cursor],
                 );
-            render.set_cursor(x, area.y + 1);
+            render.set_cursor_position(LayoutPosition { x, y: area.y + 1 });
         }
     }
 

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -30,6 +30,7 @@ use termusiclib::types::{ConfigEditorMsg, IdKey, KFMsg, Msg};
 use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
+use tuirealm::tui::widgets::ListDirection;
 use tuirealm::{Component, Event, Frame, MockComponent, State, StateValue};
 use unicode_width::UnicodeWidthStr;
 
@@ -38,8 +39,8 @@ use tuirealm::props::{
     PropValue, Props, Style, TextModifiers,
 };
 use tuirealm::tui::{
-    layout::{Constraint, Corner, Direction as LayoutDirection, Layout, Rect},
-    text::Spans,
+    layout::{Constraint, Direction as LayoutDirection, Layout, Rect},
+    text::Span,
     widgets::{Block, List, ListItem, ListState, Paragraph},
 };
 
@@ -467,7 +468,7 @@ impl KeyCombo {
             .states
             .choices
             .iter()
-            .map(|x| ListItem::new(Spans::from(x.clone())))
+            .map(|x| ListItem::new(Span::from(x.clone())))
             .collect();
         let mut foreground = self
             .props
@@ -567,7 +568,7 @@ impl KeyCombo {
         }
         let mut list = List::new(choices)
             .block(block)
-            .start_corner(Corner::TopLeft)
+            .direction(ListDirection::TopToBottom)
             .style(Style::default().fg(foreground).bg(background))
             .highlight_style(
                 Style::default()

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -70,8 +70,8 @@ use std::path::PathBuf;
 use termusiclib::config::v2::tui::Alignment as XywhAlign;
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{PropPayload, PropValue, TableBuilder, TextSpan};
-use tuirealm::tui::layout::{Constraint, Direction, Layout};
-use tuirealm::tui::widgets::Clear;
+use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::widgets::Clear;
 use tuirealm::{AttrValue, Attribute, Frame, State, StateValue};
 
 impl Model {
@@ -91,7 +91,7 @@ impl Model {
                         ]
                         .as_ref(),
                     )
-                    .split(f.size());
+                    .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
@@ -234,12 +234,12 @@ impl Model {
     fn view_config_editor_commons(f: &mut Frame<'_>, app: &mut Application<Id, Msg, NoUserEvent>) {
         // -- popups
         if app.mounted(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup)) {
-            let popup = draw_area_in_absolute(f.size(), 50, 3);
+            let popup = draw_area_in_absolute(f.area(), 50, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup), f, popup);
         }
         if app.mounted(&Id::ErrorPopup) {
-            let popup = draw_area_in_absolute(f.size(), 50, 4);
+            let popup = draw_area_in_absolute(f.area(), 50, 4);
             f.render_widget(Clear, popup);
             app.view(&Id::ErrorPopup, f, popup);
         }
@@ -414,7 +414,7 @@ impl Model {
                         ]
                         .as_ref(),
                     )
-                    .split(f.size());
+                    .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
@@ -964,7 +964,7 @@ impl Model {
                         ]
                         .as_ref(),
                     )
-                    .split(f.size());
+                    .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
@@ -1465,7 +1465,7 @@ impl Model {
                         ]
                         .as_ref(),
                     )
-                    .split(f.size());
+                    .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -641,7 +641,7 @@ impl Model {
                         .add_col(TextSpan::new(duration_string.as_str()))
                         .add_col(
                             TextSpan::new(record.artist)
-                                .fg(tuirealm::tui::style::Color::LightYellow),
+                                .fg(tuirealm::ratatui::style::Color::LightYellow),
                         )
                         .add_col(TextSpan::new(record.title).bold())
                         .add_col(TextSpan::new(record.file));

--- a/tui/src/ui/components/labels.rs
+++ b/tui/src/ui/components/labels.rs
@@ -30,7 +30,7 @@ use tuirealm::event::NoUserEvent;
 use tuirealm::props::{
     Alignment, AttrValue, Attribute, PropPayload, PropValue, TextModifiers, TextSpan,
 };
-use tuirealm::tui::layout::Rect;
+use tuirealm::ratatui::layout::Rect;
 use tuirealm::{Component, Event, Frame, MockComponent, State};
 
 #[derive(MockComponent)]

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -15,13 +15,17 @@ use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, Sta
 
 #[derive(MockComponent)]
 pub struct MusicLibrary {
-    component: TreeView,
+    component: TreeView<String>,
     config: SharedTuiSettings,
     pub init: bool,
 }
 
 impl MusicLibrary {
-    pub fn new(tree: &Tree, initial_node: Option<String>, config: SharedTuiSettings) -> Self {
+    pub fn new(
+        tree: &Tree<String>,
+        initial_node: Option<String>,
+        config: SharedTuiSettings,
+    ) -> Self {
         // Preserve initial node if exists
         let initial_node = match initial_node {
             Some(id) if tree.root().query(&id).is_some() => id,
@@ -246,12 +250,12 @@ impl Model {
             .map(std::path::Path::to_path_buf)
     }
 
-    pub fn library_dir_tree(p: &Path, depth: ScanDepth) -> Node {
+    pub fn library_dir_tree(p: &Path, depth: ScanDepth) -> Node<String> {
         let name: String = match p.file_name() {
             None => "/".to_string(),
             Some(n) => n.to_string_lossy().into_owned(),
         };
-        let mut node: Node = Node::new(p.to_string_lossy().into_owned(), name);
+        let mut node: Node<String> = Node::new(p.to_string_lossy().into_owned(), name);
 
         let depth = match depth {
             ScanDepth::Limited(v) => v,

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -430,7 +430,7 @@ impl Model {
 
             table
                 .add_col(TextSpan::new(duration_string.as_str()))
-                .add_col(TextSpan::new(artist).fg(tuirealm::tui::style::Color::LightYellow))
+                .add_col(TextSpan::new(artist).fg(tuirealm::ratatui::style::Color::LightYellow))
                 .add_col(TextSpan::new(title).bold())
                 .add_col(TextSpan::new(album));
         }
@@ -546,7 +546,7 @@ impl Model {
 
                 table
                     .add_col(TextSpan::new(duration_string.as_str()))
-                    .add_col(TextSpan::new(artist).fg(tuirealm::tui::style::Color::LightYellow))
+                    .add_col(TextSpan::new(artist).fg(tuirealm::ratatui::style::Color::LightYellow))
                     .add_col(TextSpan::new(title).bold())
                     .add_col(TextSpan::new(file_name));
                 // .add_col(TextSpan::new(record.album().unwrap_or("Unknown Album")));

--- a/tui/src/ui/components/popups/message.rs
+++ b/tui/src/ui/components/popups/message.rs
@@ -25,7 +25,7 @@ impl MessagePopup {
                 // .background(Color::Black)
                 .modifiers(TextModifiers::BOLD)
                 .alignment(Alignment::Center)
-                .title(title, Alignment::Center)
+                .title(title.as_ref(), Alignment::Center)
                 .text(vec![TextSpan::from(msg.as_ref().to_string())].as_slice()),
         }
     }

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -26,8 +26,8 @@ use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{Alignment, Borders, Color, Style, TextModifiers};
-use tuirealm::tui::layout::Rect;
-use tuirealm::tui::widgets::{BorderType, Paragraph};
+use tuirealm::ratatui::layout::Rect;
+use tuirealm::ratatui::widgets::{BorderType, Paragraph};
 use tuirealm::{
     AttrValue, Attribute, Component, Event, Frame, MockComponent, Props, State, StateValue,
 };

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -190,7 +190,7 @@ impl Model {
             }
 
             table
-                .add_col(TextSpan::new(artist).fg(tuirealm::tui::style::Color::LightYellow))
+                .add_col(TextSpan::new(artist).fg(tuirealm::ratatui::style::Color::LightYellow))
                 .add_col(TextSpan::new(title).bold())
                 .add_col(TextSpan::new(album))
                 .add_col(TextSpan::new(api))

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -33,8 +33,8 @@ use std::path::Path;
 use termusiclib::track::Track;
 use termusiclib::types::{Id, IdTagEditor};
 use tuirealm::props::{Alignment, AttrValue, Attribute, PropPayload, PropValue, TextSpan};
-use tuirealm::tui::layout::{Constraint, Direction, Layout};
-use tuirealm::tui::widgets::Clear;
+use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::widgets::Clear;
 use tuirealm::State;
 
 impl Model {
@@ -49,7 +49,7 @@ impl Model {
                         _ => 8,
                     };
                 if self.app.mounted(&Id::TagEditor(IdTagEditor::LabelHint)) {
-                    f.render_widget(Clear, f.size());
+                    f.render_widget(Clear, f.area());
                     let chunks_main = Layout::default()
                         .direction(Direction::Vertical)
                         .margin(0)
@@ -64,7 +64,7 @@ impl Model {
                             ]
                             .as_ref(),
                         )
-                        .split(f.size());
+                        .split(f.area());
 
                     let chunks_row1 = Layout::default()
                         .direction(Direction::Horizontal)
@@ -158,12 +158,12 @@ impl Model {
                     );
 
                     if self.app.mounted(&Id::MessagePopup) {
-                        let popup = draw_area_top_right_absolute(f.size(), 25, 4);
+                        let popup = draw_area_top_right_absolute(f.area(), 25, 4);
                         f.render_widget(Clear, popup);
                         self.app.view(&Id::MessagePopup, f, popup);
                     }
                     if self.app.mounted(&Id::ErrorPopup) {
-                        let popup = draw_area_in_absolute(f.size(), 50, 4);
+                        let popup = draw_area_in_absolute(f.area(), 50, 4);
                         f.render_widget(Clear, popup);
                         self.app.view(&Id::ErrorPopup, f, popup);
                     }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -121,7 +121,7 @@ impl UI {
                 progress_interval = 0;
             }
 
-            match self.model.app.tick(PollStrategy::Once) {
+            match self.model.app.tick(PollStrategy::UpTo(20)) {
                 Err(err) => {
                     self.model
                         .mount_error_popup((anyhow::anyhow!(err)).context("tick poll error"));

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -53,7 +53,7 @@ use termusicplayback::{PlayerCmd, Playlist};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
-use tuirealm::terminal::TerminalBridge;
+use tuirealm::terminal::{CrosstermTerminalAdapter, TerminalBridge};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TermusicLayout {
@@ -76,7 +76,7 @@ pub struct MusicLibraryData {
     /// Current Path that the library-tree is in
     pub tree_path: PathBuf,
     /// Tree of the Music Library widget
-    pub tree: Tree,
+    pub tree: Tree<String>,
     /// The Node that a yank & paste was started on
     pub yanked_node_id: Option<String>,
 }
@@ -139,7 +139,7 @@ pub struct Model {
     last_redraw: Instant,
     pub app: Application<Id, Msg, NoUserEvent>,
     /// Used to draw to terminal
-    pub terminal: TerminalBridge,
+    pub terminal: TerminalBridge<CrosstermTerminalAdapter>,
     pub tx_to_main: Sender<Msg>,
     pub rx_to_main: Receiver<Msg>,
     /// Sender for Player Commands
@@ -213,6 +213,7 @@ impl Model {
             tui: config_tui,
         } = config;
         let path = Self::get_full_path_from_config(&config_server.read());
+        // TODO: refactor music library tree to be Paths instead?
         let tree = Tree::new(Self::library_dir_tree(
             &path,
             config_server.read().get_library_scan_depth(),
@@ -223,7 +224,7 @@ impl Model {
         let viuer_supported = get_viuer_support();
         let db = DataBase::new(&config_server.read()).expect("Open Library Database");
         let db_criteria = SearchCriteria::Artist;
-        let terminal = TerminalBridge::new().expect("Could not initialize terminal");
+        let terminal = TerminalBridge::new_crossterm().expect("Could not initialize terminal");
 
         #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
         let ueberzug_instance = UeInstance::default();
@@ -347,7 +348,8 @@ impl Model {
     pub fn init_terminal(&mut self) {
         let original_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |panic| {
-            let mut terminal_clone = TerminalBridge::new().expect("Could not initialize terminal");
+            let mut terminal_clone =
+                TerminalBridge::new_crossterm().expect("Could not initialize terminal");
             let _drop = terminal_clone.disable_raw_mode();
             let _drop = terminal_clone.leave_alternate_screen();
             original_hook(panic);

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -356,6 +356,8 @@ impl Model {
         }));
         let _drop = self.terminal.enable_raw_mode();
         let _drop = self.terminal.enter_alternate_screen();
+        // required as "enter_alternate_screen" always enabled mouse-capture
+        let _drop = self.terminal.disable_mouse_capture();
         let _drop = self.terminal.clear_screen();
     }
 

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -39,14 +39,17 @@ use termusiclib::utils::get_parent_folder;
 use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
 use tuirealm::props::{AttrValue, Attribute, Color, PropPayload, PropValue, TextSpan};
-use tuirealm::tui::layout::{Constraint, Direction, Layout};
-use tuirealm::tui::widgets::Clear;
+use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::widgets::Clear;
 use tuirealm::EventListenerCfg;
 use tuirealm::{Frame, State, StateValue};
 
 impl Model {
     #[allow(clippy::too_many_lines)]
-    pub fn init_app(tree: &Tree, config: &SharedTuiSettings) -> Application<Id, Msg, NoUserEvent> {
+    pub fn init_app(
+        tree: &Tree<String>,
+        config: &SharedTuiSettings,
+    ) -> Application<Id, Msg, NoUserEvent> {
         // Setup application
         // NOTE: NoUserEvent is a shorthand to tell tui-realm we're not going to use any custom user event
         // NOTE: the event listener is configured to use the default crossterm input listener and to raise a Tick event each second
@@ -54,7 +57,7 @@ impl Model {
 
         let mut app: Application<Id, Msg, NoUserEvent> = Application::init(
             EventListenerCfg::default()
-                .default_input_listener(Duration::from_millis(20))
+                .crossterm_input_listener(Duration::from_millis(20), 20)
                 .poll_timeout(Duration::from_millis(10))
                 .tick_interval(Duration::from_secs(1)),
         );
@@ -204,7 +207,7 @@ impl Model {
                         ]
                         .as_ref(),
                     )
-                    .split(f.size());
+                    .split(f.area());
                 let chunks_center = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
@@ -241,7 +244,7 @@ impl Model {
                     .direction(Direction::Vertical)
                     .margin(0)
                     .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
-                    .split(f.size());
+                    .split(f.area());
                 let chunks_left = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
@@ -296,7 +299,7 @@ impl Model {
                     .direction(Direction::Vertical)
                     .margin(0)
                     .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
-                    .split(f.size());
+                    .split(f.area());
                 let chunks_left = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
@@ -338,7 +341,7 @@ impl Model {
                 .direction(Direction::Vertical)
                 .margin(0)
                 .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
-                .split(f.size());
+                .split(f.area());
             let chunks_footer = Layout::default()
                 .direction(Direction::Horizontal)
                 .margin(0)
@@ -359,37 +362,37 @@ impl Model {
                 .direction(Direction::Vertical)
                 .margin(0)
                 .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
-                .split(f.size());
+                .split(f.area());
             app.view(&Id::Label, f, chunks_main[1]);
         }
 
         // -- popups
         if app.mounted(&Id::QuitPopup) {
-            let popup = draw_area_in_absolute(f.size(), 30, 3);
+            let popup = draw_area_in_absolute(f.area(), 30, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::QuitPopup, f, popup);
         } else if app.mounted(&Id::HelpPopup) {
-            let popup = draw_area_in_relative(f.size(), 88, 91);
+            let popup = draw_area_in_relative(f.area(), 88, 91);
             f.render_widget(Clear, popup);
             app.view(&Id::HelpPopup, f, popup);
         } else if app.mounted(&Id::DeleteConfirmRadioPopup) {
-            let popup = draw_area_in_absolute(f.size(), 30, 3);
+            let popup = draw_area_in_absolute(f.area(), 30, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::DeleteConfirmRadioPopup, f, popup);
         } else if app.mounted(&Id::DeleteConfirmInputPopup) {
-            let popup = draw_area_in_absolute(f.size(), 30, 3);
+            let popup = draw_area_in_absolute(f.area(), 30, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::DeleteConfirmInputPopup, f, popup);
         } else if app.mounted(&Id::FeedDeleteConfirmRadioPopup) {
-            let popup = draw_area_in_absolute(f.size(), 60, 3);
+            let popup = draw_area_in_absolute(f.area(), 60, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::FeedDeleteConfirmRadioPopup, f, popup);
         } else if app.mounted(&Id::FeedDeleteConfirmInputPopup) {
-            let popup = draw_area_in_absolute(f.size(), 60, 3);
+            let popup = draw_area_in_absolute(f.area(), 60, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::FeedDeleteConfirmInputPopup, f, popup);
         } else if app.mounted(&Id::GeneralSearchInput) {
-            let popup = draw_area_in_relative(f.size(), 65, 68);
+            let popup = draw_area_in_relative(f.area(), 65, 68);
             f.render_widget(Clear, popup);
             let popup_chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -404,19 +407,19 @@ impl Model {
             app.view(&Id::GeneralSearchInput, f, popup_chunks[0]);
             app.view(&Id::GeneralSearchTable, f, popup_chunks[1]);
         } else if app.mounted(&Id::YoutubeSearchInputPopup) {
-            let popup = draw_area_in_absolute(f.size(), 50, 3);
+            let popup = draw_area_in_absolute(f.area(), 50, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::YoutubeSearchInputPopup, f, popup);
         } else if app.mounted(&Id::YoutubeSearchTablePopup) {
-            let popup = draw_area_in_relative(f.size(), 65, 68);
+            let popup = draw_area_in_relative(f.area(), 65, 68);
             f.render_widget(Clear, popup);
             app.view(&Id::YoutubeSearchTablePopup, f, popup);
         } else if app.mounted(&Id::PodcastSearchTablePopup) {
-            let popup = draw_area_in_relative(f.size(), 65, 68);
+            let popup = draw_area_in_relative(f.area(), 65, 68);
             f.render_widget(Clear, popup);
             app.view(&Id::PodcastSearchTablePopup, f, popup);
         } else if app.mounted(&Id::SavePlaylistPopup) {
-            let popup = draw_area_in_absolute(f.size(), 76, 6);
+            let popup = draw_area_in_absolute(f.area(), 76, 6);
             f.render_widget(Clear, popup);
             let popup_chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -425,21 +428,21 @@ impl Model {
             app.view(&Id::SavePlaylistPopup, f, popup_chunks[0]);
             app.view(&Id::SavePlaylistLabel, f, popup_chunks[1]);
         } else if app.mounted(&Id::SavePlaylistConfirm) {
-            let popup = draw_area_in_absolute(f.size(), 40, 3);
+            let popup = draw_area_in_absolute(f.area(), 40, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::SavePlaylistConfirm, f, popup);
         } else if app.mounted(&Id::PodcastAddPopup) {
-            let popup = draw_area_in_absolute(f.size(), 65, 3);
+            let popup = draw_area_in_absolute(f.area(), 65, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::PodcastAddPopup, f, popup);
         }
         if app.mounted(&Id::MessagePopup) {
-            let popup = draw_area_top_right_absolute(f.size(), 25, 4);
+            let popup = draw_area_top_right_absolute(f.area(), 25, 4);
             f.render_widget(Clear, popup);
             app.view(&Id::MessagePopup, f, popup);
         }
         if app.mounted(&Id::ErrorPopup) {
-            let popup = draw_area_in_absolute(f.size(), 50, 4);
+            let popup = draw_area_in_absolute(f.area(), 50, 4);
             f.render_widget(Clear, popup);
             app.view(&Id::ErrorPopup, f, popup);
         }

--- a/tui/src/ui/utils.rs
+++ b/tui/src/ui/utils.rs
@@ -1,4 +1,4 @@
-use tuirealm::tui::layout::{Constraint, Direction, Layout, Rect};
+use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 ///
 /// Get block

--- a/tui/src/ui/utils.rs
+++ b/tui/src/ui/utils.rs
@@ -101,7 +101,7 @@ mod tests {
         let child: Rect = draw_area_in_relative(area, 75, 30);
         assert_eq!(child.x, 43);
         assert_eq!(child.y, 63);
-        assert_eq!(child.width, 271);
-        assert_eq!(child.height, 54);
+        assert_eq!(child.width, 272);
+        assert_eq!(child.height, 55);
     }
 }


### PR DESCRIPTION
This PR updates to tui-realm 2.0 (and related component crates).

tuirealm 1.9 had been known to be laggy (see #237) and we also had config migration trouble, but now we have config translation in-place without being dependent on tuirealm and they have also fixed all the problems that we had encountered:
- Mouse capture enabled by default, but not actual events for it
- no way to disable mouse capture
- events were only polled *once* per event loop, while mouse capture events can generate ~20 events in 50ms