### PR TITLE
Remove `Msg::None` and remove some clones

### DIFF
--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -100,13 +100,6 @@ pub enum DLMsg {
     /// `((Title, Text))`
     MessageHide((String, String)),
 
-    /// The youtube search was a success, with all values.
-    YoutubeSearchSuccess(YoutubeOptions),
-    /// Indicates that the youtube search has failed, with error message.
-    ///
-    /// `(ErrorAsString)`
-    YoutubeSearchFail(String),
-
     // TODO: The Following 2 things have absolutely nothing to-do with Download
     /// Fetching & loading the image was a success, with the image.
     FetchPhotoSuccess(ImageWrapper),
@@ -492,6 +485,13 @@ pub enum YSMsg {
     TablePopupPrevious,
     TablePopupCloseCancel,
     TablePopupCloseOk(usize),
+
+    /// The youtube search was a success, with all values.
+    YoutubeSearchSuccess(YoutubeOptions),
+    /// Indicates that the youtube search has failed, with error message.
+    ///
+    /// `(ErrorAsString)`
+    YoutubeSearchFail(String),
 }
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TEMsg {

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -51,11 +51,6 @@ pub enum Msg {
     YoutubeSearch(YSMsg),
     Xywh(XYWHMsg),
 
-    /// Old value for [`Msg::ForceRedraw`] used inplace of [`Option::None`].
-    ///
-    /// This value should not be used anymore and either return [`Option::None`] or [`Msg::ForceRedraw`].
-    None,
-
     /// Force a redraw because of some change.
     ///
     /// This is necessary as `Components` do not have access to `Model.redraw`.

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -50,7 +50,18 @@ pub enum Msg {
     UpdatePhoto,
     YoutubeSearch(YSMsg),
     Xywh(XYWHMsg),
+
+    /// Old value for [`Msg::ForceRedraw`] used inplace of [`Option::None`].
+    ///
+    /// This value should not be used anymore and either return [`Option::None`] or [`Msg::ForceRedraw`].
     None,
+
+    /// Force a redraw because of some change.
+    ///
+    /// This is necessary as `Components` do not have access to `Model.redraw`.
+    ///
+    /// For example pushing ARROW DOWN to change the selection in a table.
+    ForceRedraw,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::config::v2::tui::{keys::KeyBinding, theme::styles::ColorTermusic};
 use crate::invidious::{Instance, YoutubeVideo};
 use crate::podcast::{EpData, PodcastFeed, PodcastNoId};
@@ -62,18 +64,54 @@ pub enum XYWHMsg {
     ZoomOut,
 }
 
+pub type DLMsgURL = Arc<str>;
+
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DLMsg {
-    DownloadRunning(String, String), // indicates progress
-    DownloadSuccess(String),
-    DownloadCompleted(String, Option<String>),
-    DownloadErrDownload(String, String, String),
-    DownloadErrEmbedData(String, String),
+    /// Indicates a Start of a download.
+    ///
+    /// `(Url, Title)`
+    DownloadRunning(DLMsgURL, String),
+    /// Indicates the Download was a Success, though termusic post-processing is not done yet.
+    ///
+    /// `(Url)`
+    DownloadSuccess(DLMsgURL),
+    /// Indicates the Download thread finished in both Success or Error.
+    ///
+    /// `(Url, Filename)`
+    DownloadCompleted(DLMsgURL, Option<String>),
+    /// Indicates that the Download has Errored and has been aborted.
+    ///
+    /// `(Url, Title, ErrorAsString)`
+    DownloadErrDownload(DLMsgURL, String, String),
+    /// Indicates that the Download was a Success, but termusic post-processing failed.
+    /// Like re-saving tags after editing.
+    ///
+    /// `(Url, Title)`
+    DownloadErrEmbedData(DLMsgURL, String),
+
+    // TODO: The Following 2 things have absolutely nothing to-do with Download
+    /// Show a status message in the TUI.
+    ///
+    /// `((Title, Text))`
     MessageShow((String, String)),
+    /// Hide a status message in the TUI.
+    ///
+    /// `((Title, Text))`
     MessageHide((String, String)),
+
+    /// The youtube search was a success, with all values.
     YoutubeSearchSuccess(YoutubeOptions),
+    /// Indicates that the youtube search has failed, with error message.
+    ///
+    /// `(ErrorAsString)`
     YoutubeSearchFail(String),
+
+    // TODO: The Following 2 things have absolutely nothing to-do with Download
+    /// Fetching & loading the image was a success, with the image.
     FetchPhotoSuccess(ImageWrapper),
+    /// Fetching & loading the image has failed, with error message.
+    /// `(ErrorAsString)`
     FetchPhotoErr(String),
 }
 

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -55,7 +55,8 @@ pub enum Msg {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum XYWHMsg {
-    Hide,
+    /// Toggle the hidden / shown status of the displayed image.
+    ToggleHidden,
     MoveLeft,
     MoveRight,
     MoveUp,

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -263,7 +263,7 @@ impl Playlist {
     }
 
     pub fn swap_down(&mut self, index: usize) {
-        if index < self.len() - 1 {
+        if index < self.len().saturating_sub(1) {
             let track = self.tracks.remove(index);
             self.tracks.insert(index + 1, track);
             // handle index

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -102,7 +102,7 @@ impl Component<Msg, NoUserEvent> for CEThemeSelectTable {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             // Global Hotkeys
             Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::ConfigEditor(ConfigEditorMsg::CloseOk));
@@ -168,7 +168,10 @@ impl Component<Msg, NoUserEvent> for CEThemeSelectTable {
 
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 
@@ -291,7 +294,7 @@ impl CEColorSelect {
                 AttrValue::Style(Style::default().add_modifier(Modifier::BOLD).bg(Color::Red)),
             );
 
-            Msg::None
+            Msg::ForceRedraw
         }
     }
 }
@@ -349,7 +352,8 @@ impl Component<Msg, NoUserEvent> for CEColorSelect {
             CmdResult::Submit(State::One(StateValue::Usize(index))) => {
                 Some(self.update_color(index))
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }
@@ -866,7 +870,7 @@ impl ConfigInputHighlight {
             if symbol.is_empty() {
                 let color = self.config.read().settings.theme.library_border();
                 self.update_symbol_after(color);
-                return Msg::None;
+                return Msg::ForceRedraw;
             }
             if let Some(s) = Self::string_to_unicode_char(&symbol) {
                 // success getting a unicode letter
@@ -885,7 +889,7 @@ impl ConfigInputHighlight {
                 return Msg::ConfigEditor(ConfigEditorMsg::SymbolChanged(self.id, s.to_string()));
             }
         }
-        Msg::None
+        Msg::ForceRedraw
     }
     fn update_symbol_after(&mut self, color: Color) {
         self.attr(Attribute::Foreground, AttrValue::Color(color));
@@ -923,30 +927,27 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
             Event::Keyboard(keyevent) if keyevent == keys.escape.get() => {
                 Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel))
             }
-            // Event::Keyboard(keyevent) if keyevent == keys.global_quit.get() => {
-            //     Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel))
-            // }
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
             }) => {
                 self.perform(Cmd::Move(Direction::Left));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Right, ..
             }) => {
                 self.perform(Cmd::Move(Direction::Right));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Home, ..
             }) => {
                 self.perform(Cmd::GoTo(Position::Begin));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
                 self.perform(Cmd::GoTo(Position::End));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Delete, ..
@@ -981,7 +982,7 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
                 IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
                     ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown,
                 )),
-                _ => Some(Msg::None),
+                _ => None,
             },
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => match self.id {
                 IdConfigEditor::LibraryHighlightSymbol => Some(Msg::ConfigEditor(
@@ -993,7 +994,7 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
                 IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
                     ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp,
                 )),
-                _ => Some(Msg::None),
+                _ => None,
             },
 
             Event::Keyboard(KeyEvent {
@@ -1002,7 +1003,7 @@ impl Component<Msg, NoUserEvent> for ConfigInputHighlight {
                 let result = self.perform(Cmd::Submit);
                 Some(self.update_symbol(result))
             }
-            _ => Some(Msg::None),
+            _ => None,
         }
     }
 }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -116,23 +116,23 @@ fn handle_input_ev(
             code: Key::Left, ..
         }) => {
             component.perform(Cmd::Move(Direction::Left));
-            Some(Msg::None)
+            Some(Msg::ForceRedraw)
         }
         Event::Keyboard(KeyEvent {
             code: Key::Right, ..
         }) => {
             component.perform(Cmd::Move(Direction::Right));
-            Some(Msg::None)
+            Some(Msg::ForceRedraw)
         }
         Event::Keyboard(KeyEvent {
             code: Key::Home, ..
         }) => {
             component.perform(Cmd::GoTo(Position::Begin));
-            Some(Msg::None)
+            Some(Msg::ForceRedraw)
         }
         Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
             component.perform(Cmd::GoTo(Position::End));
