### PR TITLE
feat: enable "lto" for "release" profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### next
 - Unreleased
 - Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)
+- Change: enable `lto` (Link Time Optimizations) for the `release` profile.
 - Feat: more immediate event changes (Example: updated via mpris)
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ futures = "0.3"
 cc = "1.1"
 
 [profile.release]
-# lto = true
+lto = true
 # panic = 'abort'
 # opt-level = 'z'
 # codegen-units = 1


### PR DESCRIPTION
This PR enables rust `lto`, which should not affect the arch lto. I dont fully know why it was disabled, but from my testing it has no problems.

re #372