### PR TITLE
Cleanup proto definitions

### DIFF
--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -3,44 +3,39 @@ package player;
 
 service MusicPlayer {
   // Player Commands
-  rpc TogglePause(TogglePauseRequest) returns (TogglePauseResponse);
-  rpc SkipNext(SkipNextRequest) returns (SkipNextResponse);
-  rpc SkipPrevious(SkipPreviousRequest) returns (Empty);
-  rpc GetProgress(GetProgressRequest) returns (GetProgressResponse);
-  rpc VolumeUp(VolumeUpRequest) returns (VolumeReply);
-  rpc VolumeDown(VolumeDownRequest) returns (VolumeReply);
-  rpc SpeedUp(SpeedUpRequest) returns (SpeedReply);
-  rpc SpeedDown(SpeedDownRequest) returns (SpeedReply);
-  rpc ToggleGapless(ToggleGaplessRequest) returns (ToggleGaplessReply);
-  rpc SeekForward(SeekForwardRequest) returns (PlayerTime);
-  rpc SeekBackward(SeekBackwardRequest) returns (PlayerTime);
+  rpc TogglePause(Empty) returns (TogglePauseResponse);
+  rpc SkipNext(Empty) returns (Empty);
+  rpc SkipPrevious(Empty) returns (Empty);
+  rpc GetProgress(Empty) returns (GetProgressResponse);
+  rpc VolumeUp(Empty) returns (VolumeReply);
+  rpc VolumeDown(Empty) returns (VolumeReply);
+  rpc SpeedUp(Empty) returns (SpeedReply);
+  rpc SpeedDown(Empty) returns (SpeedReply);
+  rpc ToggleGapless(Empty) returns (ToggleGaplessReply);
+  rpc SeekForward(Empty) returns (PlayerTime);
+  rpc SeekBackward(Empty) returns (PlayerTime);
 
   // Playlist Commands
-  rpc PlaySelected(PlaySelectedRequest) returns (Empty);
-  rpc CycleLoop(CycleLoopRequest) returns (CycleLoopReply);
-  rpc ReloadPlaylist(ReloadPlaylistRequest) returns (Empty);
+  rpc PlaySelected(Empty) returns (Empty);
+  rpc CycleLoop(Empty) returns (Empty);
+  rpc ReloadPlaylist(Empty) returns (Empty);
 
   // Misc Commands
-  rpc ReloadConfig(ReloadConfigRequest) returns (Empty);
+  rpc ReloadConfig(Empty) returns (Empty);
   rpc SubscribeServerUpdates(Empty) returns (stream StreamUpdates);
 }
 
 message Empty {}
 
-message TogglePauseRequest {}
 message TogglePauseResponse {
   uint32 status = 1;
 }
-
-message SkipNextRequest {}
-message SkipNextResponse {}
 
 message PlayerTime {
   Duration position = 1;
   Duration total_duration = 2;
 }
 
