### PR TITLE
Refactor discord Rpc to be more readable and require less `mut`

### DIFF
--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{self, Receiver, RecvError, Sender};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -66,12 +66,11 @@ impl Rpc {
         let mut title = String::new();
 
         loop {
-            let msg = match rx.try_recv() {
-                Err(TryRecvError::Empty) => {
-                    sleep(Duration::from_secs(1));
-                    continue;
+            let msg = match rx.recv() {
+                Err(RecvError) => {
+                    info!("No senders for discord updates anymore, closing discord connection");
+                    break;
                 }
-                Err(_) => break,
                 Ok(v) => v,
             };
 

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -37,19 +37,19 @@ impl Default for Rpc {
 
 impl Rpc {
     /// Update the discord status track information
-    pub fn update(&mut self, track: &Track) {
+    pub fn update(&self, track: &Track) {
         let artist = track.artist().unwrap_or(UNKNOWN_ARTIST).to_string();
         let title = track.title().unwrap_or(UNKNOWN_TITLE).to_string();
         self.tx.send(RpcCommand::Update(artist, title)).ok();
     }
 
     /// Update the discord status to show that it is paused
-    pub fn pause(&mut self) {
+    pub fn pause(&self) {
         self.tx.send(RpcCommand::Pause).ok();
     }
 
     /// Update the discord status to show that it is playing
-    pub fn resume(&mut self, time_pos: Option<PlayerTimeUnit>) {
+    pub fn resume(&self, time_pos: Option<PlayerTimeUnit>) {
         // ignore clippy here, this should not be a problem, maybe rich presence will support duration in the future
         #[allow(clippy::cast_possible_wrap)]
         if let Some(time_pos) = time_pos {

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -8,6 +8,8 @@ use termusiclib::track::Track;
 
 const APP_ID: &str = "968407067889131520";
 
+/// Handle for communicating with the discord ipc client
+#[derive(Debug)]
 pub struct Rpc {
     tx: Sender<RpcCommand>,
 }

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -1,8 +1,9 @@
-use crate::PlayerTimeUnit;
-use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::thread::sleep;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::PlayerTimeUnit;
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
 use termusiclib::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use termusiclib::track::Track;
 
@@ -22,104 +23,12 @@ enum RpcCommand {
 
 impl Default for Rpc {
     fn default() -> Self {
-        let mut client = DiscordIpcClient::new(APP_ID).unwrap();
+        let client = DiscordIpcClient::new(APP_ID).unwrap();
         let (tx, rx): (Sender<RpcCommand>, Receiver<RpcCommand>) = mpsc::channel();
-        let mut artist = String::new();
-        let mut title = String::new();
 
         std::thread::Builder::new()
             .name("discord rpc loop".into())
-            .spawn(move || loop {
-                let msg = match rx.try_recv() {
-                    Err(TryRecvError::Empty) => {
-                        sleep(Duration::from_secs(1));
-                        continue;
-                    }
-                    Err(_) => break,
-                    Ok(v) => v,
-                };
-
-                if !reconnect(&mut client) {
-                    // if connecting to the discord rpc fails, ignore the current command
-
-                    // likely for better status we should keep a state and try to reconnect, but also still handle all the commands send here
-                    continue;
-                }
-
-                match msg {
-                    RpcCommand::Update(artist_cmd, title_cmd) => {
-                        let assets = activity::Assets::new()
-                            .large_image("termusic")
-                            .large_text("terminal music player written in Rust");
-                        // .small_image(smol_image)
-                        // .small_text(state);
-                        let time = if let Ok(v) = i64::try_from(SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs()) {
-                                v
-                            } else {
-                                warn!("SystemTime to i64 failed, discord interface cant handle this number");
-                                0
-                            };
-                        let timestamp = activity::Timestamps::new().start(time);
-                        // .end(self.time + self.duration);
-
-                        artist = artist_cmd;
-                        title = title_cmd;
-
-                        client
-                            .set_activity(
-                                activity::Activity::new()
-                                    .assets(assets)
-                                    .timestamps(timestamp)
-                                    .state(&artist)
-                                    .details(&title),
-                            )
-                            .ok();
-                    }
-                    RpcCommand::Pause => {
-                        let assets = activity::Assets::new()
-                            .large_image("termusic")
-                            .large_text("terminal music player written in Rust");
-
-                        client
-                            .set_activity(
-                                activity::Activity::new()
-                                    .assets(assets)
-                                    .state(&artist)
-                                    .details(format!("{}: Paused", title.as_str()).as_str()),
-                            )
-                            .ok();
-                    }
-                    RpcCommand::Resume(time_pos) => {
-                        let assets = activity::Assets::new()
-                            .large_image("termusic")
-                            .large_text("terminal music player written in Rust");
-
-                        let time = if let Ok(v) = i64::try_from(SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs()) {
-                                v
-                            } else {
-                                warn!("SystemTime to i64 failed, discord interface cant handle this number");
-                                0
-                            };
-                        let timestamp = activity::Timestamps::new().start(time - time_pos);
-
-                        client
-                            .set_activity(
-                                activity::Activity::new()
-                                    .assets(assets)
-                                    .timestamps(timestamp)
-                                    .state(&artist)
-                                    .details(&title),
-                            )
-                            .ok();
-                    }
-                }
-            })
+            .spawn(|| Self::thread_fn(client, rx))
             .expect("failed to start discord rpc loop thread");
 
         Self { tx }
@@ -127,15 +36,19 @@ impl Default for Rpc {
 }
 
 impl Rpc {
+    /// Update the discord status track information
     pub fn update(&mut self, track: &Track) {
         let artist = track.artist().unwrap_or(UNKNOWN_ARTIST).to_string();
         let title = track.title().unwrap_or(UNKNOWN_TITLE).to_string();
         self.tx.send(RpcCommand::Update(artist, title)).ok();
     }
+
+    /// Update the discord status to show that it is paused
     pub fn pause(&mut self) {
         self.tx.send(RpcCommand::Pause).ok();
     }
 
+    /// Update the discord status to show that it is playing
     pub fn resume(&mut self, time_pos: Option<PlayerTimeUnit>) {
         // ignore clippy here, this should not be a problem, maybe rich presence will support duration in the future
         #[allow(clippy::cast_possible_wrap)]
@@ -143,6 +56,112 @@ impl Rpc {
             self.tx
                 .send(RpcCommand::Resume(time_pos.as_secs() as i64))
                 .ok();
+        }
+    }
+
+    /// This function actually communicates with the discord client and is meant to run in its own thread.
+    #[allow(clippy::needless_pass_by_value)]
+    fn thread_fn(mut client: DiscordIpcClient, rx: Receiver<RpcCommand>) {
+        let mut artist = String::new();
+        let mut title = String::new();
+
+        loop {
+            let msg = match rx.try_recv() {
+                Err(TryRecvError::Empty) => {
+                    sleep(Duration::from_secs(1));
+                    continue;
+                }
+                Err(_) => break,
+                Ok(v) => v,
+            };
+
+            if !reconnect(&mut client) {
+                // if connecting to the discord rpc fails, ignore the current command
+
+                // likely for better status we should keep a state and try to reconnect, but also still handle all the commands send here
+                continue;
+            }
+
+            match msg {
+                RpcCommand::Update(artist_cmd, title_cmd) => {
+                    let assets = activity::Assets::new()
+                        .large_image("termusic")
+                        .large_text("terminal music player written in Rust");
+                    // .small_text(state);
+                    let time = if let Ok(v) = i64::try_from(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs(),
+                    ) {
+                        v
+                    } else {
+                        warn!(
+                            "SystemTime to i64 failed, discord interface cant handle this number"
+                        );
+                        0
+                    };
+                    let timestamp = activity::Timestamps::new().start(time);
+                    // .end(self.time + self.duration);
+
+                    artist = artist_cmd;
+                    title = title_cmd;
+
+                    client
+                        .set_activity(
+                            activity::Activity::new()
+                                .assets(assets)
+                                .timestamps(timestamp)
+                                .state(&artist)
+                                .details(&title),
+                        )
+                        .ok();
+                }
+                RpcCommand::Pause => {
+                    let assets = activity::Assets::new()
+                        .large_image("termusic")
+                        .large_text("terminal music player written in Rust");
+
+                    client
+                        .set_activity(
+                            activity::Activity::new()
+                                .assets(assets)
+                                .state(&artist)
+                                .details(format!("{}: Paused", title.as_str()).as_str()),
+                        )
+                        .ok();
+                }
+                RpcCommand::Resume(time_pos) => {
+                    let assets = activity::Assets::new()
+                        .large_image("termusic")
+                        .large_text("terminal music player written in Rust");
+
+                    let time = if let Ok(v) = i64::try_from(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs(),
+                    ) {
+                        v
+                    } else {
+                        warn!(
+                            "SystemTime to i64 failed, discord interface cant handle this number"
+                        );
+                        0
+                    };
+                    let timestamp = activity::Timestamps::new().start(time - time_pos);
+
+                    client
+                        .set_activity(
+                            activity::Activity::new()
+                                .assets(assets)
+                                .timestamps(timestamp)
+                                .state(&artist)
+                                .details(&title),
+                        )
+                        .ok();
+                }
+            }
         }
     }
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -379,9 +379,7 @@ impl GeneralPlayer {
 
         self.playlist.proceed();
 
-        if let Some(track) = self.playlist.current_track() {
-            let track = track.clone();
-
+        if let Some(track) = self.playlist.current_track().cloned() {
             info!("Starting Track {:#?}", track);
 
             if self.playlist.has_next_track() {
@@ -435,9 +433,8 @@ impl GeneralPlayer {
             return;
         }
 
-        let track = match self.playlist.fetch_next_track() {
-            Some(t) => t.clone(),
-            None => return,
+        let Some(track) = self.playlist.fetch_next_track().cloned() else {
+            return;
         };
 
         self.enqueue_next(&track);
@@ -445,6 +442,7 @@ impl GeneralPlayer {
         info!("Next track enqueued: {:#?}", track);
     }
 
+    /// Skip to the next track, if there is one
     pub fn next(&mut self) {
         if self.playlist.current_track().is_some() {
             info!("skip route 1 which is in most cases.");
@@ -453,11 +451,10 @@ impl GeneralPlayer {
         } else {
             info!("skip route 2 cause no current track.");
             self.stop();
-            // if let Err(e) = crate::audio_cmd::<()>(PlayerCmd::StartPlay, false) {
-            //     debug!("Error in skip route 2: {e}");
-            // }
         }
     }
+
+    /// Switch & Play the previous track in the playlist
     pub fn previous(&mut self) {
         self.playlist.previous();
         self.playlist.proceed_false();

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -334,7 +334,7 @@ impl GeneralPlayer {
 
         if config.get_discord_status_enable() && self.discord.is_none() {
             // start discord ipc if new config has it enabled, but is not active yet
-            let mut discord = discord::Rpc::default();
+            let discord = discord::Rpc::default();
 
             // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
             if let Some(track) = self.playlist.current_track() {
@@ -423,7 +423,7 @@ impl GeneralPlayer {
                 mpris.add_and_play(track);
             }
 
-            if let Some(ref mut discord) = self.discord {
+            if let Some(ref discord) = self.discord {
                 discord.update(track);
             }
         }
@@ -646,7 +646,7 @@ impl PlayerTrait for GeneralPlayer {
         if let Some(ref mut mpris) = self.mpris {
             mpris.pause();
         }
-        if let Some(ref mut discord) = self.discord {
+        if let Some(ref discord) = self.discord {
             discord.pause();
         }
 
@@ -662,7 +662,7 @@ impl PlayerTrait for GeneralPlayer {
             mpris.resume();
         }
         let time_pos = self.get_player().position();
-        if let Some(ref mut discord) = self.discord {
+        if let Some(ref discord) = self.discord {
             discord.resume(time_pos);
         }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -699,9 +699,7 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn stop(&mut self) {
-        self.playlist.set_status(Status::Stopped);
-        self.playlist.set_next_track(None);
-        self.playlist.clear_current_track();
+        self.playlist.stop();
         self.get_player_mut().stop();
     }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -559,6 +559,14 @@ impl Playlist {
         }
     }
 
+    /// Stop the current playlist by setting [`Status::Stopped`], preventing going to the next track
+    /// and finally, stop the currently playing track.
+    pub fn stop(&mut self) {
+        self.set_status(Status::Stopped);
+        self.set_next_track(None);
+        self.clear_current_track();
+    }
+
     #[must_use]
     pub fn current_track(&self) -> Option<&Track> {
         if self.current_track.is_some() {


### PR DESCRIPTION
This function refactors `discord::Rpc` and touching code to be less nested, more documented and dont require `mut self` where not necessary anymore.
Additionally, the `try_recv` has been changed to just `recv` as we dont need to check or update anything other than that channel in that thread.

Also includes some slight style changes regarding `playback::playlist` and also moves the playlist stop procedure to a dedicated function.