### PR TITLE
Feature/improve searching options

### DIFF
--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -36,7 +36,7 @@ use track_db::TrackDBInsertable;
 mod migration;
 mod track_db;
 
-pub use track_db::{const_unknown, TrackDB};
+pub use track_db::{const_unknown, Indexable, TrackDB};
 
 pub struct DataBase {
     conn: Arc<Mutex<Connection>>,

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -147,6 +147,10 @@ impl TrackDBInsertable<'_> {
     }
 }
 
+/// Defined for types which could be indexed.
+/// Was made to allow generalization of indexing/search functions.
+///
+/// the required functions are generally the metadata you would find in an mp3 file.
 pub trait Indexable {
     fn meta_file(&self) -> Option<&str>;
     fn meta_title(&self) -> Option<&str>;

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -146,3 +146,70 @@ impl TrackDBInsertable<'_> {
         )
     }
 }
+
+pub trait Indexable {
+    fn meta_file(&self) -> Option<&str>;
+    fn meta_title(&self) -> Option<&str>;
+    fn meta_album(&self) -> Option<&str>;
+    fn meta_artist(&self) -> Option<&str>;
+    fn meta_genre(&self) -> Option<&str>;
+    fn duration(&self) -> Duration;
+}
+
+impl Indexable for Track {
+    fn meta_file(&self) -> Option<&str> {
+        self.file()
+    }
+    fn meta_title(&self) -> Option<&str> {
+        self.title()
+    }
+    fn meta_album(&self) -> Option<&str> {
+        self.album()
+    }
+    fn meta_artist(&self) -> Option<&str> {
+        self.artist()
+    }
+    fn meta_genre(&self) -> Option<&str> {
+        self.genre()
+    }
+    fn duration(&self) -> Duration {
+        self.duration()
+    }
+}
+
+impl Indexable for TrackDB {
+    fn meta_file(&self) -> Option<&str> {
+        if self.file == UNKNOWN_FILE {
+            return None;
+        }
+        Some(&self.file)
+    }
+    fn meta_title(&self) -> Option<&str> {
+        if self.title == UNKNOWN_TITLE {
+            return None;
+        }
+        Some(&self.title)
+    }
+    fn meta_album(&self) -> Option<&str> {
+        if self.album == UNKNOWN_ALBUM {
+            return None;
+        }
+        Some(&self.album)
+    }
+    fn meta_artist(&self) -> Option<&str> {
+        if self.artist == UNKNOWN_ARTIST {
+            return None;
+        }
+        Some(&self.artist)
+    }
+    fn meta_genre(&self) -> Option<&str> {
+        if self.genre == UNKNOWN_GENRE {
+            return None;
+        }
+        Some(&self.genre)
+    }
+
+    fn duration(&self) -> Duration {
+        self.duration
+    }
+}

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -619,7 +619,7 @@ impl Model {
         self.database_sync_results();
     }
 
-    pub fn update_search<T: Indexable>(&self, indexable_songs: &Vec<T>, input: &str) -> Table {
+    pub fn update_search<T: Indexable>(indexable_songs: &Vec<T>, input: &str) -> Table {
         let mut table: TableBuilder = TableBuilder::default();
         let search = format!("*{}*", input.to_lowercase());
         let mut idx = 0;
@@ -676,7 +676,7 @@ impl Model {
             db_tracks.clone_from(&tracks);
         }
 
-        let table = self.update_search(&db_tracks, input);
+        let table = Model::update_search(&db_tracks, input);
         self.general_search_update_show(table);
     }
 }

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -1,13 +1,14 @@
 use crate::ui::Model;
 use std::path::Path;
 use termusiclib::config::SharedTuiSettings;
-use termusiclib::library_db::SearchCriteria;
+use termusiclib::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_FILE, UNKNOWN_TITLE};
+use termusiclib::library_db::{Indexable, SearchCriteria};
 use termusiclib::types::{DBMsg, Id, Msg};
 use termusiclib::utils::{is_playlist, playlist_get_vec};
 use tui_realm_stdlib::List;
 use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::props::Borders;
