### PR TITLE
Refactor & document playlist-related things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.diff
 # ignore custom cargo configuration, like changing linker
 .cargo
+# VSCode relation configuration
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix(tui): change that the default `add_random_(song|album)` keys were inverted.
 - Fix(tui): change Theme preview to not reset to index 0 each preview.
 - Fix(tui): not having the current theme selected when entering Theme preview tab.
+- Fix(tui): actually report any errors when adding to the playlist. (Like "invalid file type")
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -216,7 +216,7 @@ impl GeneralPlayer {
         let db = DataBase::new(&config)?;
 
         let config = new_shared_server_settings(config);
-        let playlist = Playlist::new(config.clone()).unwrap_or_default();
+        let playlist = Playlist::new(&config).unwrap_or_default();
         let mpris = if config.read().settings.player.use_mediacontrols {
             Some(mpris::Mpris::new(cmd_tx.clone()))
         } else {
@@ -390,7 +390,6 @@ impl GeneralPlayer {
             None => return,
         };
 
-        self.playlist.set_next_track(Some(&track));
         self.enqueue_next(&track);
 
         info!("Next track enqueued: {:#?}", track);

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -381,7 +381,7 @@ impl GeneralPlayer {
         }
     }
     pub fn enqueue_next_from_playlist(&mut self) {
-        if self.playlist.next_track().is_some() {
+        if self.playlist.has_next_track() {
             return;
         }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -182,8 +182,10 @@ impl Playlist {
         Ok((current_track_index, playlist_items))
     }
 
+    /// Reload the current playlist from the file. This function does not save beforehand.
+    ///
     /// # Errors
-    /// Errors could happen when reading files
+    /// See [`Self::load`]
     pub fn reload_tracks(&mut self) -> Result<()> {
         let (current_track_index, tracks) = Self::load()?;
         self.tracks = tracks;
@@ -352,7 +354,7 @@ impl Playlist {
         self.status
     }
 
-    /// Cycle through the loop modes and return the new mode
+    /// Cycle through the loop modes and return the new mode.
     ///
     /// order:
     /// [Random](LoopMode::Random) -> [Playlist](LoopMode::Playlist)
@@ -373,9 +375,9 @@ impl Playlist {
         self.loop_mode
     }
 
-    /// Export the current playlist to a `.m3u` playlist file
+    /// Export the current playlist to a `.m3u` playlist file.
     ///
-    /// might be confused with [save](Self::save)
+    /// Might be confused with [save](Self::save).
     ///
     /// # Errors
     /// Error could happen when writing file to local disk.
@@ -392,9 +394,9 @@ impl Playlist {
         Ok(())
     }
 
-    /// Generate the m3u's file content
+    /// Generate the m3u's file content.
     ///
-    /// All Paths are relative to the `parent_folder` directory
+    /// All Paths are relative to the `parent_folder` directory.
     fn get_m3u_file(&self, parent_folder: &Path) -> String {
         let mut m3u = String::from("#EXTM3U\n");
         for track in &self.tracks {
@@ -410,11 +412,16 @@ impl Playlist {
         m3u
     }
 
+    /// Add a podcast episode to the playlist.
     pub fn add_episode(&mut self, ep: &Episode) {
         let track = Track::from_episode(ep);
         self.tracks.push(track);
     }
 
+    /// Add many Paths/Urls to the playlist.
+    ///
+    /// NOTE: This function currently **does not** error on bad inputs.
+    ///
     /// # Errors
     /// Error happens when track cannot be read from local file
     pub fn add_playlist<T: AsRef<str>>(&mut self, vec: &[T]) -> Result<()> {
@@ -451,7 +458,10 @@ impl Playlist {
         }
     }
 
+    /// Clear the current playlist.
+    /// This does not stop the playlist or clear [`current_track`].
     pub fn clear(&mut self) {
+        // TODO: clear everything except `current_track`
         self.tracks.clear();
         self.current_track_index = 0;
     }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -523,12 +523,14 @@ impl Playlist {
         }
     }
 
+    /// Find the index in the playlist for `item`, if it exists there.
     fn find_index_from_file(&self, item: &str) -> Option<usize> {
         for (index, track) in self.tracks.iter().enumerate() {
-            if let Some(file) = track.file() {
-                if file == item {
-                    return Some(index);
-                }
+            let Some(file) = track.file() else {
+                continue;
+            };
+            if file == item {
+                return Some(index);
             }
         }
         None

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -204,17 +204,15 @@ impl Playlist {
 
         let file = File::create(&path)?;
         let mut writer = BufWriter::new(file);
-        let mut bytes = Vec::new();
-        bytes.extend(self.current_track_index.to_string().as_bytes());
-        bytes.extend(b"\n");
+        writer.write_all(self.current_track_index.to_string().as_bytes())?;
+        writer.write_all(b"\n")?;
         for track in &self.tracks {
             if let Some(f) = track.file() {
-                bytes.extend(f.as_bytes());
-                bytes.extend(b"\n");
+                writer.write_all(f.as_bytes())?;
+                writer.write_all(b"\n")?;
             }
         }
 
-        writer.write_all(&bytes)?;
         writer.flush()?;
 
         Ok(())

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -465,9 +465,12 @@ impl Playlist {
     /// Clear the current playlist.
     /// This does not stop the playlist or clear [`current_track`].
     pub fn clear(&mut self) {
-        // TODO: clear everything except `current_track`
         self.tracks.clear();
+        self.played_index.clear();
+        self.next_track.take();
+        self.next_track_index = 0;
         self.current_track_index = 0;
+        self.need_proceed_to_next = false;
     }
 
     pub fn shuffle(&mut self) {

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -155,10 +155,6 @@ impl Playlist {
             .with_context(|| "failed to get podcasts from db.")?;
         for line in lines {
             let line = line?;
-            if let Ok(track) = Track::read_from_path(&line, false) {
-                playlist_items.push(track);
-                continue;
-            };
             if line.starts_with("http") {
                 let mut is_podcast = false;
                 'outer: for pod in &podcasts {
@@ -175,7 +171,12 @@ impl Playlist {
                     let track = Track::new_radio(&line);
                     playlist_items.push(track);
                 }
+                continue;
             }
+            if let Ok(track) = Track::read_from_path(&line, false) {
+                playlist_items.push(track);
+                continue;
+            };
         }
 
         Ok((current_track_index, playlist_items))

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -134,12 +134,11 @@ impl Playlist {
         };
 
         let reader = BufReader::new(file);
-        let mut lines = reader
-            .lines()
-            .map(|line| line.unwrap_or_else(|_| "Error".to_string()));
+        let mut lines = reader.lines();
 
         let mut current_track_index = 0;
-        if let Some(index_line) = lines.next() {
+        if let Some(line) = lines.next() {
+            let index_line = line?;
             if let Ok(index) = index_line.trim().parse() {
                 current_track_index = index;
             }
@@ -155,6 +154,7 @@ impl Playlist {
             .get_podcasts()
             .with_context(|| "failed to get podcasts from db.")?;
         for line in lines {
+            let line = line?;
             if let Ok(track) = Track::read_from_path(&line, false) {
                 playlist_items.push(track);
                 continue;

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -202,15 +202,15 @@ impl Playlist {
     pub fn save(&mut self) -> Result<()> {
         let path = get_playlist_path()?;
 
-        let file = File::create(path.as_path())?;
+        let file = File::create(&path)?;
         let mut writer = BufWriter::new(file);
         let mut bytes = Vec::new();
-        bytes.extend(format!("{}", self.current_track_index).as_bytes());
-        bytes.extend("\n".as_bytes());
-        for i in &self.tracks {
-            if let Some(f) = i.file() {
+        bytes.extend(self.current_track_index.to_string().as_bytes());
+        bytes.extend(b"\n");
+        for track in &self.tracks {
+            if let Some(f) = track.file() {
                 bytes.extend(f.as_bytes());
-                bytes.extend("\n".as_bytes());
+                bytes.extend(b"\n");
             }
         }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -450,13 +450,13 @@ impl Playlist {
         &self.tracks
     }
 
+    /// Remove the track at `index`. Does not modify `current_track`.
     pub fn remove(&mut self, index: usize) {
         self.tracks.remove(index);
         // Handle index
         if index <= self.current_track_index {
-            if self.current_track_index == 0 {
-                self.current_track_index = 0;
-            } else {
+            // nothing needs to be done if the index is already 0
+            if self.current_track_index != 0 {
                 self.current_track_index -= 1;
             }
         }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -203,6 +203,12 @@ impl Playlist {
         let path = get_playlist_path()?;
 
         let file = File::create(&path)?;
+
+        // If the playlist is empty, truncate the file, but dont write anything else (like a index number)
+        if self.is_empty() {
+            return Ok(());
+        }
+
         let mut writer = BufWriter::new(file);
         writer.write_all(self.current_track_index.to_string().as_bytes())?;
         writer.write_all(b"\n")?;

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -536,9 +536,13 @@ impl Playlist {
 
     /// Get a random index in the playlist.
     fn get_random_index(&self) -> usize {
-        let mut rng = rand::thread_rng();
         let mut random_index = self.current_track_index;
-        // TODO: is this not a infinite loop if there is only 1 element?
+
+        if self.len() <= 1 {
+            return 0;
+        }
+
+        let mut rng = rand::thread_rng();
         while self.current_track_index == random_index {
             random_index = rng.gen_range(0..self.len());
         }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -283,10 +283,10 @@ impl Playlist {
         self.tracks.is_empty()
     }
 
+    /// Swap the `index` with the one below(+1) it, if there is one.
     pub fn swap_down(&mut self, index: usize) {
         if index < self.len().saturating_sub(1) {
-            let track = self.tracks.remove(index);
-            self.tracks.insert(index + 1, track);
+            self.tracks.swap(index, index + 1);
             // handle index
             if index == self.current_track_index {
                 self.current_track_index += 1;
@@ -296,10 +296,10 @@ impl Playlist {
         }
     }
 
+    /// Swap the `index` with the one above(-1) it, if there is one.
     pub fn swap_up(&mut self, index: usize) {
         if index > 0 {
-            let track = self.tracks.remove(index);
-            self.tracks.insert(index - 1, track);
+            self.tracks.swap(index, index - 1);
             // handle index
             if index == self.current_track_index {
                 self.current_track_index -= 1;

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -56,16 +56,25 @@ impl std::fmt::Display for Status {
 
 #[derive(Default, Debug)]
 pub struct Playlist {
+    /// All tracks in the playlist
     tracks: Vec<Track>,
+    /// Index into `tracks` of which the current playing track is
     current_track_index: usize,
+    /// Index into `tracks` for the next track to play after the current
     next_track_index: usize,
-    played_index: Vec<usize>,
+    /// The currently playing [`Track`]. Does not need to be in `tracks`
     current_track: Option<Track>,
+    /// The next track to play after the current. Does not need to be in `tracks`
     next_track: Option<Track>,
+    /// The current playing running status of the playlist
     status: Status,
+    /// The loop-/play-mode for the playlist
     loop_mode: LoopMode,
-    config: SharedServerSettings,
+    /// Indexes into `tracks` that have been previously been played (for `previous`)
+    played_index: Vec<usize>,
+    /// Indicator if the playlist should advance the `current_*` and `next_*` values
     need_proceed_to_next: bool,
+    config: SharedServerSettings,
 }
 
 impl Playlist {

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -329,6 +329,9 @@ impl Sink {
     // Spawns a new thread to sleep until the sound ends, and then sends the SoundEnded
     // message through the given Sender.
     pub fn message_on_end(&self) {
+        // TODO: we should not expose this function to be called outside of rusty-mod and always just have it active as we always need it
+        // NOTE: (in addition to the todo), we always use "message_on_end" to rely on EOS, so it is basically always set, so it should not be necessary
+        // to be set by commands every time, and worst, forget to call it or have race conditions that enqueue multiple things and wait on the wrong thing.
         if let Some(sleep_until_end) = self.sleep_until_end.lock().take() {
             let pcmd_tx = self.pcmd_tx.clone();
             let picmd_tx = self.picmd_tx.clone();

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -259,6 +259,7 @@ impl Model {
         self.playlist_sync();
     }
 
+    /// Add a playlist (like m3u) to the playlist.
     fn playlist_add_playlist(&mut self, current_node: &str) -> Result<()> {
         let vec = playlist_get_vec(current_node)?;
         self.playlist.add_playlist(&vec)?;
@@ -267,6 +268,7 @@ impl Model {
         Ok(())
     }
 
+    /// Add a podcast episode to the playlist.
     pub fn playlist_add_episode(&mut self, episode_index: usize) -> Result<()> {
         if self.podcast.podcasts.is_empty() {
             return Ok(());
@@ -286,6 +288,9 @@ impl Model {
         Ok(())
     }
 
+    /// Add the `current_node`, regardless if it is a Track, dir, playlist, etc.
+    ///
+    /// See [`Model::playlist_add_episode`] for podcast episode adding
     pub fn playlist_add(&mut self, current_node: &str) -> Result<()> {
         let p: &Path = Path::new(&current_node);
         if !p.exists() {
@@ -303,6 +308,7 @@ impl Model {
         Ok(())
     }
 
+    /// Add a Track or a Playlist to the playlist
     fn playlist_add_item(&mut self, current_node: &str) -> Result<()> {
         if is_playlist(current_node) {
             self.playlist_add_playlist(current_node)?;
@@ -313,6 +319,7 @@ impl Model {
         Ok(())
     }
 
+    /// Add [`TrackDB`] to the playlist
     pub fn playlist_add_all_from_db(&mut self, vec: &[TrackDB]) {
         let vec2: Vec<&str> = vec.iter().map(|f| f.file.as_str()).collect();
         if let Err(e) = self.playlist.add_playlist(&vec2) {
@@ -324,6 +331,7 @@ impl Model {
         self.playlist_sync();
     }
 
+    /// Add random album(s) from the database to the playlist
     pub fn playlist_add_random_album(&mut self) {
         let playlist_select_random_album_quantity = self
             .config_server
@@ -336,6 +344,7 @@ impl Model {
         self.playlist_add_all_from_db(&vec);
     }
 
+    /// Add random tracks from the database to the playlist
     pub fn playlist_add_random_tracks(&mut self) {
         let playlist_select_random_track_quantity = self
             .config_server

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -245,7 +245,7 @@ impl Model {
         ));
         let (tx_to_main, rx_to_main) = mpsc::channel();
 
-        let playlist = Playlist::new(config_server.clone()).unwrap_or_default();
+        let playlist = Playlist::new(&config_server).unwrap_or_default();
         let app = Self::init_app(&tree, &config_tui);
 
         // This line is required, in order to show the playing message for the first track


### PR DESCRIPTION
This PR refactors & documents playlist-related things, in more details:
- document `tui::components::playlist::playlist_add_*` functions
- document `playback::playlist::Playlist` fields & functions
- fix possible infinite loop in `Playlist::get_random_index`
- report errors in `Playlist::add_track` / `Playlist::add_playlist` instead of silently ignoring them (like "unsupported file type")
- early-return parsing `playlist.log` if file did not exist or is empty
- dont save a empty `0` to `playlist.log` if the playlist is empty, only truncate the file
- some style changes (dedent, simpler calls)
- clear everything in `Playlist::clear` instead of having some residual data
- remove `Playlist::next_track` and only use `Playlist::next_track_index`
- gitignore the `.vscode` directory

Some optimizations:
- in `Playlist::save` write to `BufWriter` directly, instead of into a intermediate buffer
- in `Playlist::swap_*` use `Vec::swap` instead of removing & inserting