-            Some(Msg::None)
+            Some(Msg::ForceRedraw)
         }
         Event::Keyboard(KeyEvent {
             code: Key::Delete, ..

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1327,7 +1327,6 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..
             }) => self.perform(Cmd::Submit),
-            // input
 
             // Local Hotkeys
             Event::Keyboard(KeyEvent {
@@ -1350,39 +1349,39 @@ impl Component<Msg, NoUserEvent> for KEModifierSelect {
                 ..
             }) => self.perform(Cmd::Delete),
 
+            Event::Keyboard(keyevent) if keyevent == keys.escape.get() => {
+                return Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel));
+            }
+
+            // actual key to change the binding to
             Event::Keyboard(KeyEvent {
                 code: Key::Char(ch),
                 ..
             }) => {
-                self.perform(Cmd::Type(ch));
-                match self.state() {
-                    State::One(_) => {
-                        if let Ok(binding) = self.key_event() {
-                            return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
-                                self.id, binding,
-                            )));
-                        }
-                        CmdResult::None
+                let cmd_res = self.perform(Cmd::Type(ch));
+                if let State::One(_) = self.state() {
+                    if let Ok(binding) = self.key_event() {
+                        return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
+                            self.id, binding,
+                        )));
                     }
-                    _ => CmdResult::None,
                 }
