### PR TITLE
style(lib::config::v2::server::v1_interop): fix nightly clippy complaining about useless conversions

### DIFF
--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -466,7 +466,7 @@ mod v1_interop {
             };
 
             let player_settings = PlayerSettings {
-                music_dirs: value.music_dir.into_iter().map(Into::into).collect(),
+                music_dirs: value.music_dir,
                 // not converting old scan_depth as that is not stored in the config, but set via CLI, using default instead
                 // library_scan_depth: ScanDepth::Limited(value.max_depth_cli),
                 library_scan_depth: ScanDepth::Limited(10),


### PR DESCRIPTION
This PR fixes a issue with the [nightly clippy runs](https://github.com/tramhao/termusic/actions/runs/13448656742/job/37579070997) that now started complaining about this useless conversion

```txt
error: useless conversion to the same type: `std::path::PathBuf`
   --> lib/src/config/v2/server/mod.rs:469:56
    |
469 |                 music_dirs: value.music_dir.into_iter().map(Into::into).collect(),
    |                                                        ^^^^^^^^^^^^^^^^ help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`
```