-use tuirealm::props::{Alignment, BorderType, TableBuilder, TextSpan};
+use tuirealm::props::{Alignment, BorderType, Table, TableBuilder, TextSpan};
 use tuirealm::{
     event::{Key, KeyEvent, KeyModifiers, NoUserEvent},
     AttrValue, Attribute, Component, Event, MockComponent, State, StateValue,
@@ -618,47 +619,64 @@ impl Model {
         self.database_sync_results();
     }
 
-    pub fn database_update_search(&mut self, input: &str) {
+    pub fn update_search<T: Indexable>(&self, indexable_songs: &Vec<T>, input: &str) -> Table {
         let mut table: TableBuilder = TableBuilder::default();
-        let mut idx = 0;
         let search = format!("*{}*", input.to_lowercase());
-        let mut db_tracks = vec![];
-        if let Ok(tracks) = self.db.get_all_records() {
-            db_tracks.clone_from(&tracks);
-            for record in tracks {
-                if wildmatch::WildMatch::new(&search).matches(&record.artist.to_lowercase())
-                    | wildmatch::WildMatch::new(&search).matches(&record.title.to_lowercase())
-                    | wildmatch::WildMatch::new(&search).matches(&record.album.to_lowercase())
-                {
-                    if idx > 0 {
-                        table.add_row();
-                    }
-
-                    let duration =
-                        termusiclib::track::Track::duration_formatted_short(&record.duration);
-                    let duration_string = format!("[{duration:^6.6}]");
-
-                    table
-                        .add_col(TextSpan::new(duration_string.as_str()))
-                        .add_col(
-                            TextSpan::new(record.artist)
-                                .fg(tuirealm::ratatui::style::Color::LightYellow),
-                        )
-                        .add_col(TextSpan::new(record.title).bold())
-                        .add_col(TextSpan::new(record.file));
-                    // .add_col(TextSpan::new(record.album().unwrap_or("Unknown Album")));
-                    idx += 1;
+        let mut idx = 0;
+        for record in indexable_songs {
+            let artist_match: bool = if let Some(artist) = record.meta_artist() {
+                wildmatch::WildMatch::new(&search).matches(&artist.to_lowercase())
+            } else {
+                false
+            };
+            let title_match: bool = if let Some(title) = record.meta_title() {
+                wildmatch::WildMatch::new(&search).matches(&title.to_lowercase())
+            } else {
+                false
+            };
+            let album_match: bool = if let Some(album) = record.meta_album() {
+                wildmatch::WildMatch::new(&search).matches(&album.to_lowercase())
+            } else {
+                false
+            };
+            if artist_match || title_match || album_match {
+                if idx > 0 {
+                    table.add_row();
                 }
+                idx += 1;
+
+                let duration =
+                    termusiclib::track::Track::duration_formatted_short(&record.duration());
+                let duration_string = format!("[{duration:^6.6}]");
+
+                table
+                    .add_col(TextSpan::new(duration_string))
+                    .add_col(
+                        TextSpan::new(record.meta_artist().unwrap_or(UNKNOWN_ARTIST))
+                            .fg(tuirealm::ratatui::style::Color::LightYellow),
+                    )
+                    .add_col(TextSpan::new(record.meta_title().unwrap_or(UNKNOWN_TITLE)).bold())
+                    .add_col(TextSpan::new(record.meta_file().unwrap_or(UNKNOWN_FILE)));
             }
         }
 
-        if db_tracks.is_empty() {
+        if indexable_songs.is_empty() {
             table.add_col(TextSpan::from("0"));
             table.add_col(TextSpan::from("empty tracks from db"));
             table.add_col(TextSpan::from(""));
         }
         let table = table.build();
 
+        table
+    }
+
+    pub fn database_update_search(&mut self, input: &str) {
+        let mut db_tracks = vec![];
+        if let Ok(tracks) = self.db.get_all_records() {
+            db_tracks.clone_from(&tracks);
+        }
+
+        let table = self.update_search(&db_tracks, input);
         self.general_search_update_show(table);
     }
 }

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -628,6 +628,7 @@ impl Model {
             for record in tracks {
                 if wildmatch::WildMatch::new(&search).matches(&record.artist.to_lowercase())
                     | wildmatch::WildMatch::new(&search).matches(&record.title.to_lowercase())
+                    | wildmatch::WildMatch::new(&search).matches(&record.album.to_lowercase())
                 {
                     if idx > 0 {
                         table.add_row();

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -665,9 +665,7 @@ impl Model {
             table.add_col(TextSpan::from("empty tracks from db/playlist"));
             table.add_col(TextSpan::from(""));
         }
-        let table = table.build();
-
-        table
+        table.build()
     }
 
     pub fn database_update_search(&mut self, input: &str) {

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -662,7 +662,7 @@ impl Model {
 
         if indexable_songs.is_empty() {
             table.add_col(TextSpan::from("0"));
-            table.add_col(TextSpan::from("empty tracks from db"));
+            table.add_col(TextSpan::from("empty tracks from db/playlist"));
             table.add_col(TextSpan::from(""));
         }
         let table = table.build();

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::Path;
 use termusiclib::config::SharedTuiSettings;
-use termusiclib::library_db::const_unknown::{UNKNOWN_ALBUM, UNKNOWN_ARTIST, UNKNOWN_TITLE};
+use termusiclib::library_db::const_unknown::{UNKNOWN_ALBUM, UNKNOWN_ARTIST};
 use termusiclib::library_db::SearchCriteria;
 use termusiclib::library_db::TrackDB;
 use termusiclib::track::Track;

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -524,7 +524,7 @@ impl Model {
     }
 
     pub fn playlist_update_search(&mut self, input: &str) {
-        let table = self.update_search(self.playlist.tracks(), input);
+        let table = Model::update_search(self.playlist.tracks(), input);
         self.general_search_update_show(table);
     }
 

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -524,44 +524,7 @@ impl Model {
     }
 
     pub fn playlist_update_search(&mut self, input: &str) {
-        let mut table: TableBuilder = TableBuilder::default();
-        let mut idx = 0;
-        let search = format!("*{}*", input.to_lowercase());
-        for record in self.playlist.tracks() {
-            let artist = record.artist().unwrap_or(UNKNOWN_ARTIST);
-            let title = record.title().unwrap_or(UNKNOWN_TITLE);
-            if wildmatch::WildMatch::new(&search).matches(&artist.to_lowercase())
-                | wildmatch::WildMatch::new(&search).matches(&title.to_lowercase())
-            {
-                if idx > 0 {
-                    table.add_row();
-                }
-
-                let duration = record.duration_formatted().to_string();
-                let duration_string = format!("[{duration:^6.6}]");
-
-                let noname_string = "No Name".to_string();
-                let name = record.name().unwrap_or(&noname_string);
-                let artist = record.artist().unwrap_or(UNKNOWN_ARTIST);
-                let title = record.title().unwrap_or(name);
-                let file_name = record.file().unwrap_or("no file");
-
-                table
-                    .add_col(TextSpan::new(duration_string.as_str()))
-                    .add_col(TextSpan::new(artist).fg(tuirealm::ratatui::style::Color::LightYellow))
-                    .add_col(TextSpan::new(title).bold())
-                    .add_col(TextSpan::new(file_name));
-                // .add_col(TextSpan::new(record.album().unwrap_or("Unknown Album")));
-                idx += 1;
-            }
-        }
-        if self.playlist.is_empty() {
-            table.add_col(TextSpan::from("0"));
-            table.add_col(TextSpan::from("empty playlist"));
-            table.add_col(TextSpan::from(""));
-        }
-        let table = table.build();
-
+        let table = self.update_search(self.playlist.tracks(), input);
         self.general_search_update_show(table);
     }
 


### PR DESCRIPTION
add an option to specify what you search by
when "quick searching" in the database/playlist

The search options (for now) will be by album/artist/title.

I will need some guidance as to what are the standards of Rust code since this is my first time contributing using thing this language. 

+ I opened it early since I'm not sure how it is best to change the API between the client and the server.