+                cmd_res
             }
-            Event::Keyboard(keyevent) if keyevent == keys.escape.get() => {
-                return Some(Msg::ConfigEditor(ConfigEditorMsg::CloseCancel));
-            }
+
             _ => CmdResult::None,
         };
         match cmd_result {
             CmdResult::Submit(State::One(StateValue::Usize(_index))) => {
-                // Some(Msg::None)
                 if let Ok(binding) = self.key_event() {
                     return Some(Msg::ConfigEditor(ConfigEditorMsg::KeyChange(
                         self.id, binding,
                     )));
                 }
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -68,7 +68,7 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -145,7 +145,10 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 
@@ -196,7 +199,7 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -286,7 +289,10 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
 
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 
@@ -337,7 +343,7 @@ impl Component<Msg, NoUserEvent> for DBListSearchTracks {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -412,7 +418,10 @@ impl Component<Msg, NoUserEvent> for DBListSearchTracks {
 
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use termusiclib::config::SharedTuiSettings;
 use tui_realm_stdlib::Textarea;
-use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{
     Alignment, AttrValue, Attribute, BorderType, Borders, PropPayload, PropValue, TextSpan,
@@ -64,7 +64,7 @@ impl Component<Msg, NoUserEvent> for Lyric {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let cmd_result = match ev {
+        let _cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -111,12 +111,11 @@ impl Component<Msg, NoUserEvent> for Lyric {
             Event::Keyboard(key) if key == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
-            _ => CmdResult::None,
+            _ => return None,
         };
-        match cmd_result {
-            CmdResult::None => None,
-            _ => Some(Msg::ForceRedraw),
-        }
+        // "Textarea::perform" currently always returns "CmdResult::None", so always redraw on event
+        // see https://github.com/veeso/tui-realm-stdlib/issues/27
+        Some(Msg::ForceRedraw)
     }
 }
 

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -64,7 +64,7 @@ impl Component<Msg, NoUserEvent> for Lyric {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _drop = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -113,7 +113,10 @@ impl Component<Msg, NoUserEvent> for Lyric {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -186,7 +186,7 @@ impl Component<Msg, NoUserEvent> for GlobalListener {
                 Some(Msg::Xywh(XYWHMsg::ZoomOut))
             }
             Event::Keyboard(keyevent) if keyevent == keys.move_cover_art_keys.toggle_hide.get() => {
-                Some(Msg::Xywh(XYWHMsg::Hide))
+                Some(Msg::Xywh(XYWHMsg::ToggleHidden))
             }
             _ => None,
         }

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -229,7 +229,8 @@ impl Component<Msg, NoUserEvent> for MusicLibrary {
             CmdResult::Submit(State::One(StateValue::String(node))) => {
                 Some(Msg::Library(LIMsg::TreeStepInto(node)))
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -72,7 +72,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -122,7 +122,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
                     State::One(StateValue::Usize(index_selected)) => {
                         return Some(Msg::Playlist(PLMsg::Delete(index_selected)))
                     }
-                    _ => return Some(Msg::None),
+                    _ => CmdResult::None,
                 }
             }
             Event::Keyboard(key) if key == keys.playlist_keys.delete_all.get() => {
@@ -159,7 +159,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
                         self.perform(Cmd::Move(Direction::Down));
                         return Some(Msg::Playlist(PLMsg::SwapDown(index_selected)));
                     }
-                    _ => return Some(Msg::None),
+                    _ => CmdResult::None,
                 }
             }
             Event::Keyboard(key) if key == keys.playlist_keys.swap_up.get() => {
@@ -168,7 +168,7 @@ impl Component<Msg, NoUserEvent> for Playlist {
                         self.perform(Cmd::Move(Direction::Up));
                         return Some(Msg::Playlist(PLMsg::SwapUp(index_selected)));
                     }
-                    _ => return Some(Msg::None),
+                    _ => CmdResult::None,
                 }
             }
             Event::Keyboard(key) if key == keys.playlist_keys.add_random_album.get() => {
@@ -179,7 +179,10 @@ impl Component<Msg, NoUserEvent> for Playlist {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -69,7 +69,7 @@ impl Component<Msg, NoUserEvent> for FeedsList {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -177,7 +177,10 @@ impl Component<Msg, NoUserEvent> for FeedsList {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 
@@ -229,7 +232,7 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Down,
                 modifiers: KeyModifiers::NONE,
@@ -342,7 +345,10 @@ impl Component<Msg, NoUserEvent> for EpisodeList {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -105,14 +105,9 @@ impl Component<Msg, NoUserEvent> for DeleteConfirmInputPopup {
                 }
                 Some(Msg::DeleteConfirmCloseCancel)
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
-
-        // if cmd_result == CmdResult::Submit(State::One(StateValue::String("DELETE".to_string()))) {
-        //     Some(Msg::DeleteConfirmCloseOk)
-        // } else {
-        //     Some(Msg::DeleteConfirmCloseCancel)
-        // }
     }
 }
 

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -131,7 +131,8 @@ impl Component<Msg, NoUserEvent> for GSInputPopup {
             },
             CmdResult::Submit(_) => Some(Msg::GeneralSearch(GSMsg::InputBlur)),
 
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }
@@ -311,7 +312,7 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => {
                 return Some(Msg::GeneralSearch(GSMsg::PopupCloseCancel))
             }
@@ -389,7 +390,10 @@ impl Component<Msg, NoUserEvent> for GSTablePopup {
             },
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -283,7 +283,7 @@ impl Component<Msg, NoUserEvent> for HelpPopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Enter,
                 modifiers: KeyModifiers::NONE,
@@ -309,7 +309,10 @@ impl Component<Msg, NoUserEvent> for HelpPopup {
             _ => CmdResult::None,
         };
 
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/popups/mock_yn_confirm.rs
+++ b/tui/src/ui/components/popups/mock_yn_confirm.rs
@@ -108,18 +108,12 @@ impl YNConfirm {
             }) => self.perform(Cmd::Submit),
             _ => return None,
         };
-        if matches!(
-            cmd_result,
-            CmdResult::Submit(State::One(StateValue::Usize(0)))
-        ) {
-            Some(on_n)
-        } else if matches!(
-            cmd_result,
-            CmdResult::Submit(State::One(StateValue::Usize(1)))
-        ) {
-            Some(on_y)
-        } else {
-            Some(Msg::None)
+
+        match cmd_result {
+            CmdResult::Submit(State::One(StateValue::Usize(0))) => Some(on_n),
+            CmdResult::Submit(State::One(StateValue::Usize(1))) => Some(on_y),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }

--- a/tui/src/ui/components/popups/podcast.rs
+++ b/tui/src/ui/components/popups/podcast.rs
@@ -41,7 +41,7 @@ impl PodcastAddPopup {
 
 impl Component<Msg, NoUserEvent> for PodcastAddPopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
             }) => self.perform(Cmd::Move(Direction::Left)),
@@ -74,16 +74,14 @@ impl Component<Msg, NoUserEvent> for PodcastAddPopup {
                 State::One(StateValue::String(input_string)) => {
                     return Some(Msg::Podcast(PCMsg::PodcastAddPopupCloseOk(input_string)));
                 }
-                _ => return Some(Msg::None),
+                _ => CmdResult::None,
             },
             _ => CmdResult::None,
         };
-        // match cmd_result {
-        //     CmdResult::Submit(State::One(StateValue::String(input_string))) => {
-        //         Some(Msg::SavePlaylistPopupUpdate(input_string))
-        //     }
-        Some(Msg::None)
-        // }
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 
@@ -186,14 +184,9 @@ impl Component<Msg, NoUserEvent> for FeedDeleteConfirmInputPopup {
                 }
                 Some(Msg::Podcast(PCMsg::FeedsDeleteCloseCancel))
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
-
-        // if cmd_result == CmdResult::Submit(State::One(StateValue::String("DELETE".to_string()))) {
-        //     Some(Msg::DeleteConfirmCloseOk)
-        // } else {
-        //     Some(Msg::DeleteConfirmCloseCancel)
-        // }
     }
 }
 
