### PR TITLE
Fix Playlist not finding paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix: report errors reading metadata to the log
 - Fix: correctly write LRC milliseconds.
 - Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
+- Fix: fix accidental invertion of `is_absolute` for path playlist values causing items to not have the correct path.
 - Fix(tui): base "no lyrics available" message on the same value as actual parsed lyrics.
 
 ### [V0.9.1]

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -232,11 +232,21 @@ Title1=mytitle
 
         use super::super::PlaylistValue;
 
+        // different test for unix and windows as paths dont match
         #[test]
+        #[cfg(target_family = "unix")]
         fn file_url_to_path() {
             let mut value = PlaylistValue::Url(Url::parse("file:///mnt/somewhere").unwrap());
             value.file_url_to_path().unwrap();
             assert_eq!(value, PlaylistValue::Path("/mnt/somewhere".into()));
+        }
+
+        #[test]
+        #[cfg(target_family = "windows")]
+        fn file_url_to_path() {
+            let mut value = PlaylistValue::Url(Url::parse("file://C:\\somewhere").unwrap());
+            value.file_url_to_path().unwrap();
+            assert_eq!(value, PlaylistValue::Path("C:\\somewhere".into()));
         }
 
         #[test]

--- a/lib/src/playlist/mod.rs
+++ b/lib/src/playlist/mod.rs
@@ -75,7 +75,7 @@ impl PlaylistValue {
         };
 
         // do nothing if path is already absolute
-        if !path.is_absolute() {
+        if path.is_absolute() {
             return;
         }
 


### PR DESCRIPTION
This PR fixes a mistake of accidentally inverting `is_absolute`, causing playlist paths to not be absoluteized anymore (and by extension not being able to find the files).

Additionally this PR also renames some variables in `lib::utils::playlist_get_vec` and allocates the vector with the direct capacity.

fixes #387