### PR TITLE
Fix 1.84 clippy warnings

### DIFF
--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1339,7 +1339,7 @@ impl<'a> Iterator for SplitAtPlus<'a> {
                         self.last_char_was_returned_delim = false;
                         self.last_char_was_delim = true;
                         continue;
-                    } else if i == 0 && self.chars.peek().map_or(false, |v| v.1 != Self::DELIM) {
+                    } else if i == 0 && self.chars.peek().is_some_and(|v| v.1 != Self::DELIM) {
                         // special case where the delimiter is the first, but not followed by another delimiter, like "+q"
                         // this is so we return a InvalidFormat later on (treat the first "+" as a delimiter instead of a key)
                         self.last_char_was_returned_delim = false;
@@ -1863,7 +1863,7 @@ mod v1_interop {
             ) {
                 // the old impl had lowercase and uppercase characters, need to compare them equally
                 (tuievents::Key::Char(left), tuievents::Key::Char(right)) => {
-                    left.to_ascii_lowercase() == right.to_ascii_lowercase()
+                    left.eq_ignore_ascii_case(&right)
                 }
                 (left, right) => left == right,
             };

--- a/lib/src/playlist/pls.rs
+++ b/lib/src/playlist/pls.rs
@@ -194,7 +194,7 @@ fn skip_until_playlist<'a, 'b>(iter: &'a mut impl Iterator<Item = &'b str>) -> F
         }
 
         // return when finding the correct header
-        if line.trim().to_ascii_lowercase() == "[playlist]" {
+        if line.trim().eq_ignore_ascii_case("[playlist]") {
             return Found::Yes;
         }
     }

