### PR TITLE
Fix Track's tag parsing if there is no primary tag, but a different one & Enable aiff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)
 - Feat: more immediate event changes (Example: updated via mpris)
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
+- Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Unreleased
 - Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)
 - Feat: more immediate event changes (Example: updated via mpris)
+- Feat(server): on rusty backend, enable `aiff` codec support.
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,13 +82,14 @@ soundtouch = "0.4.2"
 souvlaki = { version = "0.7.3", default-features=false, features = ["use_zbus"] }
 stream-download = { version = "0.7.2", features = ["reqwest-rustls"] }
 symphonia = { version = "0.5.1", features = [
-    "default",
     "aac",
     "mp3",
     "isomp4",
     "alac",
     "flac",
     "mkv",
+    "wav",
+    "aiff"
 ] }
 sysinfo = { version = "^0.31", default-features = false, features = ["system"] }
 tempfile = "3.10"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In the case that metadata is not supported, an attempt will still be made to pla
 | Format (`feature`) | Symphonia (`rusty`)     | Mpv (`mpv`) | Gstreamer (`gst`) | Metadata |
 | ------------------ | ----------------------- | ----------- | ----------------- | -------- |
 | ADTS               | Yes                     | Yes         | Yes               | No       |
-| AIFF               | No                      | Yes         | Yes               | Yes      |
+| AIFF               | Yes                     | Yes         | Yes               | Yes      |
 | FLAC               | Yes                     | Yes         | Yes               | Yes      |
 | M4a                | Yes                     | Yes         | Yes               | Yes      |
 | MP3                | Yes                     | Yes         | Yes               | Yes      |

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -127,6 +127,9 @@ impl Track {
         }
     }
 
