### PR TITLE
Report track probe errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Feat(server): on rusty backend, enable `aiff` codec support.
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
+- Fix: report errors reading metadata to the log
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -171,6 +171,11 @@ impl Track {
             }
         }
 
+        // exit early if its for db only as no cover is needed there
+        if for_db {
+            return Ok(song);
+        }
+
         let parent_folder = get_parent_folder(path);
 
         if let Ok(files) = std::fs::read_dir(parent_folder) {

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -144,7 +144,19 @@ impl Track {
         let probe = Probe::open(path)?;
 
         let mut song = Self::new(LocationType::Path(path.to_path_buf()), MediaType::Music);
-        if let Ok(mut tagged_file) = probe.read() {
+        let tagged_file = match probe.read() {
+            Ok(v) => Some(v),
+            Err(err) => {
+                warn!(
+                    "Failed to read metadata from \"{}\": {}",
+                    path.display(),
+                    err
+                );
+                None
+            }
+        };
+
+        if let Some(mut tagged_file) = tagged_file {
             // We can at most get the duration and file type at this point
             let properties = tagged_file.properties();
             song.duration = properties.duration();


### PR DESCRIPTION
This PR changes the track metadata probe to report errors to the log instead of silently ignoring them.
I noticed this while tracking down https://github.com/Serial-ATA/lofty-rs/issues/462, it will make it easier to detect now.

Additionally, return early `for_db`, which was missed with my earlier PR #377.