### PR TITLE
fix(tui::ui::components::labels::LabelSpan): dont style the "LabelSpan"

### DIFF
--- a/tui/src/ui/components/labels.rs
+++ b/tui/src/ui/components/labels.rs
@@ -66,13 +66,12 @@ pub struct LabelSpan {
 }
 
 impl LabelSpan {
-    pub fn new(config: &TuiOverlay, span: &[TextSpan]) -> Self {
+    pub fn new(_config: &TuiOverlay, span: &[TextSpan]) -> Self {
         Self {
+            // dont style the Span itself, style the TextSpan's themself
             component: Span::default()
                 .spans(span)
                 .alignment(Alignment::Left)
-                .background(config.settings.theme.library_background())
-                .foreground(config.settings.theme.library_highlight())
                 .modifiers(TextModifiers::BOLD),
             default_span: span.to_vec(),
             active_message_start_time: None,


### PR DESCRIPTION
This PR changes `LabelSpan` to not apply any colors itself and delegates that to the `TextSpan`s inside it.

Without this, the footer may look like the following when using native themes:

![Konsole Breath Theme](https://github.com/user-attachments/assets/b015d100-f2d7-49b3-823b-f3b43f540203)

re https://github.com/tramhao/termusic/issues/342#issuecomment-2615514711