--- a/lib/src/songtag/kugou/model.rs
+++ b/lib/src/songtag/kugou/model.rs
@@ -32,7 +32,7 @@ use serde_json::{from_str, json, Value};
 pub fn to_lyric(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("status").is_none() || !value.get("status").map_or(false, |v| v.eq(&200)) {
+    if value.get("status").is_none() || !value.get("status").is_some_and(|v| v.eq(&200)) {
         let errcode = value
             .get("errcode")
             .and_then(Value::as_str)
@@ -57,7 +57,7 @@ pub fn to_lyric(json: &str) -> Result<String> {
 pub fn to_lyric_id_accesskey(json: &str) -> Result<(String, String)> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("errcode").is_none() || !value.get("errcode").map_or(false, |v| v.eq(&200)) {
+    if value.get("errcode").is_none() || !value.get("errcode").is_some_and(|v| v.eq(&200)) {
         let errcode = value
             .get("errcode")
             .and_then(Value::as_str)
@@ -93,7 +93,7 @@ pub fn to_lyric_id_accesskey(json: &str) -> Result<(String, String)> {
 pub fn to_song_url(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("status").is_none() || !value.get("status").map_or(false, |v| v.eq(&200)) {
+    if value.get("status").is_none() || !value.get("status").is_some_and(|v| v.eq(&200)) {
         let errcode = value
             .get("errcode")
             .and_then(Value::as_str)
@@ -117,7 +117,7 @@ pub fn to_song_url(json: &str) -> Result<String> {
 pub fn to_pic_url(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("status").is_none() || !value.get("status").map_or(false, |v| v.eq(&1)) {
+    if value.get("status").is_none() || !value.get("status").is_some_and(|v| v.eq(&1)) {
         bail!("Failed to get picture url, \"status\" does not exist or is not 200");
     }
 
@@ -135,7 +135,7 @@ pub fn to_pic_url(json: &str) -> Result<String> {
 pub fn to_song_info(json: &str) -> Result<Vec<SongTag>> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("status").is_none() || !value.get("status").map_or(false, |v| v.eq(&1)) {
+    if value.get("status").is_none() || !value.get("status").is_some_and(|v| v.eq(&1)) {
         bail!("Failed to get picture url, \"status\" does not exist or is not 200");
     }
 

--- a/lib/src/songtag/migu/model.rs
+++ b/lib/src/songtag/migu/model.rs
@@ -32,7 +32,7 @@ pub fn to_lyric(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
     // english for the chinese characters: "success"
-    if value.get("msg").is_none() || !value.get("msg").map_or(false, |v| v.eq(&"成功")) {
+    if value.get("msg").is_none() || !value.get("msg").is_some_and(|v| v.eq(&"成功")) {
         let message = value.get("msg").and_then(Value::as_str).unwrap_or("<none>");
         bail!(
             "Failed to get lyric text, \"msg\" does not exist or is not \"sucess\" Errcode: {message}"
@@ -53,7 +53,7 @@ pub fn to_pic_url(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
     // english for the chinese characters: "success"
-    if value.get("msg").is_none() || !value.get("msg").map_or(false, |v| v.eq(&"成功")) {
+    if value.get("msg").is_none() || !value.get("msg").is_some_and(|v| v.eq(&"成功")) {
         let message = value.get("msg").and_then(Value::as_str).unwrap_or("<none>");
         bail!(
             "Failed to get picure url, \"msg\" does not exist or is not \"sucess\" Errcode: {message}"
@@ -73,7 +73,7 @@ pub fn to_pic_url(json: &str) -> Result<String> {
 pub fn to_song_info(json: &str) -> Result<Vec<SongTag>> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("success").is_none() || !value.get("success").map_or(false, |v| v.eq(&true)) {
+    if value.get("success").is_none() || !value.get("success").is_some_and(|v| v.eq(&true)) {
         let message = value
             .get("success")
             .and_then(Value::as_str)

--- a/lib/src/songtag/netease_v2/model.rs
+++ b/lib/src/songtag/netease_v2/model.rs
@@ -7,7 +7,7 @@ use serde_json::{from_str, Value};
 pub fn to_lyric(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("code").is_none() || !value.get("code").map_or(false, |v| v.eq(&200)) {
+    if value.get("code").is_none() || !value.get("code").is_some_and(|v| v.eq(&200)) {
         let code = value
             .get("code")
             .and_then(Value::as_str)
@@ -28,7 +28,7 @@ pub fn to_lyric(json: &str) -> Result<String> {
 pub fn to_song_url(json: &str) -> Result<String> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("code").is_none() || !value.get("code").map_or(false, |v| v.eq(&200)) {
+    if value.get("code").is_none() || !value.get("code").is_some_and(|v| v.eq(&200)) {
         let errcode = value
             .get("code")
             .and_then(Value::as_str)
@@ -62,7 +62,7 @@ fn parse_song_url(value: &Value) -> Option<&str> {
 pub fn to_song_info(json: &str) -> Result<Vec<SongTag>> {
     let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
 
-    if value.get("code").is_none() || !value.get("code").map_or(false, |v| v.eq(&200)) {
+    if value.get("code").is_none() || !value.get("code").is_some_and(|v| v.eq(&200)) {
         let code = value
             .get("code")
             .and_then(Value::as_str)

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -474,7 +474,7 @@ impl Playlist {
     pub fn remove_deleted_items(&mut self) {
         if let Some(current_track_file) = self.get_current_track() {
             self.tracks
-                .retain(|x| x.file().map_or(false, |p| Path::new(p).exists()));
+                .retain(|x| x.file().is_some_and(|p| Path::new(p).exists()));
             match self.find_index_from_file(&current_track_file) {
                 Some(new_index) => self.current_track_index = new_index,
                 None => self.current_track_index = 0,

--- a/playback/src/rusty_backend/decoder/mod.rs
+++ b/playback/src/rusty_backend/decoder/mod.rs
@@ -448,7 +448,7 @@ fn decode_loop(
     if !media_title_tx.is_none() {
         // run container metadata if new and on seek to 0
         // this maybe not be 100% reliable, where for example there is no "time_base", but i dont know of a case yet where that happens
-        if elapsed.as_ref().map_or(false, Duration::is_zero) {
+        if elapsed.as_ref().is_some_and(Duration::is_zero) {
             trace!("Time is 0, doing container metadata");
             media_title_tx.send_reset();
             do_container_metdata(media_title_tx, format, probed);

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -201,7 +201,7 @@ async fn wait_till_connected(
         let status = sys.process(sys_pid);
 
         // dont endlessly try to connect, if the server exited / crashed
-        if status.is_none() || status.map_or(false, |v| v.status() == ProcessStatus::Zombie) {
+        if status.is_none() || status.is_some_and(|v| v.status() == ProcessStatus::Zombie) {
             anyhow::bail!("Process {pid} exited before being able to connect!");
         }
 

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -274,13 +274,13 @@ fn remove_downloaded_json(path: &Path, file_fullname: &str) {
         .filter(|f| {
             let name = f.file_name();
             let p = Path::new(&name);
-            p.extension().map_or(false, |ext| ext == "json")
+            p.extension().is_some_and(|ext| ext == "json")
         })
         .filter(|f| {
             let path_json = Path::new(f.file_name());
             let p1: &Path = Path::new(file_fullname);
-            path_json.file_stem().map_or(false, |stem_lrc| {
-                p1.file_stem().map_or(false, |p_base| {
+            path_json.file_stem().is_some_and(|stem_lrc| {
+                p1.file_stem().is_some_and(|p_base| {
                     stem_lrc
                         .to_string_lossy()
                         .to_string()
@@ -316,13 +316,13 @@ fn embed_downloaded_lrc(path: &Path, file_fullname: &str) {
         .filter(|f| {
             let name = f.file_name();
             let p = Path::new(&name);
-            p.extension().map_or(false, |ext| ext == "lrc")
+            p.extension().is_some_and(|ext| ext == "lrc")
         })
         .filter(|f| {
             let path_lrc = Path::new(f.file_name());
             let p1: &Path = Path::new(file_fullname);
-            path_lrc.file_stem().map_or(false, |stem_lrc| {
-                p1.file_stem().map_or(false, |p_base| {
+            path_lrc.file_stem().is_some_and(|stem_lrc| {
+                p1.file_stem().is_some_and(|p_base| {
                     stem_lrc
                         .to_string_lossy()
                         .to_string()

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -283,7 +283,6 @@ fn remove_downloaded_json(path: &Path, file_fullname: &str) {
                 p1.file_stem().is_some_and(|p_base| {
                     stem_lrc
                         .to_string_lossy()
-                        .to_string()
                         .contains(p_base.to_string_lossy().as_ref())
                 })
             })
@@ -325,7 +324,6 @@ fn embed_downloaded_lrc(path: &Path, file_fullname: &str) {
                 p1.file_stem().is_some_and(|p_base| {
                     stem_lrc
                         .to_string_lossy()
-                        .to_string()
                         .contains(p_base.to_string_lossy().as_ref())
                 })
             })


### PR DESCRIPTION
This PR fixes some new warnings added with rust  / clippy 1.84.
Also some slight other fixes i noticed while applying the clippy changes:
- rename some variables
- inline some variables