### PR TITLE
ProtoBuf renames, type changes & use callbacks instead of static waiting

### DIFF
--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -42,7 +42,7 @@ message PlayerTime {
 
 message GetProgressResponse {
   PlayerTime progress = 1;
-  uint32 current_track_index = 3;
+  uint64 current_track_index = 3;
   uint32 status = 4;
   // actually a u16, but protobuf does not support types lower than 32 bits
   uint32 volume = 5;
@@ -122,7 +122,7 @@ message UpdateGaplessChanged {
 // NOTE: this may or may not be sent for the initial track after startup as the client may connect after the track started
 message UpdateTrackChanged {
   // The index into the playlist of which track changed.
-  uint32 current_track_index = 1;
+  uint64 current_track_index = 1;
   // Indicates if this update is a change to a new track (not just metadata change)
   bool current_track_updated = 2;
 

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -3,7 +3,8 @@ package player;
 
 service MusicPlayer {
   // Player Commands
-  rpc TogglePause(Empty) returns (TogglePauseResponse);
+  // Toggle Pause/Play, returns the new state
+  rpc TogglePause(Empty) returns (PlayState);
   rpc SkipNext(Empty) returns (Empty);
   rpc SkipPrevious(Empty) returns (Empty);
   rpc GetProgress(Empty) returns (GetProgressResponse);
@@ -27,7 +28,9 @@ service MusicPlayer {
 
 message Empty {}
 
-message TogglePauseResponse {
+// A play status.
+message PlayState {
+  // The actual status, mapped to [`playback::playlist::Status`]
   uint32 status = 1;
 }
 
@@ -101,7 +104,7 @@ message UpdateSpeedChanged {
 // TODO: is play-state (playing / paused / ??) the only things this should do?
 message UpdatePlayStateChanged {
   // reuse the existing message
-  TogglePauseResponse msg = 1;
+  PlayState msg = 1;
 }
 
 // The track changed in some way, send new information

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -121,7 +121,9 @@ message UpdateGaplessChanged {
 // This is *not* used for regular track progress updates
 // NOTE: this may or may not be sent for the initial track after startup as the client may connect after the track started
 message UpdateTrackChanged {
+  // The index into the playlist of which track changed.
   uint32 current_track_index = 1;
+  // Indicates if this update is a change to a new track (not just metadata change)
   bool current_track_updated = 2;
 
   // all values below should be moved into their own "Track" message at some point

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -12,7 +12,8 @@ service MusicPlayer {
   rpc VolumeDown(Empty) returns (VolumeReply);
   rpc SpeedUp(Empty) returns (SpeedReply);
   rpc SpeedDown(Empty) returns (SpeedReply);
-  rpc ToggleGapless(Empty) returns (ToggleGaplessReply);
+  // Toggle the gapless mdoe, returns the new state.
+  rpc ToggleGapless(Empty) returns (GaplessState);
   rpc SeekForward(Empty) returns (PlayerTime);
   rpc SeekBackward(Empty) returns (PlayerTime);
 
@@ -60,7 +61,8 @@ message SpeedReply {
   int32 speed = 1;
 }
 
-message ToggleGaplessReply {
+// A Gapless state.
+message GaplessState {
   bool gapless = 1;
 }
 

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -82,6 +82,7 @@ message StreamUpdates {
     UpdateSpeedChanged speed_changed = 3;
     UpdatePlayStateChanged play_state_changed = 4;
     UpdateTrackChanged track_changed = 5;
+    UpdateGaplessChanged gapless_changed = 6;
   }
 }
 
@@ -107,6 +108,12 @@ message UpdateSpeedChanged {
 message UpdatePlayStateChanged {
   // reuse the existing message
   PlayState msg = 1;
+}
+
+// The Gapless state changed, send new information.
+message UpdateGaplessChanged {
+  // reuse the existing message
+  GaplessState msg = 1;
 }
 
 // The track changed in some way, send new information

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -73,6 +73,7 @@ pub enum UpdateEvents {
     SpeedChanged { speed: i32 },
     PlayStateChanged { playing: u32 },
     TrackChanged(TrackChangedInfo),
+    GaplessChanged { gapless: bool },
 }
 
 type StreamTypes = protobuf::stream_updates::Type;
@@ -107,6 +108,11 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
                     .map(protobuf::update_track_changed::OptionalTitle::Title),
                 progress: info.progress.map(Into::into),
             }),
+            UpdateEvents::GaplessChanged { gapless } => {
+                StreamTypes::GaplessChanged(UpdateGaplessChanged {
+                    msg: Some(GaplessState { gapless }),
+                })
+            }
         };
 
         Self { r#type: Some(val) }
@@ -142,6 +148,9 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
                 }),
                 progress: ev.progress.map(Into::into),
             }),
+            stream_updates::Type::GaplessChanged(ev) => Self::GaplessChanged {
+                gapless: unwrap_msg(ev.msg, "StreamUpdates.types.gapless_changed.msg")?.gapless,
+            },
         };
 
         Ok(res)

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -96,7 +96,7 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
             }),
             UpdateEvents::PlayStateChanged { playing } => {
                 StreamTypes::PlayStateChanged(UpdatePlayStateChanged {
-                    msg: Some(TogglePauseResponse { status: playing }),
+                    msg: Some(PlayState { status: playing }),
                 })
             }
             UpdateEvents::TrackChanged(info) => StreamTypes::TrackChanged(UpdateTrackChanged {

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -57,7 +57,7 @@ impl From<PlayerProgress> for protobuf::PlayerTime {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TrackChangedInfo {
     /// Current track index in the playlist
-    pub current_track_index: u32,
+    pub current_track_index: u64,
     /// Indicate if the track changed to another track
     pub current_track_updated: bool,
     /// Title of the current track / radio

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -668,6 +668,7 @@ impl PlayerTrait for GeneralPlayer {
 
     fn set_gapless(&mut self, to: bool) {
         self.get_player_mut().set_gapless(to);
+        self.send_stream_ev(UpdateEvents::GaplessChanged { gapless: to });
     }
 
     fn skip_one(&mut self) {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -311,8 +311,8 @@ impl GeneralPlayer {
     }
 
     pub fn toggle_gapless(&mut self) -> bool {
-        let new_gapless = !self.backend.as_player().gapless();
-        self.backend.as_player_mut().set_gapless(new_gapless);
+        let new_gapless = !<Self as PlayerTrait>::gapless(self);
+        <Self as PlayerTrait>::set_gapless(self, new_gapless);
         self.config.write().settings.player.gapless = new_gapless;
         new_gapless
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -360,7 +360,7 @@ impl GeneralPlayer {
             }
 
             self.send_stream_ev(UpdateEvents::TrackChanged(TrackChangedInfo {
-                current_track_index: u32::try_from(self.playlist.get_current_track_index())
+                current_track_index: u64::try_from(self.playlist.get_current_track_index())
                     .unwrap(),
                 current_track_updated: self.current_track_updated,
                 title: self.media_info().media_title,

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,8 +4,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::{
-    stream_updates, Empty, GetProgressResponse, PlayerTime, SpeedReply, StreamUpdates,
-    ToggleGaplessReply, TogglePauseResponse, UpdateMissedEvents, VolumeReply,
+    stream_updates, Empty, GetProgressResponse, PlayState, PlayerTime, SpeedReply, StreamUpdates,
+    ToggleGaplessReply, UpdateMissedEvents, VolumeReply,
 };
 use termusicplayback::{PlayerCmd, PlayerCmdSender, StreamTX};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -154,14 +154,11 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn toggle_pause(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<TogglePauseResponse>, Status> {
+    async fn toggle_pause(&self, _request: Request<Empty>) -> Result<Response<PlayState>, Status> {
         self.command(&PlayerCmd::TogglePause);
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
-        let reply = TogglePauseResponse { status: r.status };
+        let reply = PlayState { status: r.status };
 
         Ok(Response::new(reply))
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,8 +4,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::{
-    stream_updates, Empty, GetProgressResponse, PlayState, PlayerTime, SpeedReply, StreamUpdates,
-    ToggleGaplessReply, UpdateMissedEvents, VolumeReply,
+    stream_updates, Empty, GaplessState, GetProgressResponse, PlayState, PlayerTime, SpeedReply,
+    StreamUpdates, UpdateMissedEvents, VolumeReply,
 };
 use termusicplayback::{PlayerCmd, PlayerCmdSender, StreamTX};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
@@ -144,12 +144,12 @@ impl MusicPlayer for MusicPlayerService {
     async fn toggle_gapless(
         &self,
         _request: Request<Empty>,
-    ) -> Result<Response<ToggleGaplessReply>, Status> {
+    ) -> Result<Response<GaplessState>, Status> {
         self.command(&PlayerCmd::ToggleGapless);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
-        let reply = ToggleGaplessReply { gapless: r.gapless };
+        let reply = GaplessState { gapless: r.gapless };
 
         Ok(Response::new(reply))
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -35,7 +35,7 @@ impl MusicPlayerService {
 }
 
 impl MusicPlayerService {
-    fn command(&self, cmd: &PlayerCmd) {
+    fn command(&self, cmd: PlayerCmd) {
         if let Err(e) = self.cmd_tx.send(cmd.clone()) {
             error!("error {cmd:?}: {e}");
         }
@@ -46,7 +46,7 @@ impl MusicPlayerService {
 impl MusicPlayer for MusicPlayerService {
     async fn cycle_loop(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::CycleLoop);
+        self.command(PlayerCmd::CycleLoop);
 
         Ok(Response::new(reply))
     }
@@ -65,21 +65,21 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn play_selected(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::PlaySelected);
+        self.command(PlayerCmd::PlaySelected);
 
         Ok(Response::new(reply))
     }
 
     async fn reload_config(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::ReloadConfig);
+        self.command(PlayerCmd::ReloadConfig);
 
         Ok(Response::new(reply))
     }
 
     async fn reload_playlist(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::ReloadPlaylist);
+        self.command(PlayerCmd::ReloadPlaylist);
 
         Ok(Response::new(reply))
     }
@@ -88,7 +88,7 @@ impl MusicPlayer for MusicPlayerService {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<PlayerTime>, Status> {
-        self.command(&PlayerCmd::SeekBackward);
+        self.command(PlayerCmd::SeekBackward);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let s = self.player_stats.lock();
@@ -98,7 +98,7 @@ impl MusicPlayer for MusicPlayerService {
     }
 
     async fn seek_forward(&self, _request: Request<Empty>) -> Result<Response<PlayerTime>, Status> {
-        self.command(&PlayerCmd::SeekForward);
+        self.command(PlayerCmd::SeekForward);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let s = self.player_stats.lock();
@@ -110,19 +110,19 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn skip_next(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::SkipNext);
+        self.command(PlayerCmd::SkipNext);
 
         Ok(Response::new(reply))
     }
     async fn skip_previous(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
         let reply = Empty {};
-        self.command(&PlayerCmd::SkipPrevious);
+        self.command(PlayerCmd::SkipPrevious);
 
         Ok(Response::new(reply))
     }
 
     async fn speed_down(&self, _request: Request<Empty>) -> Result<Response<SpeedReply>, Status> {
-        self.command(&PlayerCmd::SpeedDown);
+        self.command(PlayerCmd::SpeedDown);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let s = self.player_stats.lock();
@@ -132,7 +132,7 @@ impl MusicPlayer for MusicPlayerService {
     }
 
     async fn speed_up(&self, _request: Request<Empty>) -> Result<Response<SpeedReply>, Status> {
-        self.command(&PlayerCmd::SpeedUp);
+        self.command(PlayerCmd::SpeedUp);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let s = self.player_stats.lock();
@@ -145,7 +145,7 @@ impl MusicPlayer for MusicPlayerService {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<GaplessState>, Status> {
-        self.command(&PlayerCmd::ToggleGapless);
+        self.command(PlayerCmd::ToggleGapless);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
@@ -155,7 +155,7 @@ impl MusicPlayer for MusicPlayerService {
     }
 
     async fn toggle_pause(&self, _request: Request<Empty>) -> Result<Response<PlayState>, Status> {
-        self.command(&PlayerCmd::TogglePause);
+        self.command(PlayerCmd::TogglePause);
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
         let reply = PlayState { status: r.status };
@@ -164,7 +164,7 @@ impl MusicPlayer for MusicPlayerService {
     }
 
     async fn volume_down(&self, _request: Request<Empty>) -> Result<Response<VolumeReply>, Status> {
-        self.command(&PlayerCmd::VolumeDown);
+        self.command(PlayerCmd::VolumeDown);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();
@@ -176,7 +176,7 @@ impl MusicPlayer for MusicPlayerService {
     }
 
     async fn volume_up(&self, _request: Request<Empty>) -> Result<Response<VolumeReply>, Status> {
-        self.command(&PlayerCmd::VolumeUp);
+        self.command(PlayerCmd::VolumeUp);
         // This is to let the player update volume within loop
         std::thread::sleep(std::time::Duration::from_millis(20));
         let r = self.player_stats.lock();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -37,7 +37,7 @@ pub const SPEED_STEP: SpeedSigned = 1;
 #[derive(Debug, Clone, PartialEq)]
 struct PlayerStats {
     pub progress: PlayerProgress,
-    pub current_track_index: u32,
+    pub current_track_index: u64,
     pub status: u32,
     pub volume: u16,
     pub speed: i32,
@@ -299,7 +299,8 @@ fn player_loop(
                     player.mpris_update_progress(&p_tick.progress);
                 }
                 if player.current_track_updated {
-                    p_tick.current_track_index = player.playlist.get_current_track_index() as u32;
+                    p_tick.current_track_index =
+                        u64::try_from(player.playlist.get_current_track_index()).unwrap();
                     p_tick.current_track_updated = player.current_track_updated;
                     player.current_track_updated = false;
                 }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -253,7 +253,9 @@ impl UI {
                         pprogress.total_duration.unwrap_or_default(),
                     );
                     if response.current_track_updated {
-                        self.handle_current_track_index(response.current_track_index as usize);
+                        self.handle_current_track_index(
+                            usize::try_from(response.current_track_index).unwrap(),
+                        );
                     }
 
                     self.model.lyric_update_for_radio(response.radio_title);
@@ -366,7 +368,7 @@ impl UI {
 
                     if track_changed_info.current_track_updated {
                         self.handle_current_track_index(
-                            track_changed_info.current_track_index as usize,
+                            usize::try_from(track_changed_info.current_track_index).unwrap(),
                         );
                     }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -374,6 +374,9 @@ impl UI {
                         self.model.lyric_update_for_radio(title);
                     }
                 }
+                UpdateEvents::GaplessChanged { gapless } => {
+                    self.model.config_server.write().settings.player.gapless = gapless;
+                }
             }
         }
 


### PR DESCRIPTION
This PR improves the Protobuf situation a bit more, details:
- rename some messages to be more generic usable
- change index fields to be `u64` (instead of `u32`)
- change `GeneralPlayer::toggle_gapless` to call through `GeneralPlayer::set_Gapless` (instead of on the backend directly)
- add stream event for "gapless" changes
- document a bunch of things

and finally, and biggest:
Refactor to optionally use callbacks for player events to use instead of static waiting `20ms`. This makes it more reliable by not potentially reading old values and potentially being faster than 20ms.