-message GetProgressRequest {}
 message GetProgressResponse {
   PlayerTime progress = 1;
   uint32 current_track_index = 3;
@@ -53,35 +48,18 @@ message GetProgressResponse {
   string radio_title = 9;
 }
 
-message VolumeUpRequest {}
-message VolumeDownRequest {}
 message VolumeReply {
   // actually a u16, but protobuf does not support types lower than 32 bits
   uint32 volume = 1;
 }
 
-message CycleLoopRequest {}
-message CycleLoopReply {}
-
-message SpeedUpRequest {}
-message SpeedDownRequest {}
 message SpeedReply {
   int32 speed = 1;
 }
 
-message ToggleGaplessRequest {}
 message ToggleGaplessReply {
   bool gapless = 1;
 }
-
-message SeekForwardRequest {}
-message SeekBackwardRequest {}
-
-message ReloadConfigRequest {}
-message ReloadPlaylistRequest {}
-
-message PlaySelectedRequest {}
-message SkipPreviousRequest {}
 
 // using a custom Duration that matches rust's definition, as rust's may not fit
 // into google's well-known Duration

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -5,7 +5,7 @@ service MusicPlayer {
   // Player Commands
   rpc TogglePause(TogglePauseRequest) returns (TogglePauseResponse);
   rpc SkipNext(SkipNextRequest) returns (SkipNextResponse);
-  rpc SkipPrevious(SkipPreviousRequest) returns (EmptyReply);
+  rpc SkipPrevious(SkipPreviousRequest) returns (Empty);
   rpc GetProgress(GetProgressRequest) returns (GetProgressResponse);
   rpc VolumeUp(VolumeUpRequest) returns (VolumeReply);
   rpc VolumeDown(VolumeDownRequest) returns (VolumeReply);
@@ -16,14 +16,16 @@ service MusicPlayer {
   rpc SeekBackward(SeekBackwardRequest) returns (PlayerTime);
 
   // Playlist Commands
-  rpc PlaySelected(PlaySelectedRequest) returns (EmptyReply);
+  rpc PlaySelected(PlaySelectedRequest) returns (Empty);
   rpc CycleLoop(CycleLoopRequest) returns (CycleLoopReply);
-  rpc ReloadPlaylist(ReloadPlaylistRequest) returns (EmptyReply);
+  rpc ReloadPlaylist(ReloadPlaylistRequest) returns (Empty);
 
   // Misc Commands
-  rpc ReloadConfig(ReloadConfigRequest) returns (EmptyReply);
-  rpc SubscribeServerUpdates(EmptyReply) returns (stream StreamUpdates);
+  rpc ReloadConfig(ReloadConfigRequest) returns (Empty);
+  rpc SubscribeServerUpdates(Empty) returns (stream StreamUpdates);
 }
+
+message Empty {}
 
 message TogglePauseRequest {}
 message TogglePauseResponse {
@@ -77,8 +79,6 @@ message SeekBackwardRequest {}
 
 message ReloadConfigRequest {}
 message ReloadPlaylistRequest {}
-
-message EmptyReply {}
 
 message PlaySelectedRequest {}
 message SkipPreviousRequest {}

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -2,22 +2,26 @@ syntax = "proto3";
 package player;
 
 service MusicPlayer {
+  // Player Commands
   rpc TogglePause(TogglePauseRequest) returns (TogglePauseResponse);
   rpc SkipNext(SkipNextRequest) returns (SkipNextResponse);
+  rpc SkipPrevious(SkipPreviousRequest) returns (EmptyReply);
   rpc GetProgress(GetProgressRequest) returns (GetProgressResponse);
   rpc VolumeUp(VolumeUpRequest) returns (VolumeReply);
   rpc VolumeDown(VolumeDownRequest) returns (VolumeReply);
-  rpc CycleLoop(CycleLoopRequest) returns (CycleLoopReply);
   rpc SpeedUp(SpeedUpRequest) returns (SpeedReply);
   rpc SpeedDown(SpeedDownRequest) returns (SpeedReply);
   rpc ToggleGapless(ToggleGaplessRequest) returns (ToggleGaplessReply);
   rpc SeekForward(SeekForwardRequest) returns (PlayerTime);
   rpc SeekBackward(SeekBackwardRequest) returns (PlayerTime);
-  rpc ReloadConfig(ReloadConfigRequest) returns (EmptyReply);
-  rpc ReloadPlaylist(ReloadPlaylistRequest) returns (EmptyReply);
-  rpc PlaySelected(PlaySelectedRequest) returns (EmptyReply);
-  rpc SkipPrevious(SkipPreviousRequest) returns (EmptyReply);
 
+  // Playlist Commands
+  rpc PlaySelected(PlaySelectedRequest) returns (EmptyReply);
+  rpc CycleLoop(CycleLoopRequest) returns (CycleLoopReply);
+  rpc ReloadPlaylist(ReloadPlaylistRequest) returns (EmptyReply);
+
+  // Misc Commands
+  rpc ReloadConfig(ReloadConfigRequest) returns (EmptyReply);
   rpc SubscribeServerUpdates(EmptyReply) returns (stream StreamUpdates);
 }
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::{
-    stream_updates, CycleLoopReply, CycleLoopRequest, EmptyReply, GetProgressRequest,
+    stream_updates, CycleLoopReply, CycleLoopRequest, Empty, GetProgressRequest,
     GetProgressResponse, PlaySelectedRequest, PlayerTime, ReloadConfigRequest,
     ReloadPlaylistRequest, SeekBackwardRequest, SeekForwardRequest, SkipNextRequest,
     SkipNextResponse, SkipPreviousRequest, SpeedDownRequest, SpeedReply, SpeedUpRequest,
@@ -73,8 +73,8 @@ impl MusicPlayer for MusicPlayerService {
     async fn play_selected(
         &self,
         _request: Request<PlaySelectedRequest>,
-    ) -> Result<Response<EmptyReply>, Status> {
-        let reply = EmptyReply {};
+    ) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::PlaySelected);
 
         Ok(Response::new(reply))
@@ -83,8 +83,8 @@ impl MusicPlayer for MusicPlayerService {
     async fn reload_config(
         &self,
         _request: Request<ReloadConfigRequest>,
-    ) -> Result<Response<EmptyReply>, Status> {
-        let reply = EmptyReply {};
+    ) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::ReloadConfig);
 
         Ok(Response::new(reply))
@@ -93,8 +93,8 @@ impl MusicPlayer for MusicPlayerService {
     async fn reload_playlist(
         &self,
         _request: Request<ReloadPlaylistRequest>,
-    ) -> Result<Response<EmptyReply>, Status> {
-        let reply = EmptyReply {};
+    ) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::ReloadPlaylist);
 
         Ok(Response::new(reply))
@@ -139,8 +139,8 @@ impl MusicPlayer for MusicPlayerService {
     async fn skip_previous(
         &self,
         _request: Request<SkipPreviousRequest>,
-    ) -> Result<Response<EmptyReply>, Status> {
-        let reply = EmptyReply {};
+    ) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::SkipPrevious);
 
         Ok(Response::new(reply))
@@ -231,7 +231,7 @@ impl MusicPlayer for MusicPlayerService {
         Pin<Box<dyn Stream<Item = Result<termusiclib::player::StreamUpdates, Status>> + Send>>;
     async fn subscribe_server_updates(
         &self,
-        _: Request<EmptyReply>,
+        _: Request<Empty>,
     ) -> Result<Response<Self::SubscribeServerUpdatesStream>, Status> {
         let rx = self.stream_tx.subscribe();
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,12 +4,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::{
-    stream_updates, CycleLoopReply, CycleLoopRequest, Empty, GetProgressRequest,
-    GetProgressResponse, PlaySelectedRequest, PlayerTime, ReloadConfigRequest,
-    ReloadPlaylistRequest, SeekBackwardRequest, SeekForwardRequest, SkipNextRequest,
-    SkipNextResponse, SkipPreviousRequest, SpeedDownRequest, SpeedReply, SpeedUpRequest,
-    StreamUpdates, ToggleGaplessReply, ToggleGaplessRequest, TogglePauseRequest,
-    TogglePauseResponse, UpdateMissedEvents, VolumeDownRequest, VolumeReply, VolumeUpRequest,
+    stream_updates, Empty, GetProgressResponse, PlayerTime, SpeedReply, StreamUpdates,
+    ToggleGaplessReply, TogglePauseResponse, UpdateMissedEvents, VolumeReply,
 };
 use termusicplayback::{PlayerCmd, PlayerCmdSender, StreamTX};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -48,18 +44,15 @@ impl MusicPlayerService {
 
 #[tonic::async_trait]
 impl MusicPlayer for MusicPlayerService {
-    async fn cycle_loop(
-        &self,
-        _request: Request<CycleLoopRequest>,
-    ) -> Result<Response<CycleLoopReply>, Status> {
-        let reply = CycleLoopReply {};
+    async fn cycle_loop(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::CycleLoop);
 
         Ok(Response::new(reply))
     }
     async fn get_progress(
         &self,
-        _request: Request<GetProgressRequest>,
+        _request: Request<Empty>,
     ) -> Result<Response<GetProgressResponse>, Status> {
         let mut r = self.player_stats.lock();
         let reply = r.as_getprogress_response();
@@ -70,30 +63,21 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn play_selected(
-        &self,
-        _request: Request<PlaySelectedRequest>,
-    ) -> Result<Response<Empty>, Status> {
+    async fn play_selected(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
         self.command(&PlayerCmd::PlaySelected);
 
         Ok(Response::new(reply))
     }
 
-    async fn reload_config(
-        &self,
-        _request: Request<ReloadConfigRequest>,
-    ) -> Result<Response<Empty>, Status> {
+    async fn reload_config(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
         self.command(&PlayerCmd::ReloadConfig);
 
         Ok(Response::new(reply))
     }
 
-    async fn reload_playlist(
-        &self,
-        _request: Request<ReloadPlaylistRequest>,
-    ) -> Result<Response<Empty>, Status> {
+    async fn reload_playlist(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
         self.command(&PlayerCmd::ReloadPlaylist);
 
@@ -102,7 +86,7 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn seek_backward(
         &self,
-        _request: Request<SeekBackwardRequest>,
+        _request: Request<Empty>,
     ) -> Result<Response<PlayerTime>, Status> {
         self.command(&PlayerCmd::SeekBackward);
         // This is to let the player update volume within loop
@@ -113,10 +97,7 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn seek_forward(
-        &self,
-        _request: Request<SeekForwardRequest>,
-    ) -> Result<Response<PlayerTime>, Status> {
+    async fn seek_forward(&self, _request: Request<Empty>) -> Result<Response<PlayerTime>, Status> {
         self.command(&PlayerCmd::SeekForward);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -127,29 +108,20 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn skip_next(
-        &self,
-        _request: Request<SkipNextRequest>,
-    ) -> Result<Response<SkipNextResponse>, Status> {
-        let reply = SkipNextResponse {};
+    async fn skip_next(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
+        let reply = Empty {};
         self.command(&PlayerCmd::SkipNext);
 
         Ok(Response::new(reply))
     }
-    async fn skip_previous(
-        &self,
-        _request: Request<SkipPreviousRequest>,
-    ) -> Result<Response<Empty>, Status> {
+    async fn skip_previous(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
         self.command(&PlayerCmd::SkipPrevious);
 
         Ok(Response::new(reply))
     }
 
-    async fn speed_down(
-        &self,
-        _request: Request<SpeedDownRequest>,
-    ) -> Result<Response<SpeedReply>, Status> {
+    async fn speed_down(&self, _request: Request<Empty>) -> Result<Response<SpeedReply>, Status> {
         self.command(&PlayerCmd::SpeedDown);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -159,10 +131,7 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn speed_up(
-        &self,
-        _request: Request<SpeedUpRequest>,
-    ) -> Result<Response<SpeedReply>, Status> {
+    async fn speed_up(&self, _request: Request<Empty>) -> Result<Response<SpeedReply>, Status> {
         self.command(&PlayerCmd::SpeedUp);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -174,7 +143,7 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn toggle_gapless(
         &self,
-        _request: Request<ToggleGaplessRequest>,
+        _request: Request<Empty>,
     ) -> Result<Response<ToggleGaplessReply>, Status> {
         self.command(&PlayerCmd::ToggleGapless);
         // This is to let the player update volume within loop
@@ -187,7 +156,7 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn toggle_pause(
         &self,
-        _request: Request<TogglePauseRequest>,
+        _request: Request<Empty>,
     ) -> Result<Response<TogglePauseResponse>, Status> {
         self.command(&PlayerCmd::TogglePause);
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -197,10 +166,7 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn volume_down(
-        &self,
-        _request: Request<VolumeDownRequest>,
-    ) -> Result<Response<VolumeReply>, Status> {
+    async fn volume_down(&self, _request: Request<Empty>) -> Result<Response<VolumeReply>, Status> {
         self.command(&PlayerCmd::VolumeDown);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
@@ -212,10 +178,7 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn volume_up(
-        &self,
-        _request: Request<VolumeUpRequest>,
-    ) -> Result<Response<VolumeReply>, Status> {
+    async fn volume_up(&self, _request: Request<Empty>) -> Result<Response<VolumeReply>, Status> {
         self.command(&PlayerCmd::VolumeUp);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));

--- a/tui/src/ui/playback.rs
+++ b/tui/src/ui/playback.rs
@@ -1,11 +1,6 @@
 use anyhow::Result;
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::{
-    CycleLoopRequest, Empty, GetProgressRequest, GetProgressResponse, PlaySelectedRequest,
-    PlayerProgress, ReloadConfigRequest, ReloadPlaylistRequest, SeekBackwardRequest,
-    SeekForwardRequest, SkipNextRequest, SkipPreviousRequest, SpeedDownRequest, SpeedUpRequest,
-    ToggleGaplessRequest, TogglePauseRequest, VolumeDownRequest, VolumeUpRequest,
-};
+use termusiclib::player::{Empty, GetProgressResponse, PlayerProgress};
 use termusicplayback::Status;
 use tokio_stream::{Stream, StreamExt as _};
 use tonic::transport::Channel;
@@ -19,7 +14,7 @@ impl Playback {
         Self { client }
     }
     pub async fn toggle_pause(&mut self) -> Result<Status> {
-        let request = tonic::Request::new(TogglePauseRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.toggle_pause(request).await?;
         let response = response.into_inner();
         let status = Status::from_u32(response.status);
@@ -28,14 +23,14 @@ impl Playback {
     }
 
     pub async fn skip_next(&mut self) -> Result<()> {
-        let request = tonic::Request::new(SkipNextRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.skip_next(request).await?;
         info!("Got response from server: {:?}", response);
         Ok(())
     }
 
     pub async fn get_progress(&mut self) -> Result<GetProgressResponse> {
-        let request = tonic::Request::new(GetProgressRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.get_progress(request).await?;
         let response = response.into_inner();
         // info!("Got response from server: {:?}", response);
@@ -43,7 +38,7 @@ impl Playback {
     }
 
     pub async fn volume_up(&mut self) -> Result<u16> {
-        let request = tonic::Request::new(VolumeUpRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.volume_up(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -53,7 +48,7 @@ impl Playback {
     }
 
     pub async fn volume_down(&mut self) -> Result<u16> {
-        let request = tonic::Request::new(VolumeDownRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.volume_down(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -63,7 +58,7 @@ impl Playback {
     }
 
     pub async fn cycle_loop(&mut self) -> Result<()> {
-        let request = tonic::Request::new(CycleLoopRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.cycle_loop(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -71,7 +66,7 @@ impl Playback {
     }
 
     pub async fn speed_up(&mut self) -> Result<i32> {
-        let request = tonic::Request::new(SpeedUpRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.speed_up(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -79,7 +74,7 @@ impl Playback {
     }
 
     pub async fn speed_down(&mut self) -> Result<i32> {
-        let request = tonic::Request::new(SpeedDownRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.speed_down(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -87,7 +82,7 @@ impl Playback {
     }
 
     pub async fn toggle_gapless(&mut self) -> Result<bool> {
-        let request = tonic::Request::new(ToggleGaplessRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.toggle_gapless(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -95,7 +90,7 @@ impl Playback {
     }
 
     pub async fn seek_forward(&mut self) -> Result<PlayerProgress> {
-        let request = tonic::Request::new(SeekForwardRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.seek_forward(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -103,7 +98,7 @@ impl Playback {
     }
 
     pub async fn seek_backward(&mut self) -> Result<PlayerProgress> {
-        let request = tonic::Request::new(SeekBackwardRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.seek_backward(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -111,7 +106,7 @@ impl Playback {
     }
 
     pub async fn reload_config(&mut self) -> Result<()> {
-        let request = tonic::Request::new(ReloadConfigRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.reload_config(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -119,7 +114,7 @@ impl Playback {
     }
 
     pub async fn reload_playlist(&mut self) -> Result<()> {
-        let request = tonic::Request::new(ReloadPlaylistRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.reload_playlist(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -127,7 +122,7 @@ impl Playback {
     }
 
     pub async fn play_selected(&mut self) -> Result<()> {
-        let request = tonic::Request::new(PlaySelectedRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.play_selected(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);
@@ -135,7 +130,7 @@ impl Playback {
     }
 
     pub async fn skip_previous(&mut self) -> Result<()> {
-        let request = tonic::Request::new(SkipPreviousRequest {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.skip_previous(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {:?}", response);

--- a/tui/src/ui/playback.rs
+++ b/tui/src/ui/playback.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use termusiclib::player::music_player_client::MusicPlayerClient;
 use termusiclib::player::{
-    CycleLoopRequest, EmptyReply, GetProgressRequest, GetProgressResponse, PlaySelectedRequest,
+    CycleLoopRequest, Empty, GetProgressRequest, GetProgressResponse, PlaySelectedRequest,
     PlayerProgress, ReloadConfigRequest, ReloadPlaylistRequest, SeekBackwardRequest,
     SeekForwardRequest, SkipNextRequest, SkipPreviousRequest, SpeedDownRequest, SpeedUpRequest,
     ToggleGaplessRequest, TogglePauseRequest, VolumeDownRequest, VolumeUpRequest,
@@ -145,7 +145,7 @@ impl Playback {
     pub async fn subscribe_to_stream_updates(
         &mut self,
     ) -> Result<impl Stream<Item = Result<termusiclib::player::StreamUpdates>>> {
-        let request = tonic::Request::new(EmptyReply {});
+        let request = tonic::Request::new(Empty {});
         let response = self.client.subscribe_server_updates(request).await?;
         let response = response.into_inner().map(|res| res.map_err(Into::into));
         info!("Got response from server: {:?}", response);


### PR DESCRIPTION
This PR does:
- sort all `rpc` functions into sections
- rename `EmptyReply` to `Empty`
- De-duplicate all empty message types into `Empty`