### PR TITLE
Refactor songtag LRC handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Feat(server): on rusty backend, enable `aiff` codec support.
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
-- Fix: correctly write LRC milliseconds
+- Fix: correctly write LRC milliseconds.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Feat(server): on rusty backend, enable `aiff` codec support.
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
+- Fix: correctly write LRC milliseconds
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
 - Fix: correctly write LRC milliseconds.
+- Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
 - Fix: correctly write LRC milliseconds.
 - Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
+- Fix(tui): base "no lyrics available" message on the same value as actual parsed lyrics.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -67,13 +67,16 @@ pub struct Caption {
 impl Lyric {
     // GetText will fetch lyric by time in seconds
     /// This function takes `self.offset` into account
+    ///
+    /// # Panics
+    ///
+    /// if `time` cannot be represented as a [`i64`]
     pub fn get_text(&self, time: Duration) -> Option<String> {
         if self.captions.is_empty() {
             return None;
         };
 
-        #[allow(clippy::cast_possible_wrap)]
-        let mut time = time.as_secs() as i64;
+        let mut time = i64::try_from(time.as_secs()).expect("Cannot represent input time as i64");
 
         // here we want to show lyric 2 second earlier
         let mut adjusted_time = time * 1000 + 2000;
@@ -119,9 +122,12 @@ impl Lyric {
     /// Adjust the caption at `time` or next lowest by `offset`(milliseconds) and sort captions based on new timestamps
     ///
     /// This function takes `self.offset` into account
+    ///
+    /// # Panics
+    ///
+    /// if `time` cannot be represented as a [`i64`]
     pub fn adjust_offset(&mut self, time: Duration, offset: i64) {
-        #[allow(clippy::cast_possible_wrap)]
-        let time = time.as_millis() as i64;
+        let time = i64::try_from(time.as_millis()).expect("Cannot represent input time as i64");
         if let Some(index) = self.get_index(time) {
             // when time stamp is less than 10 seconds or index is before the first line, we adjust
             // the offset.

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -77,10 +77,10 @@ impl Lyric {
             return None;
         };
 
-        let mut time = i64::try_from(time.as_secs()).expect("Cannot represent input time as i64");
+        let mut time = i64::try_from(time.as_millis()).expect("Cannot represent input time as i64");
 
         // here we want to show lyric 2 second earlier
-        let mut adjusted_time = time * 1000 + 2000;
+        let mut adjusted_time = time + 2000;
         adjusted_time += self.offset;
         if adjusted_time < 0 {
             adjusted_time = 0;

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -368,4 +368,35 @@ mod tests {
 
         assert_eq!(lyrics.captions.len(), 0);
     }
+
+    #[test]
+    fn should_format_as_lrc() {
+        let lyrics = Lyric {
+            offset: 10,
+            captions: vec![
+                Caption {
+                    timestamp: 12 * 1000,
+                    text: "Lyrics beginning ...".into(),
+                },
+                Caption {
+                    timestamp: (15 * 1000) + 300,
+                    text: "Some more lyrics ...".into(),
+                },
+                Caption {
+                    timestamp: (10 * 60 * 1000) + (11 * 1000) + 120,
+                    text: "Extra Lyrics".into(),
+                },
+            ],
+        };
+
+        // TODO: the milliseconds dont seem to work right
+        assert_eq!(
+            lyrics.as_lrc_text(),
+            r"[offset:10]
+[00:12.00]Lyrics beginning ...
+[00:15.00]Some more lyrics ...
+[10:11.20]Extra Lyrics
+"
+        );
+    }
 }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -69,8 +69,6 @@ pub struct Caption {
     text: String,
 }
 
-const EOL: &str = "\n";
-
 impl Lyric {
     // GetText will fetch lyric by time in seconds
     pub fn get_text(&self, time: Duration) -> Option<String> {
@@ -232,12 +230,11 @@ impl Caption {
 
     /// Format the current [`Caption`] as a LRC line
     fn as_lrc(&self) -> String {
-        let line = format!(
-            "[{}]{}",
+        format!(
+            "[{}]{}\n",
             time_lrc(self.timestamp.try_into().unwrap_or(0)),
             self.text
-        );
-        line + EOL
+        )
     }
 }
 

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -37,7 +37,6 @@
 // [00:12.00]Lyrics beginning ...
 // [00:15.30]Some more lyrics ...
 use anyhow::Result;
-use std::cmp::Ordering;
 use std::fmt::{Error as FmtError, Write};
 use std::str::FromStr;
 use std::time::Duration;
@@ -137,9 +136,10 @@ impl Lyric {
                 // fine tuning each line after 10 seconds
                 let caption = &mut self.captions[index];
                 let adjusted_time_stamp = caption.timestamp + offset;
-                caption.timestamp = match adjusted_time_stamp.cmp(&0) {
-                    Ordering::Greater | Ordering::Equal => adjusted_time_stamp,
-                    Ordering::Less => 0,
+                caption.timestamp = if adjusted_time_stamp > 0 {
+                    adjusted_time_stamp
+                } else {
+                    0
                 };
             }
         };

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -170,10 +170,7 @@ impl Lyric {
     pub fn merge_adjacent(&mut self) {
         let mut merged_captions = self.captions.clone();
         let mut offset = 1;
-        for (i, old_caption) in self.captions.iter().enumerate() {
-            if i < 1 {
-                continue;
-            }
+        for (i, old_caption) in self.captions.iter().enumerate().skip(1) {
             if let Some(item) = merged_captions.get_mut(i - offset) {
                 if old_caption.timestamp - item.timestamp < 2000 {
                     item.text += "  ";

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -57,7 +57,6 @@ pub struct Lyric {
     ///
     /// positive means delay lyric
     pub offset: i64,
-    pub lang_extension: Option<String>,
     /// USLT captions
     pub unsynced_captions: Vec<UnsyncedCaption>,
 }
@@ -254,7 +253,6 @@ impl FromStr for Lyric {
         // s = cleanLRC(s)
         // lines := strings.Split(s, "\n")
         let mut offset: i64 = 0;
-        let lang_extension = Some(String::new());
         let mut unsynced_captions = vec![];
         for line in s.split('\n') {
             let mut line = line.to_string();
@@ -293,7 +291,6 @@ impl FromStr for Lyric {
 
         let mut lyric = Self {
             offset,
-            lang_extension,
             unsynced_captions,
         };
 
@@ -325,7 +322,6 @@ mod tests {
         let lyrics = Lyric::from_str(txt).unwrap();
 
         assert_eq!(lyrics.offset, 10);
-        assert_eq!(lyrics.lang_extension, Some(String::new()));
 
         assert_eq!(
             lyrics.unsynced_captions.as_slice(),
@@ -353,7 +349,6 @@ mod tests {
         let lyrics = Lyric::from_str(txt).unwrap();
 
         assert_eq!(lyrics.offset, 0);
-        assert_eq!(lyrics.lang_extension, Some(String::new()));
 
         assert_eq!(
             lyrics.unsynced_captions.as_slice(),

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -72,7 +72,7 @@ impl Lyric {
     /// # Panics
     ///
     /// if `time` cannot be represented as a [`i64`]
-    pub fn get_text(&self, time: Duration) -> Option<String> {
+    pub fn get_text(&self, time: Duration) -> Option<&str> {
         if self.captions.is_empty() {
             return None;
         };
@@ -88,10 +88,10 @@ impl Lyric {
 
         time = adjusted_time;
 
-        let mut text = self.captions.first()?.text.clone();
+        let mut text = &self.captions.first()?.text;
         for caption in &self.captions {
             if time >= caption.timestamp {
-                text.clone_from(&caption.text);
+                text = &caption.text;
             } else {
                 break;
             }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -409,4 +409,49 @@ mod tests {
 "
         );
     }
+
+    #[test]
+    fn should_merge_adjacent() {
+        let mut lyrics = Lyric {
+            offset: 0,
+            captions: vec![
+                Caption {
+                    timestamp: 1000,
+                    text: "unmerged1".into(),
+                },
+                Caption {
+                    timestamp: 3 * 1000,
+                    text: "merged1".into(),
+                },
+                Caption {
+                    timestamp: 4 * 1000,
+                    text: "merged2".into(),
+                },
+                Caption {
+                    timestamp: 5 * 1000,
+                    text: "unmerged2".into(),
+                },
+            ],
+        };
+
+        lyrics.merge_adjacent();
+
+        assert_eq!(
+            lyrics.captions.as_slice(),
+            &[
+                Caption {
+                    timestamp: 1000,
+                    text: "unmerged1".into()
+                },
+                Caption {
+                    timestamp: 3 * 1000,
+                    text: "merged1  merged2".into()
+                },
+                Caption {
+                    timestamp: 5 * 1000,
+                    text: "unmerged2".into()
+                },
+            ]
+        );
+    }
 }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -64,8 +64,10 @@ pub struct Caption {
 }
 
 impl Lyric {
-    // GetText will fetch lyric by time in seconds
-    /// This function takes `self.offset` into account
+    /// Get the lyric text at `time` or next lowest (in seconds)
+    ///
+    /// `time` is adjusted by +2 seconds.
+    /// This function takes `self.offset` into account.
     ///
     /// # Panics
     ///
@@ -99,7 +101,7 @@ impl Lyric {
 
     /// Get a index for the next lowest caption from `time` (in milliseconds)
     ///
-    /// This function takes `self.offset` into account
+    /// This function takes `self.offset` into account.
     pub fn get_index(&self, time: i64) -> Option<usize> {
         if self.captions.is_empty() {
             return None;
@@ -531,6 +533,46 @@ mod tests {
                     text: "unchanged3".into(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn should_get_text() {
+        let lyrics = Lyric {
+            offset: 0,
+            captions: vec![
+                Caption {
+                    timestamp: 1000,
+                    text: "text1".into(),
+                },
+                Caption {
+                    timestamp: 3 * 1000,
+                    text: "text2".into(),
+                },
+                Caption {
+                    timestamp: 4 * 1000,
+                    text: "text3".into(),
+                },
+                Caption {
+                    timestamp: 5 * 1000,
+                    text: "text4".into(),
+                },
+            ],
+        };
+
+        assert_eq!(lyrics.get_text(Duration::from_secs(0)).unwrap(), "text1");
+        // plus 2 seconds as the function adjusts by 2 seconds
+        assert_eq!(
+            lyrics.get_text(Duration::from_secs(3 - 2)).unwrap(),
+            "text2"
+        );
+        assert_eq!(
+            lyrics.get_text(Duration::from_secs(4 - 2)).unwrap(),
+            "text3"
+        );
+        assert_eq!(
+            lyrics.get_text(Duration::from_secs(5 - 2)).unwrap(),
+            "text4"
         );
     }
 }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -79,7 +79,7 @@ impl Lyric {
 
         let mut time = i64::try_from(time.as_millis()).expect("Cannot represent input time as i64");
 
-        // here we want to show lyric 2 second earlier
+        // use a 2 second offset because of client progress delay
         let mut adjusted_time = time + 2000;
         adjusted_time += self.offset;
         if adjusted_time < 0 {

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -241,10 +241,14 @@ impl Caption {
 /// Format a time as a LRC time `mm:ss.ms`
 fn time_lrc(time_stamp: u64) -> String {
     let time_duration = Duration::from_millis(time_stamp);
+    // LRC format does not handle hours, so this formatting assumes it is below 1 hour
     // let _h = time_duration.as_secs() / 3600;
+    // modulate by 60 to keep it only to the current hour, instead of all the duration as minutes
     let m = (time_duration.as_secs() / 60) % 60;
+    // modulate by 60 to keep it only to the current minute, instead of all the duration as seconds
     let s = time_duration.as_secs() % 60;
-    let ms = time_duration.as_millis() % 60;
+    // subsec is always guranteed to be less than a second; dividing by 10 to only have the 2 most significant numbers
+    let ms = time_duration.subsec_millis() / 10;
 
     format!("{m:02}:{s:02}.{ms:02}")
 }
@@ -389,13 +393,12 @@ mod tests {
             ],
         };
 
-        // TODO: the milliseconds dont seem to work right
         assert_eq!(
             lyrics.as_lrc_text(),
             r"[offset:10]
 [00:12.00]Lyrics beginning ...
-[00:15.00]Some more lyrics ...
-[10:11.20]Extra Lyrics
+[00:15.30]Some more lyrics ...
+[10:11.12]Extra Lyrics
 "
         );
     }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -174,10 +174,10 @@ impl Lyric {
             if i < 1 {
                 continue;
             }
-            if let Some(item) = merged_captions.get(i - offset) {
+            if let Some(item) = merged_captions.get_mut(i - offset) {
                 if old_caption.timestamp - item.timestamp < 2000 {
-                    merged_captions[i - offset].text += "  ";
-                    merged_captions[i - offset].text += old_caption.text.as_ref();
+                    item.text += "  ";
+                    item.text += old_caption.text.as_ref();
                     merged_captions.remove(i - offset + 1);
                     offset += 1;
                 }

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -44,8 +44,6 @@ use std::str::FromStr;
 use std::time::Duration;
 
 lazy_static! {
-    static ref LYRICS_RE: Regex = Regex::new("^[^\x00-\x08\x0A-\x1F\x7F]*$").unwrap();
-    static ref TAG_RE: Regex = Regex::new(r"\[.*:.*\]").unwrap();
     static ref LINE_STARTS_WITH_RE: Regex =
         Regex::new("^\\[([^\x00-\x08\x0A-\x1F\x7F\\[\\]:]*):([^\x00-\x08\x0A-\x1F\x7F\\[\\]]*)\\]")
             .unwrap();

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -494,14 +494,11 @@ impl Track {
         let mut lyric_frames = self.lyric_frames.clone();
         match self.lyric_frames.get(self.lyric_selected_index) {
             Some(lyric_frame) => {
-                lyric_frames.remove(self.lyric_selected_index);
-                lyric_frames.insert(
-                    self.lyric_selected_index,
-                    Id3Lyrics {
-                        text: lyric_str.to_string(),
-                        ..lyric_frame.clone()
-                    },
-                );
+                // No panic as the vec has just been cloned and using the same index into both vecs which has been checked
+                lyric_frames[self.lyric_selected_index] = Id3Lyrics {
+                    text: lyric_str.to_string(),
+                    ..lyric_frame.clone()
+                };
             }
             None => {
                 lyric_frames.push(Id3Lyrics {

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -26,7 +26,7 @@ use crate::podcast::episode::Episode;
 use crate::songtag::lrc::Lyric;
 use crate::utils::get_parent_folder;
 use anyhow::{bail, Result};
-use id3::frame::Lyrics;
+use id3::frame::Lyrics as Id3Lyrics;
 use lofty::config::WriteOptions;
 use lofty::picture::{Picture, PictureType};
 use lofty::prelude::{Accessor, AudioFile, ItemKey, TagExt, TaggedFileExt};
@@ -77,7 +77,7 @@ pub struct Track {
     duration: Duration,
     pub last_modified: SystemTime,
     /// USLT lyrics
-    lyric_frames: Vec<Lyrics>,
+    lyric_frames: Vec<Id3Lyrics>,
     lyric_selected_index: usize,
     parsed_lyric: Option<Lyric>,
     picture: Option<Picture>,
@@ -110,7 +110,7 @@ impl Track {
     /// Create a new [`MediaType::Podcast`] track
     #[allow(clippy::cast_sign_loss)]
     pub fn from_episode(ep: &Episode) -> Self {
-        let lyric_frames: Vec<Lyrics> = Vec::new();
+        let lyric_frames: Vec<Id3Lyrics> = Vec::new();
         let mut podcast_localfile: Option<String> = None;
         if let Some(path) = &ep.path {
             if path.exists() {
@@ -193,13 +193,12 @@ impl Track {
         }
 
         // Get all of the lyrics tags
-        let mut lyric_frames: Vec<Lyrics> = Vec::new();
+        let mut lyric_frames: Vec<Id3Lyrics> = Vec::new();
         create_lyrics(tag, &mut lyric_frames);
 
         track.parsed_lyric = lyric_frames
             .first()
-            .map(|lf| Lyric::from_str(&lf.text).ok())
-            .and_then(|pl| pl);
+            .and_then(|lf| Lyric::from_str(&lf.text).ok());
         track.lyric_frames = lyric_frames;
 
         // Get the picture (not necessarily the front cover)
@@ -228,7 +227,7 @@ impl Track {
 
     fn new(location: LocationType, media_type: MediaType) -> Self {
         let duration = Duration::from_secs(0);
-        let lyric_frames: Vec<Lyrics> = Vec::new();
+        let lyric_frames: Vec<Id3Lyrics> = Vec::new();
         let mut last_modified = SystemTime::now();
         let mut title = None;
 
@@ -271,7 +270,7 @@ impl Track {
         Ok(())
     }
 
-    pub fn cycle_lyrics(&mut self) -> Result<&Lyrics> {
+    pub fn cycle_lyrics(&mut self) -> Result<&Id3Lyrics> {
         if self.lyric_frames_is_empty() {
             bail!("no lyrics embedded");
         }
@@ -311,7 +310,7 @@ impl Track {
         self.lyric_selected_index
     }
 
-    pub fn lyric_selected(&self) -> Option<&Lyrics> {
+    pub fn lyric_selected(&self) -> Option<&Id3Lyrics> {
         if self.lyric_frames.is_empty() {
             return None;
         }
@@ -332,7 +331,7 @@ impl Track {
         self.lyric_frames.len()
     }
 
-    pub fn lyric_frames(&self) -> Option<Vec<Lyrics>> {
+    pub fn lyric_frames(&self) -> Option<Vec<Id3Lyrics>> {
         if self.lyric_frames.is_empty() {
             return None;
         }
@@ -500,14 +499,14 @@ impl Track {
                 lyric_frames.remove(self.lyric_selected_index);
                 lyric_frames.insert(
                     self.lyric_selected_index,
-                    Lyrics {
+                    Id3Lyrics {
                         text: lyric_str.to_string(),
                         ..lyric_frame.clone()
                     },
                 );
             }
             None => {
-                lyric_frames.push(Lyrics {
+                lyric_frames.push(Id3Lyrics {
                     lang: "eng".to_string(),
                     description: lang_ext.to_string(),
                     text: lyric_str.to_string(),
@@ -537,11 +536,11 @@ impl Track {
     }
 }
 
-fn create_lyrics(tag: &mut LoftyTag, lyric_frames: &mut Vec<Lyrics>) {
+fn create_lyrics(tag: &mut LoftyTag, lyric_frames: &mut Vec<Id3Lyrics>) {
     let lyrics = tag.take(&ItemKey::Lyrics);
     for lyric in lyrics {
         if let ItemValue::Text(lyrics_text) = lyric.value() {
-            lyric_frames.push(Lyrics {
+            lyric_frames.push(Id3Lyrics {
                 lang: lyric.lang().escape_ascii().to_string(),
                 description: lyric.description().to_string(),
                 text: lyrics_text.to_string(),

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -202,14 +202,12 @@ impl Track {
         track.lyric_frames = lyric_frames;
 
         // Get the picture (not necessarily the front cover)
-        let mut picture = tag
+        let picture = tag
             .pictures()
             .iter()
             .find(|pic| pic.pic_type() == PictureType::CoverFront)
+            .or_else(|| tag.pictures().first())
             .cloned();
-        if picture.is_none() {
-            picture = tag.pictures().first().cloned();
-        }
 
         track.picture = picture;
 

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -270,7 +270,7 @@ impl Model {
             }
 
             if let Some(l) = song.parsed_lyric() {
-                if l.unsynced_captions.is_empty() {
+                if l.captions.is_empty() {
                     self.lyric_set_lyric("No lyrics available.");
                     return;
                 }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -275,10 +275,10 @@ impl Model {
                     return;
                 }
                 if let Some(l) = l.get_text(self.time_pos) {
-                    line = l;
+                    line = l.to_string();
                 }
             }
-            self.lyric_set_lyric(&line);
+            self.lyric_set_lyric(line);
         }
     }
 

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -264,10 +264,6 @@ impl Model {
             }
 
             let mut line = String::new();
-            if song.lyric_frames_is_empty() {
-                self.lyric_set_lyric("No lyrics available.");
-                return;
-            }
 
             if let Some(l) = song.parsed_lyric() {
                 if l.captions.is_empty() {
@@ -277,6 +273,9 @@ impl Model {
                 if let Some(l) = l.get_text(self.time_pos) {
                     line = l.to_string();
                 }
+            } else {
+                self.lyric_set_lyric("No lyrics available.");
+                return;
             }
             self.lyric_set_lyric(line);
         }

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -368,11 +368,9 @@ impl Model {
             return;
         }
 
-        let mut vec_lang: Vec<String> = vec![];
+        let mut vec_lang: Vec<String> = Vec::new();
         if let Some(lf) = s.lyric_frames() {
-            for l in lf {
-                vec_lang.push(l.description.clone());
-            }
+            vec_lang = lf.into_iter().map(|lyric| lyric.description).collect();
         }
         vec_lang.sort();
 


### PR DESCRIPTION
This PR refactors many parts of the `lib::songtag::lrc` module and touches upon some related lyric things, in more details:
- add tests for LRC parsing and writing
- fix writing milliseconds to LRC format (previously the completely wrong value was used)
- refactor a bunch of stuff to require less heap (string) allocations
- refactor a bunch of stuff to do less (repeated) searching
- general addition of doc-comments
- cleanup unused code / variables / properties