+    /// Read all metadata from a given `path` and process them into a new [`Track`]
+    ///
+    /// Setting `for_db` to `true` skips lyric and picture processing
     pub fn read_from_path<P: AsRef<Path>>(path: P, for_db: bool) -> Result<Self> {
         let path = path.as_ref();
 
@@ -141,65 +144,11 @@ impl Track {
             song.file_type = Some(tagged_file.file_type());
 
             if let Some(tag) = tagged_file.primary_tag_mut() {
-                // Check for a length tag (Ex. TLEN in ID3v2)
-                if let Some(len_tag) = tag.get_string(&ItemKey::Length) {
-                    song.duration = Duration::from_millis(len_tag.parse::<u64>()?);
-                }
-
-                song.artist = tag.artist().map(std::borrow::Cow::into_owned);
-                song.album = tag.album().map(std::borrow::Cow::into_owned);
-                song.title = tag.title().map(std::borrow::Cow::into_owned);
-                song.genre = tag.genre().map(std::borrow::Cow::into_owned);
-                song.media_type = MediaType::Music;
-
-                if for_db {
-                    return Ok(song);
-                }
-
-                // Get all of the lyrics tags
-                let mut lyric_frames: Vec<Lyrics> = Vec::new();
-                match file_type {
-                    Some(FileType::Mpeg) => {
-                        let mut reader = BufReader::new(File::open(path)?);
-                        // let file = MPEGFile::read_from(&mut reader, false)?;
-                        let file = MpegFile::read_from(&mut reader, ParseOptions::new())?;
-
-                        if let Some(id3v2_tag) = file.id3v2() {
-                            for lyrics_frame in id3v2_tag.unsync_text() {
-                                let mut language =
-                                    String::from_utf8_lossy(&lyrics_frame.language).to_string();
-                                if language.len() < 3 {
-                                    language = "eng".to_string();
-                                }
-                                lyric_frames.push(Lyrics {
-                                    lang: language,
-                                    description: lyrics_frame.description.clone(),
-                                    text: lyrics_frame.content.clone(),
-                                });
-                            }
-                        }
-                    }
-                    _ => {
-                        create_lyrics(tag, &mut lyric_frames);
-                    }
-                };
-                song.parsed_lyric = lyric_frames
-                    .first()
-                    .map(|lf| Lyric::from_str(&lf.text).ok())
-                    .and_then(|pl| pl);
-                song.lyric_frames = lyric_frames;
-
-                // Get the picture (not necessarily the front cover)
-                let mut picture = tag
-                    .pictures()
-                    .iter()
-                    .find(|pic| pic.pic_type() == PictureType::CoverFront)
-                    .cloned();
-                if picture.is_none() {
-                    picture = tag.pictures().first().cloned();
-                }
-
-                song.picture = picture;
+                Self::process_tag(path, tag, &mut song, &file_type, for_db)?;
+            } else if let Some(tag) = tagged_file.first_tag_mut() {
+                Self::process_tag(path, tag, &mut song, &file_type, for_db)?;
+            } else {
+                warn!("File \"{}\" does not have any tags!", path.display());
             }
         }
 
@@ -217,6 +166,77 @@ impl Track {
         }
 
         Ok(song)
+    }
+
+    /// Process a given [`LoftyTag`] into the given `track`
+    fn process_tag(
+        path: &Path,
+        tag: &mut LoftyTag,
+        track: &mut Track,
+        file_type: &Option<FileType>,
+        for_db: bool,
+    ) -> Result<()> {
+        // Check for a length tag (Ex. TLEN in ID3v2)
+        if let Some(len_tag) = tag.get_string(&ItemKey::Length) {
+            track.duration = Duration::from_millis(len_tag.parse::<u64>()?);
+        }
+
+        track.artist = tag.artist().map(std::borrow::Cow::into_owned);
+        track.album = tag.album().map(std::borrow::Cow::into_owned);
+        track.title = tag.title().map(std::borrow::Cow::into_owned);
+        track.genre = tag.genre().map(std::borrow::Cow::into_owned);
+        track.media_type = MediaType::Music;
+
+        if for_db {
+            return Ok(());
+        }
+
+        // Get all of the lyrics tags
+        let mut lyric_frames: Vec<Lyrics> = Vec::new();
+        match file_type {
+            Some(FileType::Mpeg) => {
+                let mut reader = BufReader::new(File::open(path)?);
+                // let file = MPEGFile::read_from(&mut reader, false)?;
+                let file = MpegFile::read_from(&mut reader, ParseOptions::new())?;
+
+                if let Some(id3v2_tag) = file.id3v2() {
+                    for lyrics_frame in id3v2_tag.unsync_text() {
+                        let mut language =
+                            String::from_utf8_lossy(&lyrics_frame.language).to_string();
+                        if language.len() < 3 {
+                            language = "eng".to_string();
+                        }
+                        lyric_frames.push(Lyrics {
+                            lang: language,
+                            description: lyrics_frame.description.clone(),
+                            text: lyrics_frame.content.clone(),
+                        });
+                    }
+                }
+            }
+            _ => {
+                create_lyrics(tag, &mut lyric_frames);
+            }
+        };
+        track.parsed_lyric = lyric_frames
+            .first()
+            .map(|lf| Lyric::from_str(&lf.text).ok())
+            .and_then(|pl| pl);
+        track.lyric_frames = lyric_frames;
+
+        // Get the picture (not necessarily the front cover)
+        let mut picture = tag
+            .pictures()
+            .iter()
+            .find(|pic| pic.pic_type() == PictureType::CoverFront)
+            .cloned();
+        if picture.is_none() {
+            picture = tag.pictures().first().cloned();
+        }
+
+        track.picture = picture;
+
+        Ok(())
     }
 
     pub fn new_radio(url: &str) -> Self {


### PR DESCRIPTION
This PR fixes a issue where a Track's tag parsing was only looking for the primary tag type lofty sets for that file type, which could lead to errors.
Example: in lofty, `wav` files are set to have `Id3v2` as the primary tags type, but if it only has riff tag type, termusic would not parse anything.

Additionally, this PR enables symphonia's `aiff` support.