### PR TITLE
Refactor some more theme related things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change(server): on rusty backend, use upstream rodio again.
 - Feat: more immediate event changes (Example: updated via mpris)
 - Feat(server): on rusty backend, enable `aiff` codec support.
+- Feat(tui): show default theme as a preview option.
 - Fix: change default config ip address to `::1` instead of `::` (any old values on windows will need to be changed manually)
 - Fix: check for other tag types instead of just the primary tag type (for example a wav file with riff metadata instead of id3v2 would not get metadata)
 - Fix: report errors reading metadata to the log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fix(tui): not being able to parse themes that use `0x` as the prefix.
 - Fix(tui): change that the default Theme is not using bad colors.
 - Fix(tui): change that the default `add_random_(song|album)` keys were inverted.
+- Fix(tui): change Theme preview to not reset to index 0 each preview.
+- Fix(tui): not having the current theme selected when entering Theme preview tab.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/lib/src/config/v1/theme.rs
+++ b/lib/src/config/v1/theme.rs
@@ -343,6 +343,16 @@ impl From<AlacrittyColor> for Color {
     }
 }
 
+#[inline]
+fn default_name() -> String {
+    "default".to_string()
+}
+
+#[inline]
+fn default_author() -> String {
+    "Larry Hao".to_string()
+}
+
 #[derive(Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub struct Alacritty {
     pub path: String,
