### PR TITLE
Alphanumeric sort for Music-Library & Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix(tui): change Theme preview to not reset to index 0 each preview.
 - Fix(tui): not having the current theme selected when entering Theme preview tab.
 - Fix(tui): actually report any errors when adding to the playlist. (Like "invalid file type")
+- Fix(tui): sort Music-Library content Alphanumerically.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alphanumeric-sort"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67c60c5f10f11c6ee04de72b2dd98bb9d2548cbc314d22a609bfa8bd9e87e8f"
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,6 +4506,7 @@ dependencies = [
 name = "termusic"
 version = "0.9.1"
 dependencies = [
+ "alphanumeric-sort",
  "anyhow",
  "bytes",
  "clap",
@@ -4545,6 +4552,7 @@ name = "termusic-lib"
 version = "0.9.1"
 dependencies = [
  "ahash",
+ "alphanumeric-sort",
  "anyhow",
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ walkdir = "2.5"
 wildmatch = "2.4"
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }
 futures = "0.3"
+alphanumeric-sort = "1.5"
 # transistive dependency for some packages (like libsqlite), manually specified to upgrade the version, see https://github.com/rusqlite/rusqlite/issues/1543
 cc = "1.1"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -71,6 +71,7 @@ tokio.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 tonic.workspace = true
 prost.workspace = true
+alphanumeric-sort.workspace = true
 
 [build-dependencies]
 cc.workspace = true

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -58,6 +58,7 @@ tokio-stream.workspace = true
 futures.workspace = true
 reqwest.workspace = true
 parking_lot.workspace = true
+alphanumeric-sort.workspace = true
 
 
 [features]


### PR DESCRIPTION
This PR changes the sort for the Music-Library (file explorer) and the Database views (Criteria and Tracks) to be Alphanumerically sorted instead of Lexicographical.

Example current master (lexicographical):
![lex](https://github.com/user-attachments/assets/7516ca3d-ce04-4aa2-b18a-77d84a245eb2)

Example with this PR (alphanumeric):
![alphanum](https://github.com/user-attachments/assets/56a9b453-0351-4d02-b913-281da41850e4)

fixes #417
re #138

---

@Sporarum could you test this PR?