### PR TITLE
`lib::track::Track` refactor

### DIFF
--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -36,7 +36,7 @@ use track_db::TrackDBInsertable;
 mod migration;
 mod track_db;
 
-pub use track_db::TrackDB;
+pub use track_db::{const_unknown, TrackDB};
 
 pub struct DataBase {
     conn: Arc<Mutex<Connection>>,

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use rusqlite::{named_params, Connection, Row};
 
-use crate::{const_str, track::Track};
+use crate::track::Track;
 
 /// A struct representing a [`Track`](Track) in the database
 #[derive(Clone, Debug)]
@@ -86,13 +86,19 @@ pub struct TrackDBInsertable<'a> {
     pub last_position: Duration,
 }
 
-const_str! {
-    UNKNOWN_ARTIST "Unknown Artist",
-    UNKNOWN_TITLE "Unknown Title",
-    UNKNOWN_ALBUM "empty",
-    UNKNOWN_GENRE "no type",
-    UNKNOWN_FILE "Unknown File",
+/// Constant strings for Unknown values
+pub mod const_unknown {
+    use crate::const_str;
+
+    const_str! {
+        UNKNOWN_ARTIST "Unknown Artist",
+        UNKNOWN_TITLE "Unknown Title",
+        UNKNOWN_ALBUM "empty",
+        UNKNOWN_GENRE "no type",
+        UNKNOWN_FILE "Unknown File",
+    }
 }
+use const_unknown::{UNKNOWN_ALBUM, UNKNOWN_ARTIST, UNKNOWN_FILE, UNKNOWN_GENRE, UNKNOWN_TITLE};
 
 impl<'a> From<&'a Track> for TrackDBInsertable<'a> {
     fn from(value: &'a Track) -> Self {

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -38,7 +38,7 @@ use std::ffi::OsStr;
 use std::fs::rename;
 use std::fs::File;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
@@ -49,25 +49,35 @@ use std::time::{Duration, SystemTime};
 #[allow(unused)]
 pub const UNSUPPORTED: &str = "Unsupported?";
 
-// TODO: add some kind of identifier for easy printing, like a uri that is NOT optional
+/// Location types for a Track, could be a local file with [`LocationType::Path`] or a remote URI with [`LocationType::Uri`]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LocationType {
+    /// A Local file, for use with [`MediaType::Music`]
+    Path(PathBuf),
+    /// A remote URI, for use with [`MediaType::LiveRadio`] and [`MediaType::Podcast`]
+    Uri(String),
+}
+
+impl From<PathBuf> for LocationType {
+    fn from(value: PathBuf) -> Self {
+        Self::Path(value)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Track {
+    /// The URI or the Path of the file
+    location: LocationType,
+    pub media_type: MediaType,
+
     /// Artist of the song
     artist: Option<String>,
     /// Album of the song
     album: Option<String>,
     /// Title of the song
     title: Option<String>,
-    /// File path to the song
-    // TODO: why is this a http(s) url in Radio case?
-    file: Option<String>,
     /// Duration of the song
     duration: Duration,
-    /// Name of the song
-    name: Option<String>,
-    /// Extension of the song
-    ext: Option<String>,
-    directory: Option<String>,
     pub last_modified: SystemTime,
     /// USLT lyrics
     lyric_frames: Vec<Lyrics>,
@@ -83,13 +93,12 @@ pub struct Track {
     // Performer
     // Disc
     // Comment
-    pub media_type: MediaType,
     pub podcast_localfile: Option<String>,
 }
 
 impl PartialEq for Track {
     fn eq(&self, other: &Self) -> bool {
-        self.file == other.file
+        self.location == other.location
     }
 }
 
@@ -101,6 +110,7 @@ pub enum MediaType {
 }
 
 impl Track {
+    /// Create a new [`MediaType::Podcast`] track
     #[allow(clippy::cast_sign_loss)]
     pub fn from_episode(ep: &Episode) -> Self {
         let lyric_frames: Vec<Lyrics> = Vec::new();
@@ -114,13 +124,9 @@ impl Track {
         Self {
             artist: Some("Episode".to_string()),
             album: None,
-            // album: Some(ep.description.clone()),
             title: Some(ep.title.clone()),
-            file: Some(ep.url.clone()),
+            location: LocationType::Uri(ep.url.clone()),
             duration: Duration::from_secs(ep.duration.unwrap_or(0) as u64),
-            name: None,
-            ext: None,
-            directory: None,
             last_modified: SystemTime::now(),
             lyric_frames,
             lyric_selected_index: 0,
@@ -134,13 +140,14 @@ impl Track {
         }
     }
 
+    /// Create a new [`MediaType::Music`] track
     pub fn read_from_path<P: AsRef<Path>>(path: P, for_db: bool) -> Result<Self> {
         let path = path.as_ref();
 
         let probe = Probe::open(path)?;
         let file_type = probe.file_type();
 
-        let mut song = Self::new(path);
+        let mut song = Self::new(LocationType::Path(path.to_path_buf()), MediaType::Music);
         if let Ok(mut tagged_file) = probe.read() {
             // We can at most get the duration and file type at this point
             let properties = tagged_file.properties();
@@ -226,43 +233,38 @@ impl Track {
         Ok(song)
     }
 
+    /// Create a new [`MediaType::LiveRadio`] track
     pub fn new_radio(url: &str) -> Self {
-        let mut track = Self::new(url);
+        let mut track = Self::new(LocationType::Uri(url.to_string()), MediaType::LiveRadio);
         track.artist = Some("Radio".to_string());
         track.title = Some("Radio Station".to_string());
         track.album = Some("Live".to_string());
-        track.media_type = MediaType::LiveRadio;
-        track.directory = None;
         track
     }
-    fn new<P: AsRef<Path>>(path: P) -> Self {
-        let p = path.as_ref();
-        let directory = Some(get_parent_folder(p).to_string_lossy().to_string());
-        let ext = p.extension().and_then(OsStr::to_str).map(String::from);
-        let title = p.file_stem().and_then(OsStr::to_str).map(String::from);
-        let file = Some(p.to_string_lossy().into_owned());
+
+    fn new(location: LocationType, media_type: MediaType) -> Self {
         let duration = Duration::from_secs(0);
-        let name = p
-            .file_name()
-            .and_then(OsStr::to_str)
-            .map(std::string::ToString::to_string);
         let lyric_frames: Vec<Lyrics> = Vec::new();
         let mut last_modified = SystemTime::now();
-        if let Ok(meta) = p.metadata() {
-            if let Ok(modified) = meta.modified() {
-                last_modified = modified;
+        let mut title = None;
+
+        if let LocationType::Path(path) = &location {
+            if let Ok(meta) = path.metadata() {
+                if let Ok(modified) = meta.modified() {
+                    last_modified = modified;
+                }
             }
+
+            title = path.file_stem().and_then(OsStr::to_str).map(String::from);
         }
+
         Self {
-            ext,
             file_type: None,
             artist: None,
             album: None,
             title,
-            file,
-            directory,
             duration,
-            name,
+            location,
             parsed_lyric: None,
             lyric_frames,
             lyric_selected_index: 0,
@@ -270,7 +272,7 @@ impl Track {
             album_photo: None,
             last_modified,
             genre: None,
-            media_type: MediaType::Music,
+            media_type,
             podcast_localfile: None,
         }
     }
@@ -399,16 +401,31 @@ impl Track {
         self.title = Some(title.to_string());
     }
 
+    /// Get the full Path or URI of the track, if its a local file
     pub fn file(&self) -> Option<&str> {
-        self.file.as_deref()
+        match &self.location {
+            LocationType::Path(path_buf) => path_buf.to_str(),
+            LocationType::Uri(uri) => Some(uri),
+        }
     }
 
+    /// Get the directory the track is in, if its a local file
     pub fn directory(&self) -> Option<&str> {
-        self.directory.as_deref()
+        if let LocationType::Path(path) = &self.location {
+            // not using "utils::get_parent_directory" as if a track is "LocationType::Path", it should have a directory and a file in the path
+            path.parent().and_then(Path::to_str)
+        } else {
+            None
+        }
     }
 
+    /// Get the extension of the track, if its a local file
     pub fn ext(&self) -> Option<&str> {
-        self.ext.as_deref()
+        if let LocationType::Path(path) = &self.location {
+            path.extension().and_then(OsStr::to_str)
+        } else {
+            None
+        }
     }
 
     pub const fn duration(&self) -> Duration {
@@ -431,8 +448,13 @@ impl Track {
         }
     }
 
+    /// Get the `file_name` or the full URI of the current Track
     pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
+        match &self.location {
+            LocationType::Path(path) => path.file_name().and_then(OsStr::to_str),
+            // TODO: should this really return the uri here instead of None?
+            LocationType::Uri(uri) => Some(uri),
+        }
     }
 
     pub fn save_tag(&mut self) -> Result<()> {
@@ -513,7 +535,7 @@ impl Track {
                 if let Some(p_prefix) = p_old.parent() {
                     let p_new = p_prefix.join(new_name_path);
                     rename(p_old, &p_new)?;
-                    self.file = Some(String::from(p_new.to_string_lossy()));
+                    self.location = LocationType::Path(p_new);
                 }
             }
         }

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -247,7 +247,6 @@ impl Track {
             .and_then(OsStr::to_str)
             .map(std::string::ToString::to_string);
         let lyric_frames: Vec<Lyrics> = Vec::new();
-        let genre = Some(String::from("Unknown"));
         let mut last_modified = SystemTime::now();
         if let Ok(meta) = p.metadata() {
             if let Ok(modified) = meta.modified() {
@@ -270,7 +269,7 @@ impl Track {
             picture: None,
             album_photo: None,
             last_modified,
-            genre,
+            genre: None,
             media_type: MediaType::Music,
             podcast_localfile: None,
         }

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -202,7 +202,7 @@ impl Track {
             }
         }
 
-        let parent_folder = get_parent_folder(&path.to_string_lossy());
+        let parent_folder = get_parent_folder(path);
 
         if let Ok(files) = std::fs::read_dir(parent_folder) {
             for f in files.flatten() {
@@ -229,7 +229,7 @@ impl Track {
     }
     fn new<P: AsRef<Path>>(path: P) -> Self {
         let p = path.as_ref();
-        let directory = Some(get_parent_folder(&p.to_string_lossy()));
+        let directory = Some(get_parent_folder(p).to_string_lossy().to_string());
         let ext = p.extension().and_then(OsStr::to_str).map(String::from);
         let artist = Some(String::from("Unsupported?"));
         let album = Some(String::from("Unsupported?"));

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -240,10 +240,7 @@ impl Track {
             .file_name()
             .and_then(OsStr::to_str)
             .map(std::string::ToString::to_string);
-        let parsed_lyric: Option<Lyric> = None;
         let lyric_frames: Vec<Lyrics> = Vec::new();
-        let picture: Option<Picture> = None;
-        let album_photo: Option<String> = None;
         let genre = Some(String::from("Unknown"));
         let mut last_modified = SystemTime::now();
         if let Ok(meta) = p.metadata() {
@@ -261,11 +258,11 @@ impl Track {
             directory,
             duration,
             name,
-            parsed_lyric,
+            parsed_lyric: None,
             lyric_frames,
             lyric_selected_index: 0,
-            picture,
-            album_photo,
+            picture: None,
+            album_photo: None,
             last_modified,
             genre,
             media_type: MediaType::Music,

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -59,7 +59,6 @@ pub struct Track {
     name: Option<String>,
     /// Extension of the song
     ext: Option<String>,
-    // TODO: why is this set to the http(s) url in Radio case?
     directory: Option<String>,
     pub last_modified: SystemTime,
     /// USLT lyrics
@@ -225,6 +224,7 @@ impl Track {
         track.title = Some("Radio Station".to_string());
         track.album = Some("Live".to_string());
         track.media_type = MediaType::LiveRadio;
+        track.directory = None;
         track
     }
     fn new<P: AsRef<Path>>(path: P) -> Self {

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -41,6 +41,13 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
+// TODO: use this for database migration
+/// This is the old string that was used as default for "artist" & "album"
+///
+/// this value is currently unused, but this will stay here as a reminder until the database is migrated
+#[allow(unused)]
+pub const UNSUPPORTED: &str = "Unsupported?";
+
 // TODO: add some kind of identifier for easy printing, like a uri that is NOT optional
 #[derive(Clone, Debug)]
 pub struct Track {
@@ -231,8 +238,6 @@ impl Track {
         let p = path.as_ref();
         let directory = Some(get_parent_folder(p).to_string_lossy().to_string());
         let ext = p.extension().and_then(OsStr::to_str).map(String::from);
-        let artist = Some(String::from("Unsupported?"));
-        let album = Some(String::from("Unsupported?"));
         let title = p.file_stem().and_then(OsStr::to_str).map(String::from);
         let file = Some(p.to_string_lossy().into_owned());
         let duration = Duration::from_secs(0);
@@ -251,8 +256,8 @@ impl Track {
         Self {
             ext,
             file_type: None,
-            artist,
-            album,
+            artist: None,
+            album: None,
             title,
             file,
             directory,

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -1,3 +1,4 @@
+use crate::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use crate::podcast::episode::Episode;
 /**
  * MIT License
@@ -502,8 +503,8 @@ impl Track {
         if let Some(ext) = self.ext() {
             let new_name = format!(
                 "{}-{}.{}",
-                self.artist().unwrap_or("Unknown Artist"),
-                self.title().unwrap_or("Unknown Title"),
+                self.artist().unwrap_or(UNKNOWN_ARTIST),
+                self.title().unwrap_or(UNKNOWN_TITLE),
                 ext,
             );
 
@@ -552,12 +553,12 @@ impl Track {
     fn update_tag<T: Accessor>(&self, tag: &mut T) {
         tag.set_artist(
             self.artist()
-                .map_or_else(|| String::from("Unknown Artist"), str::to_string),
+                .map_or_else(|| String::from(UNKNOWN_ARTIST), str::to_string),
         );
 
         tag.set_title(
             self.title()
-                .map_or_else(|| String::from("Unknown Title"), str::to_string),
+                .map_or_else(|| String::from(UNKNOWN_TITLE), str::to_string),
         );
 
         tag.set_album(self.album().map_or_else(String::new, str::to_string));

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -64,19 +64,15 @@ pub fn is_playlist(current_node: &str) -> bool {
     }
 }
 
-pub fn get_parent_folder(filename: &str) -> String {
-    let parent_folder: PathBuf;
-    let path_old = Path::new(filename);
-
-    if path_old.is_dir() {
-        parent_folder = path_old.to_path_buf();
-        return parent_folder.to_string_lossy().to_string();
+/// Get the parent path of the given `path`, if there is none use the tempdir
+pub fn get_parent_folder(path: &Path) -> Cow<'_, Path> {
+    if path.is_dir() {
+        return path.into();
     }
-    match path_old.parent() {
-        Some(p) => parent_folder = p.to_path_buf(),
-        None => parent_folder = std::env::temp_dir(),
+    match path.parent() {
+        Some(p) => p.into(),
+        None => std::env::temp_dir().into(),
     }
-    parent_folder.to_string_lossy().to_string()
 }
 
 pub fn get_app_config_path() -> Result<PathBuf> {

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -3,6 +3,7 @@ use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use termusiclib::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use termusiclib::track::Track;
 
 const APP_ID: &str = "968407067889131520";
@@ -125,8 +126,8 @@ impl Default for Rpc {
 
 impl Rpc {
     pub fn update(&mut self, track: &Track) {
-        let artist = track.artist().unwrap_or("Unknown Artist").to_string();
-        let title = track.title().unwrap_or("Unknown Title").to_string();
+        let artist = track.artist().unwrap_or(UNKNOWN_ARTIST).to_string();
+        let title = track.title().unwrap_or(UNKNOWN_TITLE).to_string();
         self.tx.send(RpcCommand::Update(artist, title)).ok();
     }
     pub fn pause(&mut self) {

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -1,7 +1,10 @@
 use base64::Engine;
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
 use std::sync::mpsc::{self, Receiver};
-use termusiclib::track::Track;
+use termusiclib::{
+    library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE},
+    track::Track,
+};
 
 use crate::{
     GeneralPlayer, PlayerCmd, PlayerProgress, PlayerTimeUnit, PlayerTrait, Status, Volume,
@@ -85,8 +88,8 @@ impl Mpris {
 
         self.controls
             .set_metadata(MediaMetadata {
-                title: Some(track.title().unwrap_or("Unknown Title")),
-                artist: Some(track.artist().unwrap_or("Unknown Artist")),
+                title: Some(track.title().unwrap_or(UNKNOWN_TITLE)),
+                artist: Some(track.artist().unwrap_or(UNKNOWN_ARTIST)),
                 album: Some(track.album().unwrap_or("")),
                 cover_url: cover_art.as_deref(),
                 duration: Some(track.duration()),

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use pathdiff::diff_utf8_paths;
+use pathdiff::diff_paths;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use rand::Rng;
@@ -364,7 +364,7 @@ impl Playlist {
     ///
     /// # Errors
     /// Error could happen when writing file to local disk.
-    pub fn save_m3u(&self, filename: &str) -> Result<()> {
+    pub fn save_m3u(&self, filename: &Path) -> Result<()> {
         if self.tracks.is_empty() {
             bail!("Unable to save since the playlist is empty.");
         }
@@ -377,14 +377,17 @@ impl Playlist {
         Ok(())
     }
 
-    fn get_m3u_file(&self, parent_folder: &str) -> String {
+    /// Generate the m3u's file content
+    ///
+    /// All Paths are relative to the `parent_folder` directory
+    fn get_m3u_file(&self, parent_folder: &Path) -> String {
         let mut m3u = String::from("#EXTM3U\n");
         for track in &self.tracks {
             if let Some(file) = track.file() {
-                let path_relative = diff_utf8_paths(file, parent_folder);
+                let path_relative = diff_paths(file, parent_folder);
 
-                if let Some(p) = path_relative {
-                    let path = format!("{p}\n");
+                if let Some(path_relative) = path_relative {
+                    let path = format!("{}\n", path_relative.display());
                     m3u.push_str(&path);
                 }
             }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -1,4 +1,5 @@
 use crate::ui::{model::TermusicLayout, Model};
+use termusiclib::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use termusiclib::podcast::episode::Episode;
 use termusiclib::track::MediaType;
 use termusiclib::types::{Id, LyricMsg, Msg};
@@ -342,8 +343,8 @@ impl Model {
         if let Some(track) = &self.current_song {
             match track.media_type {
                 MediaType::Music => {
-                    let artist = track.artist().unwrap_or("Unknown Artist");
-                    let title = track.title().unwrap_or("Unknown Title");
+                    let artist = track.artist().unwrap_or(UNKNOWN_ARTIST);
+                    let title = track.title().unwrap_or(UNKNOWN_TITLE);
                     lyric_title = format!(" Lyrics of {artist:^.20} - {title:^.20} ");
                 }
                 MediaType::Podcast => {

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::Path;
 use termusiclib::config::SharedTuiSettings;
+use termusiclib::library_db::const_unknown::{UNKNOWN_ALBUM, UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use termusiclib::library_db::SearchCriteria;
 use termusiclib::library_db::TrackDB;
 use termusiclib::track::Track;
@@ -410,9 +411,9 @@ impl Model {
 
             let noname_string = "No Name".to_string();
             let name = record.name().unwrap_or(&noname_string);
-            let artist = record.artist().unwrap_or(name);
-            let mut title: Cow<'_, str> = record.title().unwrap_or("Unknown Title").into();
-            let album = record.album().unwrap_or("Unknown Album");
+            let artist = record.artist().unwrap_or(UNKNOWN_ARTIST);
+            let mut title: Cow<'_, str> = record.title().unwrap_or(name).into();
+            let album = record.album().unwrap_or(UNKNOWN_ALBUM);
 
             // TODO: is there maybe a better option to do this on-demand instead of the whole playlist; like on draw-time?
             if idx == self.playlist.get_current_track_index() {
@@ -527,8 +528,8 @@ impl Model {
         let mut idx = 0;
         let search = format!("*{}*", input.to_lowercase());
         for record in self.playlist.tracks() {
-            let artist = record.artist().unwrap_or("Unknown artist");
-            let title = record.title().unwrap_or("Unknown title");
+            let artist = record.artist().unwrap_or(UNKNOWN_ARTIST);
+            let title = record.title().unwrap_or(UNKNOWN_TITLE);
             if wildmatch::WildMatch::new(&search).matches(&artist.to_lowercase())
                 | wildmatch::WildMatch::new(&search).matches(&title.to_lowercase())
             {
@@ -541,8 +542,8 @@ impl Model {
 
                 let noname_string = "No Name".to_string();
                 let name = record.name().unwrap_or(&noname_string);
-                let artist = record.artist().unwrap_or(name);
-                let title = record.title().unwrap_or("Unknown Title");
+                let artist = record.artist().unwrap_or(UNKNOWN_ARTIST);
+                let title = record.title().unwrap_or(name);
                 let file_name = record.file().unwrap_or("no file");
 
                 table

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -1,5 +1,6 @@
 use crate::ui::{model::TermusicLayout, Model};
 use anyhow::anyhow;
+use std::path::Path;
 use std::thread::{self, sleep};
 use std::time::Duration;
 use termusiclib::library_db::SearchCriteria;
@@ -161,7 +162,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::SavePlaylistConfirmCloseOk(filename) => {
-                    if let Err(e) = self.playlist_save_m3u(&filename) {
+                    if let Err(e) = self.playlist_save_m3u(Path::new(&filename)) {
                         self.mount_error_popup(e.context("save m3u playlist"));
                     }
                     self.umount_save_playlist_confirm();

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -9,6 +9,7 @@ use crate::ui::utils::{
 };
 use crate::ui::Application;
 use anyhow::{bail, Result};
+use std::path::Path;
 use std::time::{Duration, Instant};
 use termusiclib::config::SharedTuiSettings;
 /**
@@ -579,7 +580,10 @@ impl Model {
             _ => bail!("Invalid node selected in library"),
         };
 
-        let mut path_string = get_parent_folder(&current_node);
+        let mut path_string = get_parent_folder(Path::new(&current_node))
+            .to_string_lossy()
+            .to_string();
+        // push extra "/" as "Path::to_string()" does not end with a "/"
         path_string.push('/');
 
         let config = self.config_tui.read();

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -174,7 +174,7 @@ impl Model {
     pub fn youtube_dl(&mut self, url: &str) -> Result<()> {
         let mut path: PathBuf = std::env::temp_dir();
         if let Ok(State::One(StateValue::String(node_id))) = self.app.state(&Id::Library) {
-            path = PathBuf::from(get_parent_folder(&node_id));
+            path = get_parent_folder(Path::new(&node_id)).to_path_buf();
         }
         let args = vec![
             Arg::new("--extract-audio"),


### PR DESCRIPTION
This PR mainly refactors `Track` to store less needed / derivable data, in more details:
- refactor Track to not store any initial strings which like `Unsupported` or `Unknown` and have all consuming places decide how to handle `None`
- refactor Track to not store `directory, ext, filename, file` and only store a single `URI|Path` (and derive the other values on-demand
- refactor Track to always require a location, which can either be a `Path` or `Uri`

This PR also does:
- refactor `lib::utils::get_parent_folder` and all functions using it to use `Path`s instead of strings (way less back-and-forth)
- use one single const string for all fallback `Unknown Artist|Title` strings (because of this there is no more `Unsupported?` only `Unknown Artist|Title` or `empty` for Albums)
- change the fallback of filename from album to title only

PS: because this PR touches upon the default unknown strings, it kinda messes with new database entries, though i am planning to re-do the database anyway