@@ -374,8 +384,8 @@ impl Default for Alacritty {
     fn default() -> Self {
         Self {
             path: String::new(),
-            name: "default".to_string(),
-            author: "Larry Hao".to_string(),
+            name: default_name(),
+            author: default_author(),
             background: AlacrittyColor::from_hex("#101421").unwrap(),
             foreground: AlacrittyColor::from_hex("#fffbf6").unwrap(),
             cursor: AlacrittyColor::from_hex("#ffffff").unwrap(),
@@ -408,8 +418,8 @@ impl Alacritty {
         let colors = value.colors;
         Ok(Alacritty {
             path,
-            name: colors.name,
-            author: colors.author,
+            name: colors.name.unwrap_or_else(default_name),
+            author: colors.author.unwrap_or_else(default_name),
             background: colors.primary.background.try_into()?,
             foreground: colors.primary.foreground.try_into()?,
             cursor: colors.cursor.cursor.try_into()?,

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -271,6 +271,12 @@ impl From<ThemeColor> for Color {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ThemeColors {
+    /// The Filename of the current theme, if a file is used.
+    /// This value is skipped if empty.
+    ///
+    /// This is used for example to pre-select in the config editor if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_name: Option<String>,
     pub name: String,
     pub author: String,
     pub primary: ThemePrimary,
@@ -282,6 +288,7 @@ pub struct ThemeColors {
 impl Default for ThemeColors {
     fn default() -> Self {
         Self {
+            file_name: None,
             name: default_name(),
             author: default_author(),
             primary: ThemePrimary::default(),
@@ -331,6 +338,7 @@ impl TryFrom<YAMLTheme> for ThemeColors {
     fn try_from(value: YAMLTheme) -> Result<Self, Self::Error> {
         let colors = value.colors;
         Ok(Self {
+            file_name: None,
             name: colors.name.unwrap_or_else(default_name),
             author: colors.author.unwrap_or_else(default_author),
             primary: colors.primary.try_into()?,
@@ -346,7 +354,12 @@ impl ThemeColors {
     pub fn from_yaml_file(path: &Path) -> anyhow::Result<Self> {
         let parsed: YAMLTheme = serde_yaml::from_reader(BufReader::new(File::open(path)?))?;
 
-        Ok(Self::try_from(parsed)?)
+        let mut theme = Self::try_from(parsed)?;
+
+        let file_name = path.file_stem();
+        theme.file_name = file_name.map(|v| v.to_string_lossy().to_string());
+
+        Ok(theme)
     }
 }
 
@@ -515,6 +528,7 @@ mod v1_interop {
     impl From<&v1::Alacritty> for ThemeColors {
         fn from(value: &v1::Alacritty) -> Self {
             Self {
+                file_name: None,
                 name: value.name.clone(),
                 author: value.author.clone(),
                 primary: ThemePrimary {
@@ -569,6 +583,7 @@ mod v1_interop {
             assert_eq!(
                 converted,
                 ThemeColors {
+                    file_name: None,
                     name: "default".into(),
                     author: "Larry Hao".into(),
                     primary: ThemePrimary {

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -331,8 +331,8 @@ impl TryFrom<YAMLTheme> for ThemeColors {
     fn try_from(value: YAMLTheme) -> Result<Self, Self::Error> {
         let colors = value.colors;
         Ok(Self {
-            name: colors.name,
-            author: colors.author,
+            name: colors.name.unwrap_or_else(default_name),
+            author: colors.author.unwrap_or_else(default_author),
             primary: colors.primary.try_into()?,
             cursor: colors.cursor.try_into()?,
             normal: colors.normal.try_into()?,

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -20,6 +20,9 @@ pub mod styles;
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ThemeWrap {
     pub style: styles::Styles,
+    // On full-on default, also set the names to "Termusic Default"
+    // this function is only used if this property does not exist at all
+    #[serde(default = "ThemeColors::full_default")]
     pub theme: ThemeColors,
 }
 
@@ -295,6 +298,19 @@ impl Default for ThemeColors {
             cursor: ThemeCursor::default(),
             normal: ThemeNormal::default(),
             bright: ThemeBright::default(),
+        }
+    }
+}
+
+impl ThemeColors {
+    /// Get the full default theme, including names.
+    ///
+    /// This function is different from [`Self::default`] as the trait impl is also used for filling empty places
+    pub fn full_default() -> Self {
+        Self {
+            name: "Termusic Default".to_string(),
+            author: "Termusic Developers".to_string(),
+            ..Default::default()
         }
     }
 }

--- a/lib/src/config/yaml_theme.rs
+++ b/lib/src/config/yaml_theme.rs
@@ -135,6 +135,8 @@ fn default_fff() -> YAMLThemeColor {
 mod test {
     use std::{ffi::OsStr, fs::File, io::BufReader, path::PathBuf};
 
+    use crate::config::v2::tui::theme::ThemeColors;
+
     use super::*;
 
     /// First test one theme for better debugging
@@ -204,11 +206,11 @@ mod test {
             let reader = BufReader::new(File::open(entry.path()).unwrap());
             let parsed: std::result::Result<YAMLTheme, _> = serde_yaml::from_reader(reader);
 
-            if let Err(ref parsed) = parsed {
-                eprintln!("{parsed:#?}");
-            }
+            let parsed = parsed.unwrap();
 
-            assert!(parsed.is_ok());
+            let actual_theme = ThemeColors::try_from(parsed);
+
+            let _actual_theme = actual_theme.unwrap();
         }
     }
 }

--- a/lib/src/config/yaml_theme.rs
+++ b/lib/src/config/yaml_theme.rs
@@ -10,10 +10,10 @@ type YAMLThemeColor = String;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct YAMLThemeColors {
-    #[serde(default = "default_name")]
-    pub name: String,
-    #[serde(default = "default_author")]
-    pub author: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub author: Option<String>,
     #[serde(default)]
     pub primary: YAMLThemePrimary,
     #[serde(default)]
@@ -112,16 +112,6 @@ impl Default for YAMLThemeBright {
 }
 
 #[inline]
-fn default_name() -> String {
-    "empty name".to_string()
-}
-
-#[inline]
-fn default_author() -> String {
-    "empty author".to_string()
-}
-
-#[inline]
 fn default_000() -> YAMLThemeColor {
     "#00000".to_string()
 }
@@ -151,8 +141,8 @@ mod test {
             parsed,
             YAMLTheme {
                 colors: YAMLThemeColors {
-                    name: default_name(),
-                    author: default_author(),
+                    name: None,
+                    author: None,
                     primary: YAMLThemePrimary {
                         background: "#2c2c2c".to_string(),
                         foreground: "#d6d6d6".to_string()

--- a/lib/src/config/yaml_theme.rs
+++ b/lib/src/config/yaml_theme.rs
@@ -123,9 +123,7 @@ fn default_fff() -> YAMLThemeColor {
 
 #[cfg(test)]
 mod test {
-    use std::{ffi::OsStr, fs::File, io::BufReader, path::PathBuf};
-
-    use crate::config::v2::tui::theme::ThemeColors;
+    use std::{fs::File, io::BufReader};
 
     use super::*;
 
@@ -174,33 +172,5 @@ mod test {
                 },
             }
         );
-    }
-
-    /// Test that all themes in /lib/themes/ can be loaded
-    #[test]
-    fn should_parse_all_themes() {
-        let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let path = PathBuf::from(format!("{cargo_manifest_dir}/themes/"));
-        for entry in path.read_dir().unwrap() {
-            let entry = entry.unwrap();
-
-            if entry.path().extension() != Some(OsStr::new("yml")) {
-                continue;
-            }
-
-            println!(
-                "Theme: {}",
-                entry.path().file_name().unwrap().to_string_lossy()
-            );
-
-            let reader = BufReader::new(File::open(entry.path()).unwrap());
-            let parsed: std::result::Result<YAMLTheme, _> = serde_yaml::from_reader(reader);
-
-            let parsed = parsed.unwrap();
-
-            let actual_theme = ThemeColors::try_from(parsed);
-
-            let _actual_theme = actual_theme.unwrap();
-        }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,3 +26,34 @@ pub static THEME_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/themes");
 
 #[macro_use]
 extern crate log;
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, path::PathBuf};
+
+    use crate::config::v2::tui::theme::ThemeColors;
+
+    /// Test that all themes in /lib/themes/ can be loaded
+    #[test]
+    fn should_parse_all_themes() {
+        let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let path = PathBuf::from(format!("{cargo_manifest_dir}/themes/"));
+        for entry in path.read_dir().unwrap() {
+            let entry = entry.unwrap();
+            let entry_path = entry.path();
+
+            if entry_path.extension() != Some(OsStr::new("yml")) {
+                continue;
+            }
+
+            println!(
+                "Theme: {}",
+                entry_path.file_name().unwrap().to_string_lossy()
+            );
+
+            let actual_theme = ThemeColors::from_yaml_file(&entry_path).unwrap();
+
+            assert!(actual_theme.file_name.is_some_and(|v| !v.is_empty()));
+        }
+    }
+}

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -339,19 +339,19 @@ impl Model {
             }
 
             ConfigEditorMsg::ThemeSelectLoad(index) => {
-                if let Some(theme_name) = self.config_editor.themes.get(index) {
+                if let Some(theme_filename) = self.config_editor.themes.get(index) {
                     match get_app_config_path() {
                         Ok(mut theme_path) => {
                             theme_path.push("themes");
-                            theme_path.push(format!("{theme_name}.yml"));
-                            self.config_tui.write().settings.theme.theme.name =
-                                theme_name.to_string();
+                            theme_path.push(format!("{theme_filename}.yml"));
                             match ThemeColors::from_yaml_file(&theme_path) {
-                                Ok(theme) => {
+                                Ok(mut theme) => {
+                                    theme.file_name = Some(theme_filename.to_string());
                                     self.config_editor.theme.theme = theme;
                                     self.config_editor.config_changed = true;
-                                    let mut config = self.config_tui.read().clone();
+
                                     // This is for preview the theme colors
+                                    let mut config = self.config_tui.read().clone();
                                     config.settings.theme = self.config_editor.theme.clone();
                                     let config = new_shared_tui_settings(config);
                                     self.remount_config_color(&config, Some(index));

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -354,7 +354,7 @@ impl Model {
                                     // This is for preview the theme colors
                                     config.settings.theme = self.config_editor.theme.clone();
                                     let config = new_shared_tui_settings(config);
-                                    self.remount_config_color(&config);
+                                    self.remount_config_color(&config, Some(index));
                                 }
                                 Err(e) => {
                                     error!("Failed to load theme colors: {:?}", e);

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -3526,6 +3526,8 @@ impl Model {
 
         Ok(())
     }
+
+    /// Find all themes in the `config/themes` directory and add them to be selected for preview
     pub fn theme_select_load_themes(&mut self) -> Result<()> {
         let mut path = get_app_config_path()?;
         path.push("themes");
@@ -3550,6 +3552,7 @@ impl Model {
         Ok(())
     }
 
+    /// Build the theme UI table and select the current theme
     pub fn theme_select_sync(&mut self, previous_index: Option<usize>) {
         let mut table: TableBuilder = TableBuilder::default();
 
@@ -3575,15 +3578,18 @@ impl Model {
                 AttrValue::Table(table),
             )
             .ok();
+
         // select theme currently used
         let index = if let Some(index) = previous_index {
             index
         } else {
             let mut index = 0;
-            for (idx, name) in self.config_editor.themes.iter().enumerate() {
-                if name == &self.config_editor.theme.theme.name {
-                    index = idx;
-                    break;
+            if let Some(current_file_name) = self.config_editor.theme.theme.file_name.as_ref() {
+                for (idx, name) in self.config_editor.themes.iter().enumerate() {
+                    if name == current_file_name {
+                        index = idx;
+                        break;
+                    }
                 }
             }
 

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -3499,7 +3499,8 @@ impl Model {
         Ok(())
     }
 
-    pub fn theme_select_save() -> Result<()> {
+    /// Extract all Themes to actual locations that can be loaded
+    pub fn theme_extract_all() -> Result<()> {
         let mut path = get_app_config_path()?;
         path.push("themes");
         if !path.exists() {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -3558,18 +3558,17 @@ impl Model {
     pub fn theme_select_sync(&mut self, previous_index: Option<usize>) {
         let mut table: TableBuilder = TableBuilder::default();
 
-        for (idx, record) in self.config_editor.themes.iter().enumerate() {
-            if idx > 0 {
-                table.add_row();
-            }
+        table
+            .add_col(TextSpan::new(0.to_string()))
+            .add_col(TextSpan::new("Termusic Default"));
 
+        for (idx, record) in self.config_editor.themes.iter().enumerate() {
+            table.add_row();
+
+            // idx + 1 as 0 entry is termusic default
             table
-                .add_col(TextSpan::new(idx.to_string()))
+                .add_col(TextSpan::new((idx + 1).to_string()))
                 .add_col(TextSpan::new(record));
-        }
-        if self.config_editor.themes.is_empty() {
-            table.add_col(TextSpan::from("0"));
-            table.add_col(TextSpan::from("empty theme list"));
         }
 
         let table = table.build();
@@ -3585,17 +3584,18 @@ impl Model {
         let index = if let Some(index) = previous_index {
             index
         } else {
-            let mut index = 0;
+            let mut index = None;
             if let Some(current_file_name) = self.config_editor.theme.theme.file_name.as_ref() {
                 for (idx, name) in self.config_editor.themes.iter().enumerate() {
                     if name == current_file_name {
-                        index = idx;
+                        // idx + 1 as 0 entry is termusic default
+                        index = Some(idx + 1);
                         break;
                     }
                 }
             }
 
-            index
+            index.unwrap_or(0)
         };
         assert!(self
             .app

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1890,7 +1890,7 @@ impl Model {
             )
             .is_ok());
         let config = self.config_tui.clone();
-        self.remount_config_color(&config);
+        self.remount_config_color(&config, None);
 
         // Active Config Editor
         assert!(self
@@ -1901,14 +1901,18 @@ impl Model {
         if let Err(e) = self.theme_select_load_themes() {
             self.mount_error_popup(e.context("load themes"));
         }
-        self.theme_select_sync();
+        self.theme_select_sync(None);
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn remount_config_color(&mut self, config: &SharedTuiSettings) {
+    pub fn remount_config_color(
+        &mut self,
+        config: &SharedTuiSettings,
+        previous_index: Option<usize>,
+    ) {
         // Mount color page
         assert!(self
             .app
@@ -2708,7 +2712,7 @@ impl Model {
                 vec![],
             )
             .is_ok());
-        self.theme_select_sync();
+        self.theme_select_sync(previous_index);
     }
 
     #[allow(clippy::too_many_lines)]
@@ -3545,7 +3549,7 @@ impl Model {
         Ok(())
     }
 
-    pub fn theme_select_sync(&mut self) {
+    pub fn theme_select_sync(&mut self, previous_index: Option<usize>) {
         let mut table: TableBuilder = TableBuilder::default();
 
         for (idx, record) in self.config_editor.themes.iter().enumerate() {
@@ -3571,13 +3575,19 @@ impl Model {
             )
             .ok();
         // select theme currently used
-        let mut index = 0;
-        for (idx, name) in self.config_editor.themes.iter().enumerate() {
-            if name == &self.config_editor.theme.theme.name {
-                index = idx;
-                break;
+        let index = if let Some(index) = previous_index {
+            index
+        } else {
+            let mut index = 0;
+            for (idx, name) in self.config_editor.themes.iter().enumerate() {
+                if name == &self.config_editor.theme.theme.name {
+                    index = idx;
+                    break;
+                }
             }
-        }
+
+            index
+        };
         assert!(self
             .app
             .attr(

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -3531,7 +3531,9 @@ impl Model {
     pub fn theme_select_load_themes(&mut self) -> Result<()> {
         let mut path = get_app_config_path()?;
         path.push("themes");
+
         if let Ok(paths) = std::fs::read_dir(path) {
+            self.config_editor.themes.clear();
             let mut paths: Vec<_> = paths.filter_map(std::result::Result::ok).collect();
 
             paths.sort_by_cached_key(|k| get_pin_yin(&k.file_name().to_string_lossy()));

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -336,7 +336,7 @@ impl Model {
     }
 
     pub fn init_config(&mut self) {
-        if let Err(e) = Self::theme_select_save() {
+        if let Err(e) = Self::theme_extract_all() {
             self.mount_error_popup(e.context("theme save"));
         }
         self.mount_label_help();

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -119,7 +119,7 @@ pub struct PodcastWidgetData {
 /// All data specific to the Config Editor Widget / View
 #[derive(Debug)]
 pub struct ConfigEditorData {
-    /// All possible themes that could be selected
+    /// All possible file-themes that could be selected
     pub themes: Vec<String>,
     /// The Theme to edit to preview before saving
     pub theme: ThemeWrap,


### PR DESCRIPTION
This PR changes some more theme things:
- relocate the "load and test all themes" test to root and actually try parsing each into `ThemeColors`
- add the default Termusic theme as a preview option
- set a proper theme name for the Default Termusic theme (only on full-on default)
- add `file_name` option to theme config for better pre-select in preview window on first open
- remember index of the selected theme in preview and re-select it on new table
- rename some functions
- dont have `name` and `author` be required in `YAMLThemeColors`
- move preview theme code to own function (instead of being deeply nested in event handling)

~~Draft until #407 is merged and clippy is re-run~~