### PR TITLE
Fix recent merges & separate lint CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,34 @@ on:
     - cron: '00 01 * * *'
 
 jobs:
+  lint:
+    name: Lint (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Install developer package dependencies
+        run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config protobuf-compiler libgstreamer1.0-0 libunwind-dev libgstreamer1.0-dev libmpv-dev
+        # extra packages for gst (last updated for 22.04): libgstreamer1.0-0 libunwind-dev libgstreamer1.0-dev
+        # extra packages for mpv: libmpv-dev
+        # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev
+        # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev gstreamer-player-1
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # run formatting after clippy, so that the CI does not exit early when formatting has issues (but still would compile)
+      - name: Run cargo fmt
+        run: cargo fmt --all --check
+
   test_linux:
     name: Test Linux
     strategy:
@@ -21,7 +49,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Install developer package dependencies
         run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config protobuf-compiler libgstreamer1.0-0 libunwind-dev libgstreamer1.0-dev libmpv-dev
@@ -36,12 +63,6 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --features cover,all-backends --release --all
-
-      - name: Run cargo fmt
-        run: cargo fmt --all
-
-      - name: Run cargo clippy
-        run: cargo clippy --all --features cover,all-backends -- -D warnings
 
   test_macos:
     name: Test Mac
@@ -58,7 +79,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Install developer package dependencies
         run: | 
@@ -79,14 +99,6 @@ jobs:
         run: cargo test --all
         # run: cargo test --features cover,all-backends --release --all
 
-      - name: Run cargo fmt
-        run: cargo fmt --all
-
-      - name: Run cargo clippy
-        run: cargo clippy --all -- -D warnings
-        # run: cargo clippy --all --features cover,all-backends -- -D warnings
-
-
   test-win:
     name: Test Win
     strategy:
@@ -102,7 +114,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
 
       - name: Install dependencies
         run: choco install protoc
@@ -114,9 +125,3 @@ jobs:
 
       - name: Run cargo test
         run: cargo test
-
-      - name: Run cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: Run cargo clippy
-        run: cargo clippy -- -D warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo check --workspace --features cover,all-backends
 
       - name: Run cargo test
-        run: cargo test --workspace --features cover,all-backends --release
+        run: cargo test --workspace --features cover,all-backends
 
   test_macos:
     name: Test Mac
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --workspace
-        # run: cargo test --workspace --features cover,all-backends --release
+        # run: cargo test --workspace --features cover,all-backends
 
   test-win:
     name: Test Win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,10 +59,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        run: cargo check --all --features cover,all-backends
+        run: cargo check --workspace --features cover,all-backends
 
       - name: Run cargo test
-        run: cargo test --features cover,all-backends --release --all
+        run: cargo test --workspace --features cover,all-backends --release
 
   test_macos:
     name: Test Mac
@@ -92,12 +92,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        run: cargo check --all
-        # run: cargo check --all --features cover,all-backends
+        run: cargo check --workspace
+        # run: cargo check --workspace --features cover,all-backends
 
       - name: Run cargo test
-        run: cargo test --all
-        # run: cargo test --features cover,all-backends --release --all
+        run: cargo test --workspace
+        # run: cargo test --workspace --features cover,all-backends --release
 
   test-win:
     name: Test Win
@@ -121,7 +121,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --workspace
 
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --workspace

--- a/lib/src/config/v1/theme.rs
+++ b/lib/src/config/v1/theme.rs
@@ -250,10 +250,7 @@ pub enum ColorParseError {
 impl ColorParseError {
     #[cfg(test)]
     fn is_parseint_error(&self) -> bool {
-        match self {
-            Self::ParseIntError(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::ParseIntError(_))
     }
 }
 

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -2000,6 +2000,7 @@ mod v1_interop {
         use pretty_assertions::assert_eq;
         use v1::BindingForEvent;
 
+        #[allow(clippy::too_many_lines)] // this test just requires a lot of fields
         #[test]
         fn should_convert_default_without_error() {
             let converted: Keys = v1::Keys::default().into();
@@ -2262,10 +2263,12 @@ mod v1_interop {
         #[test]
         fn should_fixup_old_volume_default() {
             let converted: Keys = {
-                let mut v1 = v1::Keys::default();
-                v1.global_player_volume_minus_2 = BindingForEvent {
-                    code: tuievents::Key::Char('_'),
-                    modifier: tuievents::KeyModifiers::SHIFT,
+                let v1 = v1::Keys {
+                    global_player_volume_minus_2: BindingForEvent {
+                        code: tuievents::Key::Char('_'),
+                        modifier: tuievents::KeyModifiers::SHIFT,
+                    },
+                    ..v1::Keys::default()
                 };
 
                 v1.into()


### PR DESCRIPTION
This PR fixes the recent merge issues:
- the faulty merge of #381 (specifically ccef496a038f92339d04078b166393487e1ed1e0)
- cargo format issues

additionally, this PR also changes to run clippy & fmt in a separate job so that it can fail quicker and be more obvious on a glance what failed. (also all linux & mac didnt actually fail on format issues, only windows)