@@ -243,7 +236,7 @@ impl Component<Msg, NoUserEvent> for PodcastSearchTablePopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => {
                 return Some(Msg::Podcast(PCMsg::SearchItunesCloseCancel))
             }
@@ -295,7 +288,10 @@ impl Component<Msg, NoUserEvent> for PodcastSearchTablePopup {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/popups/saveplaylist.rs
+++ b/tui/src/ui/components/popups/saveplaylist.rs
@@ -78,7 +78,7 @@ impl Component<Msg, NoUserEvent> for SavePlaylistPopup {
                 State::One(StateValue::String(input_string)) => {
                     return Some(Msg::SavePlaylistPopupCloseOk(input_string))
                 }
-                _ => return Some(Msg::None),
+                _ => CmdResult::None,
             },
             _ => CmdResult::None,
         };
@@ -86,7 +86,8 @@ impl Component<Msg, NoUserEvent> for SavePlaylistPopup {
             CmdResult::Submit(State::One(StateValue::String(input_string))) => {
                 Some(Msg::SavePlaylistPopupUpdate(input_string))
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -93,7 +93,8 @@ impl Component<Msg, NoUserEvent> for YSInputPopup {
                 Some(Msg::YoutubeSearch(YSMsg::InputPopupCloseOk(input_string)))
             }
 
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }
@@ -147,7 +148,7 @@ impl Component<Msg, NoUserEvent> for YSTablePopup {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => {
                 return Some(Msg::YoutubeSearch(YSMsg::TablePopupCloseCancel))
             }
@@ -199,7 +200,10 @@ impl Component<Msg, NoUserEvent> for YSTablePopup {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -37,7 +37,7 @@ impl Progress {
 
 impl Component<Msg, NoUserEvent> for Progress {
     fn on(&mut self, _ev: Event<NoUserEvent>) -> Option<Msg> {
-        Some(Msg::None)
+        None
     }
 }
 

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -86,36 +86,36 @@ impl EditField {
                 code: Key::Left, ..
             }) => {
                 self.perform(Cmd::Move(Direction::Left));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Right, ..
             }) => {
                 self.perform(Cmd::Move(Direction::Right));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Home, ..
             }) => {
                 self.perform(Cmd::GoTo(Position::Begin));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent { code: Key::End, .. }) => {
                 self.perform(Cmd::GoTo(Position::End));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Delete, ..
             }) => {
                 self.perform(Cmd::Cancel);
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Backspace,
                 ..
             }) => {
                 self.perform(Cmd::Delete);
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
 
             Event::Keyboard(KeyEvent {
@@ -123,7 +123,7 @@ impl EditField {
                 modifiers: KeyModifiers::SHIFT | KeyModifiers::NONE,
             }) => {
                 self.perform(Cmd::Type(ch));
-                Some(Msg::None)
+                Some(Msg::ForceRedraw)
             }
 
             Event::Keyboard(KeyEvent {

--- a/tui/src/ui/components/tag_editor/te_select_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_select_lyric.rs
@@ -120,7 +120,8 @@ impl Component<Msg, NoUserEvent> for TESelectLyric {
             CmdResult::Submit(State::One(StateValue::Usize(index))) => {
                 Some(Msg::TagEditor(TEMsg::TESelectLyricOk(index)))
             }
-            _ => Some(Msg::None),
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
         }
     }
 }

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -80,7 +80,7 @@ impl Component<Msg, NoUserEvent> for TETableLyricOptions {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
                 return Some(Msg::TagEditor(TEMsg::TEFocus(
                     TFMsg::TableLyricOptionsBlurDown,
@@ -155,7 +155,10 @@ impl Component<Msg, NoUserEvent> for TETableLyricOptions {
 
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }
 

--- a/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
@@ -62,7 +62,7 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let _cmd_result = match ev {
+        let cmd_result = match ev {
             Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
@@ -115,6 +115,9 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
             }
             _ => CmdResult::None,
         };
-        Some(Msg::None)
+        match cmd_result {
+            CmdResult::None => None,
+            _ => Some(Msg::ForceRedraw),
+        }
     }
 }

--- a/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_textarea_lyric.rs
@@ -26,7 +26,7 @@ use crate::ui::{Msg, TEMsg, TFMsg};
 
 use termusiclib::config::SharedTuiSettings;
 use tui_realm_stdlib::Textarea;
-use tuirealm::command::{Cmd, CmdResult, Direction, Position};
+use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
 use tuirealm::props::{Alignment, BorderType, Borders, TextSpan};
 use tuirealm::{Component, Event, MockComponent};
@@ -62,7 +62,7 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
-        let cmd_result = match ev {
+        let _cmd_result = match ev {
             Event::Keyboard(keyevent) if keyevent == keys.config_keys.save.get() => {
                 return Some(Msg::TagEditor(TEMsg::TERename))
             }
@@ -113,11 +113,10 @@ impl Component<Msg, NoUserEvent> for TETextareaLyric {
             Event::Keyboard(k) if k == keys.navigation_keys.goto_bottom.get() => {
                 self.perform(Cmd::GoTo(Position::End))
             }
-            _ => CmdResult::None,
+            _ => return None,
         };
-        match cmd_result {
-            CmdResult::None => None,
-            _ => Some(Msg::ForceRedraw),
-        }
+        // "Textarea::perform" currently always returns "CmdResult::None", so always redraw on event
+        // see https://github.com/veeso/tui-realm-stdlib/issues/27
+        Some(Msg::ForceRedraw)
     }
 }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -133,7 +133,6 @@ impl Update<Msg> for Model {
                     self.update_layout(&msg)
                 }
 
-                Msg::None => None,
                 Msg::SavePlaylistPopupShow => {
                     if let Err(e) = self.mount_save_playlist() {
                         self.mount_error_popup(e.context("mount save playlist"));
@@ -172,6 +171,8 @@ impl Update<Msg> for Model {
                 Msg::LyricMessage(m) => self.update_lyric_textarea(m),
                 Msg::Download(m) => self.update_download_msg(&m),
                 Msg::Xywh(m) => self.update_xywh_msg(m),
+
+                Msg::None | Msg::ForceRedraw => None,
             }
         } else {
             None

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -670,6 +670,15 @@ impl Model {
                     self.mount_error_popup(e.context("youtube-dl options download"));
                 }
             }
+            YSMsg::YoutubeSearchSuccess(y) => {
+                self.youtube_options = y.clone();
+                self.sync_youtube_options();
+                self.redraw = true;
+            }
+            YSMsg::YoutubeSearchFail(e) => {
+                self.redraw = true;
+                self.mount_error_popup(anyhow!("Youtube search fail: {e}"));
+            }
         }
     }
 
@@ -1005,14 +1014,6 @@ impl Model {
             }
             DLMsg::MessageHide((title, text)) => {
                 self.umount_message(title, text);
-            }
-            DLMsg::YoutubeSearchSuccess(y) => {
-                self.youtube_options = y.clone();
-                self.sync_youtube_options();
-                self.redraw = true;
-            }
-            DLMsg::YoutubeSearchFail(e) => {
-                self.mount_error_popup(anyhow!("Youtube search fail: {e}"));
             }
             DLMsg::FetchPhotoSuccess(image_wrapper) => {
                 self.show_image(&image_wrapper.data).ok();

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -172,7 +172,7 @@ impl Update<Msg> for Model {
                 Msg::Download(m) => self.update_download_msg(&m),
                 Msg::Xywh(m) => self.update_xywh_msg(m),
 
-                Msg::None | Msg::ForceRedraw => None,
+                Msg::ForceRedraw => None,
             }
         } else {
             None

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -108,7 +108,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::YoutubeSearch(m) => {
-                    self.update_youtube_search(&m);
+                    self.update_youtube_search(m);
                     None
                 }
                 Msg::LyricCycle => {
@@ -629,7 +629,7 @@ impl Model {
         }
     }
 
-    fn update_youtube_search(&mut self, msg: &YSMsg) {
+    fn update_youtube_search(&mut self, msg: YSMsg) {
         match msg {
             YSMsg::InputPopupShow => {
                 self.mount_youtube_search_input();
@@ -644,7 +644,7 @@ impl Model {
                     assert!(self.app.umount(&Id::YoutubeSearchInputPopup).is_ok());
                 }
                 if url.starts_with("http") {
-                    match self.youtube_dl(url) {
+                    match self.youtube_dl(&url) {
                         Ok(()) => {}
                         Err(e) => {
                             self.mount_error_popup(e.context("youtube-dl download"));
@@ -665,13 +665,13 @@ impl Model {
                 self.youtube_options_prev_page();
             }
             YSMsg::TablePopupCloseOk(index) => {
-                if let Err(e) = self.youtube_options_download(*index) {
+                if let Err(e) = self.youtube_options_download(index) {
                     self.library_reload_with_node_focus(None);
                     self.mount_error_popup(e.context("youtube-dl options download"));
                 }
             }
-            YSMsg::YoutubeSearchSuccess(y) => {
-                self.youtube_options = y.clone();
+            YSMsg::YoutubeSearchSuccess(youtube_options) => {
+                self.youtube_options = youtube_options;
                 self.sync_youtube_options();
                 self.redraw = true;
             }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -197,7 +197,7 @@ impl Model {
             XYWHMsg::MoveDown => self.xywh_move_down(),
             XYWHMsg::ZoomIn => self.xywh_zoom_in(),
             XYWHMsg::ZoomOut => self.xywh_zoom_out(),
-            XYWHMsg::Hide => {
+            XYWHMsg::ToggleHidden => {
                 self.xywh_toggle_hide();
             }
         };

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -61,11 +61,10 @@ impl Model {
     }
 
     /// This function requires to be run in a tokio Runtime context
-    pub fn youtube_options_search(&mut self, keyword: &str) {
-        let search_word = keyword.to_string();
+    pub fn youtube_options_search(&mut self, keyword: String) {
         let tx = self.tx_to_main.clone();
         tokio::spawn(async move {
-            match Instance::new(&search_word).await {
+            match Instance::new(&keyword).await {
                 Ok((instance, result)) => {
                     let youtube_options = YoutubeOptions {
                         items: result,

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -33,8 +33,8 @@ use std::thread::{self, sleep};
 use std::time::Duration;
 use termusiclib::invidious::Instance;
 use termusiclib::track::Track;
-use termusiclib::types::YoutubeOptions;
 use termusiclib::types::{DLMsg, Id, Msg};
+use termusiclib::types::{YSMsg, YoutubeOptions};
 use termusiclib::utils::get_parent_folder;
 use tokio::runtime::Handle;
 use tuirealm::props::{Alignment, AttrValue, Attribute, TableBuilder, TextSpan};
@@ -72,11 +72,13 @@ impl Model {
                         page: 1,
                         invidious_instance: instance,
                     };
-                    tx.send(Msg::Download(DLMsg::YoutubeSearchSuccess(youtube_options)))
-                        .ok();
+                    tx.send(Msg::YoutubeSearch(YSMsg::YoutubeSearchSuccess(
+                        youtube_options,
+                    )))
+                    .ok();
                 }
                 Err(e) => {
-                    tx.send(Msg::Download(DLMsg::YoutubeSearchFail(e.to_string())))
+                    tx.send(Msg::YoutubeSearch(YSMsg::YoutubeSearchFail(e.to_string())))
                         .ok();
                 }
             }


### PR DESCRIPTION
This PR does:
- remove `Msg::None` and replace it with `Option::None` or `Msg::ForceRedraw` where necessary
- decrease amount of string clones in downloads
- move `YoutubeSearch*` variants from `DLMsg` to `YSMsg`
- rename `XYWHMsg::Hide` to `ToggleHidden`
- fix a panic in `playback::playlist::swap_down` when the playlist is empty

~~Draft until https://github.com/tramhao/termusic/pull/407 is merged and clippy is re-run~~

Also related is https://github.com/veeso/tui-realm-stdlib/issues/27