### PR TITLE
Playlist completely server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.
 - Fix(tui): on track change, dont select "current track" playlist item if the old "current track" was not selected.
+- Fix(tui): re-select the (approximately) same playlist item after a shuffle.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Change: updated MSRV to 1.79.
 - Change: update some dependencies.
 - Change: remove unused dependencies from all packages.
+- Change: move many playlist operations to be executed by the server and listend to by clients. (see #152)
 - Change(server): on rusty backend, use upstream rodio again.
 - Feat: more immediate event changes (Example: updated via mpris)
 - Feat(server): on rusty backend, enable `aiff` codec support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.
+- Fix(tui): on track change, dont select "current track" playlist item if the old "current track" was not selected.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.
+- Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]
 - Released on: March 8, 2025.
@@ -29,7 +30,7 @@
 - Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
 - Fix: fix accidental invertion of `is_absolute` for path playlist values causing items to not have the correct path.
 - Fix: create and save config if it does not exist, without needing a successful connect first.
-- Fix: in `rusty` backen, correctly track the time before speed change.
+- Fix: in `rusty` backend, correctly track the time before speed change.
 - Fix(tui): base "no lyrics available" message on the same value as actual parsed lyrics.
 - Fix(tui): not being able to parse themes that use `0x` as the prefix.
 - Fix(tui): change that the default Theme is not using bad colors.

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -20,7 +20,7 @@ service MusicPlayer {
   // Playlist Commands
   // Skip to a specific track in the playlist
   // at the momemnt, the one set via "current_track_index"
-  rpc PlaySelected(Empty) returns (Empty);
+  rpc PlaySpecific(PlaylistPlaySpecific) returns (Empty);
   // Cycle the playlist loop mode, returns the new mode.
   rpc CycleLoop(Empty) returns (PlaylistLoopMode);
   rpc ReloadPlaylist(Empty) returns (Empty);
@@ -151,6 +151,13 @@ message UpdateTrackChanged {
     string title = 3;
   }
   PlayerTime progress = 4;
+}
+
+// Play a specific track in the playlist
+message PlaylistPlaySpecific {
+  uint64 track_index = 1;
+
+  TrackId id = 2;
 }
 
 // All tracks in the current playlist, they *should* be ordered from lowest to highest index.

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -32,7 +32,7 @@ service MusicPlayer {
   // Get all tracks of the playlist.
   rpc GetPlaylist(Empty) returns (PlaylistTracks);
   // Shuffle the playlist, returns the new playlist tracks.
-  rpc ShufflePlaylist(Empty) returns (PlaylistTracks);
+  rpc ShufflePlaylist(Empty) returns (Empty);
   // Check for and remove deleted items from the playlist.
   // Unlike shuffle, this will send Removal events
   rpc RemoveDeletedTracks(Empty) returns (Empty);
@@ -263,7 +263,7 @@ message PlaylistTracksToRemoveClear {
 
 /// Indicate that the playlist has been shuffled and should be re-fetched
 message PlaylistShuffled {
-  // empty as there are no values, but not using "Empty" to have a unique message id
+  PlaylistTracks shuffled = 1;
 }
 
 // A Identifier for a track.

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -32,6 +32,8 @@ service MusicPlayer {
   rpc SwapTracks(PlaylistSwapTracks) returns (Empty);
   // Get all tracks of the playlist.
   rpc GetPlaylist(Empty) returns (PlaylistTracks);
+  // Shuffle the playlist, returns the new playlist tracks.
+  rpc ShufflePlaylist(Empty) returns (PlaylistTracks);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -175,6 +175,7 @@ message UpdatePlaylist {
     PlaylistCleared cleared = 3;
     PlaylistLoopMode loop_mode = 4;
     PlaylistSwapTracks swap_tracks = 5;
+    PlaylistShuffled shuffled = 6;
   }
 }
 
@@ -208,7 +209,7 @@ message PlaylistRemoveTrack {
   TrackId id = 2;
 }
 
-/// The Playlist got completely cleared
+// The Playlist got completely cleared
 message PlaylistCleared {
   // empty as there are no values, but not using "Empty" to have a unique message id
 }
@@ -237,7 +238,7 @@ message PlaylistTracksToAdd {
   repeated TrackId tracks = 2;
 }
 
-/// Remove multiple track or clear the playlist
+// Remove multiple track or clear the playlist
 message PlaylistTracksToRemove {
   oneof type {
     PlaylistTracksToRemoveIndexed indexed = 1;
@@ -245,7 +246,7 @@ message PlaylistTracksToRemove {
   }
 }
 
-/// Remove multiple tracks from a playlist
+// Remove multiple tracks from a playlist
 message PlaylistTracksToRemoveIndexed {
   // The index the track(s) that are removed
   // This is the starting index, and x amount of elements are removed after
@@ -257,6 +258,11 @@ message PlaylistTracksToRemoveIndexed {
 
 /// Clear the entire playlist
 message PlaylistTracksToRemoveClear {
+  // empty as there are no values, but not using "Empty" to have a unique message id
+}
+
+/// Indicate that the playlist has been shuffled and should be re-fetched
+message PlaylistShuffled {
   // empty as there are no values, but not using "Empty" to have a unique message id
 }
 

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -28,6 +28,8 @@ service MusicPlayer {
   rpc AddToPlaylist(PlaylistTracksToAdd) returns (Empty);
   // Remove one or multiple tracks from the playlist
   rpc RemoveFromPlaylist(PlaylistTracksToRemove) returns (Empty);
+  // Swap some tracks.
+  rpc SwapTracks(PlaylistSwapTracks) returns (Empty);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);
@@ -153,6 +155,7 @@ message UpdatePlaylist {
     PlaylistRemoveTrack remove_track = 2;
     PlaylistCleared cleared = 3;
     PlaylistLoopMode loop_mode = 4;
+    PlaylistSwapTracks swap_tracks = 5;
   }
 }
 
@@ -195,6 +198,14 @@ message PlaylistCleared {
 message PlaylistLoopMode {
   // The actual mode, mapped to [`config::v2::server::LoopMode`]
   uint32 mode = 1;
+}
+
+// Some track needs to be swapped.
+message PlaylistSwapTracks {
+  // The first index to swap
+  uint64 index_a = 1;
+  // The second index to swap
+  uint64 index_b = 2;
 }
 
 // Add multiple tracks to a Playlist

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -26,6 +26,8 @@ service MusicPlayer {
   rpc ReloadPlaylist(Empty) returns (Empty);
   // Add one or multiple tracks to the playlist
   rpc AddToPlaylist(PlaylistTracksToAdd) returns (Empty);
+  // Remove one or multiple tracks from the playlist
+  rpc RemoveFromPlaylist(PlaylistTracksToRemove) returns (Empty);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);
@@ -148,6 +150,7 @@ message UpdateTrackChanged {
 message UpdatePlaylist {
   oneof type {
     PlaylistAddTrack add_track = 1;
+    PlaylistRemoveTrack remove_track = 2;
   }
 }
 
@@ -172,6 +175,15 @@ message PlaylistAddTrack {
   TrackId id = 4;
 }
 
+// A Track got removed from the playlist.
+message PlaylistRemoveTrack {
+  // The index of the track that was removed.
+  uint64 at_index = 1;
+
+  // The Id of the track that was removed
+  TrackId id = 2;
+}
+
 // The current Loop mode for the playlist
 message PlaylistLoopMode {
   // The actual mode, mapped to [`config::v2::server::LoopMode`]
@@ -185,6 +197,16 @@ message PlaylistTracksToAdd {
   uint64 at_index = 1;
 
   // All the Tracks to add at the index
+  repeated TrackId tracks = 2;
+}
+
+/// Remove multiple tracks from a playlist
+message PlaylistTracksToRemove {
+  // The index the track(s) that are removed
+  // This is the starting index, and x amount of elements are removed after
+  uint64 at_index = 1;
+
+  // All the Tracks to remove at the index
   repeated TrackId tracks = 2;
 }
 

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -18,10 +18,14 @@ service MusicPlayer {
   rpc SeekBackward(Empty) returns (PlayerTime);
 
   // Playlist Commands
+  // Skip to a specific track in the playlist
+  // at the momemnt, the one set via "current_track_index"
   rpc PlaySelected(Empty) returns (Empty);
   // Cycle the playlist loop mode, returns the new mode.
   rpc CycleLoop(Empty) returns (PlaylistLoopMode);
   rpc ReloadPlaylist(Empty) returns (Empty);
+  // Add one or multiple tracks to the playlist
+  rpc AddToPlaylist(PlaylistTracksToAdd) returns (Empty);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);
@@ -84,6 +88,8 @@ message StreamUpdates {
     UpdatePlayStateChanged play_state_changed = 4;
     UpdateTrackChanged track_changed = 5;
     UpdateGaplessChanged gapless_changed = 6;
+
+    UpdatePlaylist playlist_changed = 7;
   }
 }
 
@@ -139,8 +145,58 @@ message UpdateTrackChanged {
   PlayerTime progress = 4;
 }
 
+message UpdatePlaylist {
+  oneof type {
+    PlaylistAddTrack add_track = 1;
+  }
+}
+
+// A Track got added to the playlist, this message contains where it was added and all the metadata required for display.
+message PlaylistAddTrack {
+  // The index the track was added to the playlist.
+  // If this is not at the end, all tracks at that index and after need to be shifted to make place for this new one.
+  uint64 at_index = 1;
+
+  // all values below should be moved into their own "Track" message at some point
+  // instead of having the TUI fetch everything from the file itself
+  // radio title, track title
+  // the following is (linux protobuf) 3.15, ubuntu 2204 still has (linux protobuf) 3.12
+  // optional string title = 3;
+  // the following "oneof" is wire equivalent to the above "optional"
+  oneof optional_title {
+    string title = 2;
+  }
+  Duration duration = 3;
+
+  // The Id of the track that was added
+  TrackId id = 4;
+}
+
 // The current Loop mode for the playlist
 message PlaylistLoopMode {
   // The actual mode, mapped to [`config::v2::server::LoopMode`]
   uint32 mode = 1;
+}
+
+// Add multiple tracks to a Playlist
+message PlaylistTracksToAdd {
+  // The index the track(s) are added at.
+  // If this is not at the end, all tracks at that index and after need to be shifted to make place for this new one.
+  uint64 at_index = 1;
+
+  // All the Tracks to add at the index
+  repeated TrackId tracks = 2;
+}
+
+// A Identifier for a track.
+message TrackId {
+  oneof source {
+    // Path on the system
+    // bytes *could* be used, but it way more complex and platform dependant
+    string path = 1;
+    // Url (ex. radio)
+    string url = 2;
+    // A podcast episode
+    string podcastUrl = 3;
+  }
 }

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -30,6 +30,8 @@ service MusicPlayer {
   rpc RemoveFromPlaylist(PlaylistTracksToRemove) returns (Empty);
   // Swap some tracks.
   rpc SwapTracks(PlaylistSwapTracks) returns (Empty);
+  // Get all tracks of the playlist.
+  rpc GetPlaylist(Empty) returns (PlaylistTracks);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);
@@ -147,6 +149,12 @@ message UpdateTrackChanged {
     string title = 3;
   }
   PlayerTime progress = 4;
+}
+
+// All tracks in the current playlist, they *should* be ordered from lowest to highest index.
+message PlaylistTracks {
+  uint64 current_track_index = 1;
+  repeated PlaylistAddTrack tracks = 2;
 }
 
 message UpdatePlaylist {

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -23,7 +23,6 @@ service MusicPlayer {
   rpc PlaySpecific(PlaylistPlaySpecific) returns (Empty);
   // Cycle the playlist loop mode, returns the new mode.
   rpc CycleLoop(Empty) returns (PlaylistLoopMode);
-  rpc ReloadPlaylist(Empty) returns (Empty);
   // Add one or multiple tracks to the playlist
   rpc AddToPlaylist(PlaylistTracksToAdd) returns (Empty);
   // Remove one or multiple tracks from the playlist

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -151,6 +151,7 @@ message UpdatePlaylist {
   oneof type {
     PlaylistAddTrack add_track = 1;
     PlaylistRemoveTrack remove_track = 2;
+    PlaylistCleared cleared = 3;
   }
 }
 
@@ -184,6 +185,11 @@ message PlaylistRemoveTrack {
   TrackId id = 2;
 }
 
+/// The Playlist got completely cleared
+message PlaylistCleared {
+  // empty as there are no values, but not using "Empty" to have a unique message id
+}
+
 // The current Loop mode for the playlist
 message PlaylistLoopMode {
   // The actual mode, mapped to [`config::v2::server::LoopMode`]
@@ -200,14 +206,27 @@ message PlaylistTracksToAdd {
   repeated TrackId tracks = 2;
 }
 
-/// Remove multiple tracks from a playlist
+/// Remove multiple track or clear the playlist
 message PlaylistTracksToRemove {
+  oneof type {
+    PlaylistTracksToRemoveIndexed indexed = 1;
+    PlaylistTracksToRemoveClear clear = 2;
+  }
+}
+
+/// Remove multiple tracks from a playlist
+message PlaylistTracksToRemoveIndexed {
   // The index the track(s) that are removed
   // This is the starting index, and x amount of elements are removed after
   uint64 at_index = 1;
 
   // All the Tracks to remove at the index
   repeated TrackId tracks = 2;
+}
+
+/// Clear the entire playlist
+message PlaylistTracksToRemoveClear {
+  // empty as there are no values, but not using "Empty" to have a unique message id
 }
 
 // A Identifier for a track.

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -34,6 +34,9 @@ service MusicPlayer {
   rpc GetPlaylist(Empty) returns (PlaylistTracks);
   // Shuffle the playlist, returns the new playlist tracks.
   rpc ShufflePlaylist(Empty) returns (PlaylistTracks);
+  // Check for and remove deleted items from the playlist.
+  // Unlike shuffle, this will send Removal events
+  rpc RemoveDeletedTracks(Empty) returns (Empty);
 
   // Misc Commands
   rpc ReloadConfig(Empty) returns (Empty);

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -152,6 +152,7 @@ message UpdatePlaylist {
     PlaylistAddTrack add_track = 1;
     PlaylistRemoveTrack remove_track = 2;
     PlaylistCleared cleared = 3;
+    PlaylistLoopMode loop_mode = 4;
   }
 }
 

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::module_name_repetitions)]
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 
 // using lower mod to restrict clippy
 #[allow(clippy::pedantic)]
@@ -74,6 +74,7 @@ pub enum UpdateEvents {
     PlayStateChanged { playing: u32 },
     TrackChanged(TrackChangedInfo),
     GaplessChanged { gapless: bool },
+    PlaylistChanged(UpdatePlaylistEvents),
 }
 
 type StreamTypes = protobuf::stream_updates::Type;
@@ -113,6 +114,7 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
                     msg: Some(GaplessState { gapless }),
                 })
             }
+            UpdateEvents::PlaylistChanged(ev) => StreamTypes::PlaylistChanged(ev.into()),
         };
 
         Self { r#type: Some(val) }
@@ -151,6 +153,76 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
             StreamTypes::GaplessChanged(ev) => Self::GaplessChanged {
                 gapless: unwrap_msg(ev.msg, "StreamUpdates.types.gapless_changed.msg")?.gapless,
             },
+            StreamTypes::PlaylistChanged(ev) => Self::PlaylistChanged(
+                ev.try_into()
+                    .context("In \"StreamUpdates.types.playlist_changed\"")?,
+            ),
+        };
+
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlaylistAddTrackInfo {
+    /// The Index at which a track was added at.
+    /// If this is not at the end, all tracks at this index and beyond should be shifted.
+    pub at_index: u64,
+    pub title: Option<String>,
+    /// Duration of the track
+    pub duration: PlayerTimeUnit,
+    pub trackid: playlist_helpers::PlaylistTrackSource,
+}
+
+/// Separate nested enum to handle all playlist related events
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdatePlaylistEvents {
+    PlaylistAddTrack(PlaylistAddTrackInfo),
+}
+
+type PPlaylistTypes = protobuf::update_playlist::Type;
+
+// mainly for server to grpc
+impl From<UpdatePlaylistEvents> for protobuf::UpdatePlaylist {
+    fn from(value: UpdatePlaylistEvents) -> Self {
+        let val = match value {
+            UpdatePlaylistEvents::PlaylistAddTrack(vals) => {
+                PPlaylistTypes::AddTrack(protobuf::PlaylistAddTrack {
+                    at_index: vals.at_index,
+                    optional_title: vals
+                        .title
+                        .map(protobuf::playlist_add_track::OptionalTitle::Title),
+                    duration: Some(vals.duration.into()),
+                    id: Some(vals.trackid.into()),
+                })
+            }
+        };
+
+        Self { r#type: Some(val) }
+    }
+}
+
+// mainly for grpc to client(tui)
+impl TryFrom<protobuf::UpdatePlaylist> for UpdatePlaylistEvents {
+    type Error = anyhow::Error;
+
+    fn try_from(value: protobuf::UpdatePlaylist) -> Result<Self, Self::Error> {
+        let value = unwrap_msg(value.r#type, "UpdatePlaylist.type")?;
+
+        let res = match value {
+            PPlaylistTypes::AddTrack(ev) => Self::PlaylistAddTrack(PlaylistAddTrackInfo {
+                at_index: ev.at_index,
+                title: ev.optional_title.map(|v| {
+                    let protobuf::playlist_add_track::OptionalTitle::Title(v) = v;
+                    v
+                }),
+                duration: unwrap_msg(ev.duration, "UpdatePlaylist.type.add_track.duration")?.into(),
+                trackid: unwrap_msg(
+                    unwrap_msg(ev.id, "UpdatePlaylist.type.add_track.id")?.source,
+                    "UpdatePlaylist.type.add_track.id.source",
+                )?
+                .try_into()?,
+            }),
         };
 
         Ok(res)
@@ -168,4 +240,97 @@ fn unwrap_msg<T>(opt: Option<T>, place: &str) -> Result<T, anyhow::Error> {
 #[allow(clippy::cast_possible_truncation)]
 fn clamp_u16(val: u32) -> u16 {
     val.min(u32::from(u16::MAX)) as u16
+}
+
+pub mod playlist_helpers {
+    use super::{protobuf, unwrap_msg};
+
+    /// A Id / Source for a given Track
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum PlaylistTrackSource {
+        Path(String),
+        Url(String),
+        PodcastUrl(String),
+    }
+
+    impl From<PlaylistTrackSource> for protobuf::track_id::Source {
+        fn from(value: PlaylistTrackSource) -> Self {
+            match value {
+                PlaylistTrackSource::Path(v) => Self::Path(v),
+                PlaylistTrackSource::Url(v) => Self::Url(v),
+                PlaylistTrackSource::PodcastUrl(v) => Self::PodcastUrl(v),
+            }
+        }
+    }
+
+    impl From<PlaylistTrackSource> for protobuf::TrackId {
+        fn from(value: PlaylistTrackSource) -> Self {
+            Self {
+                source: Some(value.into()),
+            }
+        }
+    }
+
+    impl TryFrom<protobuf::track_id::Source> for PlaylistTrackSource {
+        type Error = anyhow::Error;
+
+        fn try_from(value: protobuf::track_id::Source) -> Result<Self, Self::Error> {
+            Ok(match value {
+                protobuf::track_id::Source::Path(v) => Self::Path(v),
+                protobuf::track_id::Source::Url(v) => Self::Url(v),
+                protobuf::track_id::Source::PodcastUrl(v) => Self::PodcastUrl(v),
+            })
+        }
+    }
+
+    /// Data for requesting some tracks to be added in the server
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PlaylistAddTrack {
+        pub at_index: u64,
+        pub tracks: Vec<PlaylistTrackSource>,
+    }
+
+    impl PlaylistAddTrack {
+        #[must_use]
+        pub fn new_single(at_index: u64, track: PlaylistTrackSource) -> Self {
+            Self {
+                at_index,
+                tracks: vec![track],
+            }
+        }
+
+        #[must_use]
+        pub fn new_vec(at_index: u64, tracks: Vec<PlaylistTrackSource>) -> Self {
+            Self { at_index, tracks }
+        }
+    }
+
+    impl From<PlaylistAddTrack> for protobuf::PlaylistTracksToAdd {
+        fn from(value: PlaylistAddTrack) -> Self {
+            Self {
+                at_index: value.at_index,
+                tracks: value.tracks.into_iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    impl TryFrom<protobuf::PlaylistTracksToAdd> for PlaylistAddTrack {
+        type Error = anyhow::Error;
+
+        fn try_from(value: protobuf::PlaylistTracksToAdd) -> Result<Self, Self::Error> {
+            let tracks = value
+                .tracks
+                .into_iter()
+                .map(|v| {
+                    unwrap_msg(v.source, "PlaylistTracksToAdd.tracks")
+                        .and_then(PlaylistTrackSource::try_from)
+                })
+                .collect::<Result<Vec<_>, anyhow::Error>>()?;
+
+            Ok(Self {
+                at_index: value.at_index,
+                tracks,
+            })
+        }
+    }
 }

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -212,6 +212,7 @@ pub enum UpdatePlaylistEvents {
     PlaylistCleared,
     PlaylistLoopMode(PlaylistLoopModeInfo),
     PlaylistSwapTracks(PlaylistSwapInfo),
+    PlaylistShuffled,
 }
 
 type PPlaylistTypes = protobuf::update_playlist::Type;
@@ -245,6 +246,9 @@ impl From<UpdatePlaylistEvents> for protobuf::UpdatePlaylist {
                     index_a: vals.index_a,
                     index_b: vals.index_b,
                 })
+            }
+            UpdatePlaylistEvents::PlaylistShuffled => {
+                PPlaylistTypes::Shuffled(protobuf::PlaylistShuffled {})
             }
         };
 
@@ -289,6 +293,7 @@ impl TryFrom<protobuf::UpdatePlaylist> for UpdatePlaylistEvents {
                 index_a: ev.index_a,
                 index_b: ev.index_b,
             }),
+            PPlaylistTypes::Shuffled(_) => Self::PlaylistShuffled,
         };
 
         Ok(res)

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -518,4 +518,33 @@ pub mod playlist_helpers {
             })
         }
     }
+
+    /// Data for requesting to skip / play a specific track
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PlaylistPlaySpecific {
+        pub track_index: u64,
+        pub id: PlaylistTrackSource,
+    }
+
+    impl From<PlaylistPlaySpecific> for protobuf::PlaylistPlaySpecific {
+        fn from(value: PlaylistPlaySpecific) -> Self {
+            Self {
+                track_index: value.track_index,
+                id: Some(value.id.into()),
+            }
+        }
+    }
+
+    impl TryFrom<protobuf::PlaylistPlaySpecific> for PlaylistPlaySpecific {
+        type Error = anyhow::Error;
+
+        fn try_from(value: protobuf::PlaylistPlaySpecific) -> Result<Self, Self::Error> {
+            Ok(Self {
+                track_index: value.track_index,
+                id: unwrap_msg(value.id, "PlaylistPlaySpecific.id").and_then(|v| {
+                    PlaylistTrackSource::try_from(v).context("PlaylistPlaySpecific.id")
+                })?,
+            })
+        }
+    }
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -8,7 +8,9 @@ pub use playlist::{Playlist, Status};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::library_db::DataBase;
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
+use termusiclib::player::playlist_helpers::{
+    PlaylistAddTrack, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
+};
 use termusiclib::player::{PlayerProgress, PlayerTimeUnit, TrackChangedInfo, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaType, Track};
@@ -115,6 +117,7 @@ pub enum PlayerCmd {
     PlaylistAddTrack(PlaylistAddTrack),
     PlaylistRemoveTrack(PlaylistRemoveTrackIndexed),
     PlaylistClear,
+    PlaylistSwapTrack(PlaylistSwapTrack),
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -151,6 +151,7 @@ impl GeneralPlayer {
         config: SharedServerSettings,
         cmd_tx: PlayerCmdSender,
         stream_tx: StreamTX,
+        playlist: SharedPlaylist,
     ) -> Result<Self> {
         let config_read = config.read();
         let backend = Backend::new_select(backend, &config_read, cmd_tx.clone());
@@ -160,9 +161,6 @@ impl GeneralPlayer {
         let db_podcast = DBPod::new(&db_path).with_context(|| "error connecting to podcast db.")?;
         let db = DataBase::new(&config_read)?;
 
-        let playlist = Arc::new(RwLock::new(
-            Playlist::new(&config, stream_tx.clone()).context("Failed to load playlist")?,
-        ));
         let mpris = if config.read().settings.player.use_mediacontrols {
             Some(mpris::Mpris::new(cmd_tx.clone()))
         } else {
@@ -200,8 +198,9 @@ impl GeneralPlayer {
         config: SharedServerSettings,
         cmd_tx: PlayerCmdSender,
         stream_tx: StreamTX,
+        playlist: SharedPlaylist,
     ) -> Result<Self> {
-        Self::new_backend(BackendSelect::Rusty, config, cmd_tx, stream_tx)
+        Self::new_backend(BackendSelect::Rusty, config, cmd_tx, stream_tx, playlist)
     }
 
     /// Reload the config from file, on fail continue to use the old

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -8,6 +8,7 @@ pub use playlist::{Playlist, Status};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::library_db::DataBase;
+use termusiclib::player::playlist_helpers::PlaylistAddTrack;
 use termusiclib::player::{PlayerProgress, PlayerTimeUnit, TrackChangedInfo, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaType, Track};
@@ -110,6 +111,8 @@ pub enum PlayerCmd {
     TogglePause,
     VolumeDown,
     VolumeUp,
+
+    PlaylistAddTrack(PlaylistAddTrack),
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;
@@ -149,7 +152,8 @@ impl GeneralPlayer {
         let db_podcast = DBPod::new(&db_path).with_context(|| "error connecting to podcast db.")?;
         let db = DataBase::new(&config_read)?;
 
-        let playlist = Playlist::new(&config).context("Failed to load playlist")?;
+        let playlist =
+            Playlist::new(&config, stream_tx.clone()).context("Failed to load playlist")?;
         let mpris = if config.read().settings.player.use_mediacontrols {
             Some(mpris::Mpris::new(cmd_tx.clone()))
         } else {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -121,6 +121,7 @@ pub enum PlayerCmd {
     PlaylistClear,
     PlaylistSwapTrack(PlaylistSwapTrack),
     PlaylistShuffle,
+    PlaylistRemoveDeletedTracks,
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -8,7 +8,7 @@ pub use playlist::{Playlist, Status};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::library_db::DataBase;
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
 use termusiclib::player::{PlayerProgress, PlayerTimeUnit, TrackChangedInfo, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaType, Track};
@@ -113,7 +113,8 @@ pub enum PlayerCmd {
     VolumeUp,
 
     PlaylistAddTrack(PlaylistAddTrack),
-    PlaylistRemoveTrack(PlaylistRemoveTrack),
+    PlaylistRemoveTrack(PlaylistRemoveTrackIndexed),
+    PlaylistClear,
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -120,6 +120,7 @@ pub enum PlayerCmd {
     PlaylistRemoveTrack(PlaylistRemoveTrackIndexed),
     PlaylistClear,
     PlaylistSwapTrack(PlaylistSwapTrack),
+    PlaylistShuffle,
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -1,9 +1,11 @@
 //! SPDX-License-Identifier: MIT
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use parking_lot::RwLock;
 pub use playlist::{Playlist, Status};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::SharedServerSettings;
@@ -121,11 +123,12 @@ pub enum PlayerCmd {
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;
+pub type SharedPlaylist = Arc<RwLock<Playlist>>;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct GeneralPlayer {
     pub backend: Backend,
-    pub playlist: Playlist,
+    pub playlist: SharedPlaylist,
     pub config: SharedServerSettings,
     pub current_track_updated: bool,
     pub mpris: Option<mpris::Mpris>,
@@ -157,8 +160,9 @@ impl GeneralPlayer {
         let db_podcast = DBPod::new(&db_path).with_context(|| "error connecting to podcast db.")?;
         let db = DataBase::new(&config_read)?;
 
-        let playlist =
-            Playlist::new(&config, stream_tx.clone()).context("Failed to load playlist")?;
+        let playlist = Arc::new(RwLock::new(
+            Playlist::new(&config, stream_tx.clone()).context("Failed to load playlist")?,
+        ));
         let mpris = if config.read().settings.player.use_mediacontrols {
             Some(mpris::Mpris::new(cmd_tx.clone()))
         } else {
@@ -215,7 +219,7 @@ impl GeneralPlayer {
             // start mpris if new config has it enabled, but is not active yet
             let mut mpris = mpris::Mpris::new(self.cmd_tx.clone());
             // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
-            if let Some(track) = self.playlist.current_track() {
+            if let Some(track) = self.playlist.read().current_track() {
                 mpris.add_and_play(track);
             }
             // the same for volume
@@ -231,7 +235,7 @@ impl GeneralPlayer {
             let discord = discord::Rpc::default();
 
             // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
-            if let Some(track) = self.playlist.current_track() {
+            if let Some(track) = self.playlist.read().current_track() {
                 discord.update(track);
             }
 
@@ -267,17 +271,19 @@ impl GeneralPlayer {
     ///
     /// if `current_track_index` in playlist is above u32
     pub fn start_play(&mut self) {
-        if self.playlist.is_stopped() | self.playlist.is_paused() {
-            self.playlist.set_status(Status::Running);
+        let mut playlist = self.playlist.write();
+        if playlist.is_stopped() | playlist.is_paused() {
+            playlist.set_status(Status::Running);
         }
 
-        self.playlist.proceed();
+        playlist.proceed();
 
-        if let Some(track) = self.playlist.current_track().cloned() {
+        if let Some(track) = playlist.current_track().cloned() {
             info!("Starting Track {track:#?}");
 
-            if self.playlist.has_next_track() {
-                self.playlist.set_next_track(None);
+            if playlist.has_next_track() {
+                playlist.set_next_track(None);
+                drop(playlist);
                 self.current_track_updated = true;
                 info!("gapless next track played");
                 #[allow(irrefutable_let_patterns)]
@@ -287,6 +293,7 @@ impl GeneralPlayer {
                 self.add_and_play_mpris_discord();
                 return;
             }
+            drop(playlist);
 
             self.current_track_updated = true;
             let wait = async {
@@ -302,7 +309,7 @@ impl GeneralPlayer {
             }
 
             self.send_stream_ev(UpdateEvents::TrackChanged(TrackChangedInfo {
-                current_track_index: u64::try_from(self.playlist.get_current_track_index())
+                current_track_index: u64::try_from(self.playlist.read().get_current_track_index())
                     .unwrap(),
                 current_track_updated: self.current_track_updated,
                 title: self.media_info().media_title,
@@ -312,7 +319,7 @@ impl GeneralPlayer {
     }
 
     fn add_and_play_mpris_discord(&mut self) {
-        if let Some(track) = self.playlist.current_track() {
+        if let Some(track) = self.playlist.read().current_track() {
             if let Some(ref mut mpris) = self.mpris {
                 mpris.add_and_play(track);
             }
@@ -323,13 +330,15 @@ impl GeneralPlayer {
         }
     }
     pub fn enqueue_next_from_playlist(&mut self) {
-        if self.playlist.has_next_track() {
+        let mut playlist = self.playlist.write();
+        if playlist.has_next_track() {
             return;
         }
 
-        let Some(track) = self.playlist.fetch_next_track().cloned() else {
+        let Some(track) = playlist.fetch_next_track().cloned() else {
             return;
         };
+        drop(playlist);
 
         self.enqueue_next(&track);
 
@@ -338,9 +347,9 @@ impl GeneralPlayer {
 
     /// Skip to the next track, if there is one
     pub fn next(&mut self) {
-        if self.playlist.current_track().is_some() {
+        if self.playlist.read().current_track().is_some() {
             info!("skip route 1 which is in most cases.");
-            self.playlist.set_next_track(None);
+            self.playlist.write().set_next_track(None);
             self.skip_one();
         } else {
             info!("skip route 2 cause no current track.");
@@ -350,14 +359,19 @@ impl GeneralPlayer {
 
     /// Switch & Play the previous track in the playlist
     pub fn previous(&mut self) {
-        self.playlist.previous();
-        self.playlist.proceed_false();
+        let mut playlist = self.playlist.write();
+        playlist.previous();
+        playlist.proceed_false();
+        drop(playlist);
         self.next();
     }
 
     /// Resume playback if paused, pause playback if running
     pub fn toggle_pause(&mut self) {
-        match self.playlist.status() {
+        // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
+        // see https://github.com/rust-lang/rust/issues/93883
+        let status = self.playlist.read().status();
+        match status {
             Status::Running => {
                 <Self as PlayerTrait>::pause(self);
             }
@@ -370,7 +384,10 @@ impl GeneralPlayer {
 
     /// Pause playback if running
     pub fn pause(&mut self) {
-        match self.playlist.status() {
+        // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
+        // see https://github.com/rust-lang/rust/issues/93883
+        let status = self.playlist.read().status();
+        match status {
             Status::Running => {
                 <Self as PlayerTrait>::pause(self);
             }
@@ -380,7 +397,10 @@ impl GeneralPlayer {
 
     /// Resume playback if paused
     pub fn play(&mut self) {
-        match self.playlist.status() {
+        // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
+        // see https://github.com/rust-lang/rust/issues/93883
+        let status = self.playlist.read().status();
+        match status {
             Status::Running | Status::Stopped => {}
             Status::Paused => {
                 <Self as PlayerTrait>::resume(self);
@@ -391,7 +411,7 @@ impl GeneralPlayer {
     ///
     /// if the underlying "seek" returns a error (which current never happens)
     pub fn seek_relative(&mut self, forward: bool) {
-        let track_len = if let Some(track) = self.playlist.current_track() {
+        let track_len = if let Some(track) = self.playlist.read().current_track() {
             track.duration().as_secs()
         } else {
             // fallback to 5 instead of not seeking at all
@@ -414,7 +434,8 @@ impl GeneralPlayer {
 
     #[allow(clippy::cast_sign_loss)]
     pub fn player_save_last_position(&mut self) {
-        let Some(track) = self.playlist.current_track() else {
+        let playlist = self.playlist.read();
+        let Some(track) = playlist.current_track() else {
             info!("Not saving Last position as there is no current track");
             return;
         };
@@ -458,10 +479,12 @@ impl GeneralPlayer {
     }
 
     pub fn player_restore_last_position(&mut self) {
-        let Some(track) = self.playlist.current_track() else {
+        let playlist = self.playlist.read();
+        let Some(track) = playlist.current_track().cloned() else {
             info!("Not restoring Last position as there is no current track");
             return;
         };
+        drop(playlist);
 
         let mut restored = false;
 
@@ -475,13 +498,13 @@ impl GeneralPlayer {
         {
             match track.media_type {
                 MediaType::Music => {
-                    if let Ok(last_pos) = self.db.get_last_position(track) {
+                    if let Ok(last_pos) = self.db.get_last_position(&track) {
                         self.seek_to(last_pos);
                         restored = true;
                     }
                 }
                 MediaType::Podcast => {
-                    if let Ok(last_pos) = self.db_podcast.get_last_position(track) {
+                    if let Ok(last_pos) = self.db_podcast.get_last_position(&track) {
                         self.seek_to(last_pos);
                         restored = true;
                     }
@@ -496,10 +519,8 @@ impl GeneralPlayer {
         }
 
         if restored {
-            if let Some(track) = self.playlist.current_track() {
-                if let Err(err) = self.db.set_last_position(track, Duration::from_secs(0)) {
-                    error!("Resetting last_position failed, Error: {err:#?}");
-                }
+            if let Err(err) = self.db.set_last_position(&track, Duration::from_secs(0)) {
+                error!("Resetting last_position failed, Error: {err:#?}");
             }
         }
     }
@@ -535,7 +556,7 @@ impl PlayerTrait for GeneralPlayer {
     }
     /// This function should not be used directly, use GeneralPlayer::pause
     fn pause(&mut self) {
-        self.playlist.set_status(Status::Paused);
+        self.playlist.write().set_status(Status::Paused);
         self.get_player_mut().pause();
         if let Some(ref mut mpris) = self.mpris {
             mpris.pause();
@@ -550,7 +571,7 @@ impl PlayerTrait for GeneralPlayer {
     }
     /// This function should not be used directly, use GeneralPlayer::play
     fn resume(&mut self) {
-        self.playlist.set_status(Status::Running);
+        self.playlist.write().set_status(Status::Running);
         self.get_player_mut().resume();
         if let Some(ref mut mpris) = self.mpris {
             mpris.resume();
@@ -593,7 +614,7 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn stop(&mut self) {
-        self.playlist.stop();
+        self.playlist.write().stop();
         self.get_player_mut().stop();
     }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -11,7 +11,7 @@ use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulte
 use termusiclib::config::SharedServerSettings;
 use termusiclib::library_db::DataBase;
 use termusiclib::player::playlist_helpers::{
-    PlaylistAddTrack, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
+    PlaylistAddTrack, PlaylistPlaySpecific, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
 };
 use termusiclib::player::{PlayerProgress, PlayerTimeUnit, TrackChangedInfo, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
@@ -98,7 +98,6 @@ pub enum PlayerCmd {
     CycleLoop,
     Eos,
     GetProgress,
-    PlaySelected,
     SkipPrevious,
     Pause,
     Play,
@@ -116,6 +115,7 @@ pub enum PlayerCmd {
     VolumeDown,
     VolumeUp,
 
+    PlaylistPlaySpecific(PlaylistPlaySpecific),
     PlaylistAddTrack(PlaylistAddTrack),
     PlaylistRemoveTrack(PlaylistRemoveTrackIndexed),
     PlaylistClear,

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -8,7 +8,7 @@ pub use playlist::{Playlist, Status};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::library_db::DataBase;
-use termusiclib::player::playlist_helpers::PlaylistAddTrack;
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
 use termusiclib::player::{PlayerProgress, PlayerTimeUnit, TrackChangedInfo, UpdateEvents};
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaType, Track};
@@ -113,6 +113,7 @@ pub enum PlayerCmd {
     VolumeUp,
 
     PlaylistAddTrack(PlaylistAddTrack),
+    PlaylistRemoveTrack(PlaylistRemoveTrack),
 }
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -242,7 +242,7 @@ impl GeneralPlayer {
     #[inline]
     pub fn mpris_update_progress(&mut self, progress: &PlayerProgress) {
         if let Some(ref mut mpris) = self.mpris {
-            mpris.update_progress(progress.position, self.playlist.status());
+            mpris.update_progress(progress.position, self.playlist.read_recursive().status());
         }
     }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -906,9 +906,11 @@ impl Playlist {
 
     /// Shuffle the playlist
     pub fn shuffle(&mut self) {
-        // TODO: why does this only shuffle if there is a current track?
-        if let Some(current_track_file) = self.get_current_track() {
-            self.tracks.shuffle(&mut rand::rng());
+        let current_track_file = self.get_current_track();
+
+        self.tracks.shuffle(&mut rand::rng());
+
+        if let Some(current_track_file) = current_track_file {
             if let Some(index) = self.find_index_from_file(&current_track_file) {
                 self.current_track_index = index;
             }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -910,6 +910,8 @@ impl Playlist {
 
         self.tracks.shuffle(&mut rand::rng());
 
+        self.send_stream_ev(UpdatePlaylistEvents::PlaylistShuffled);
+
         if let Some(current_track_file) = current_track_file {
             if let Some(index) = self.find_index_from_file(&current_track_file) {
                 self.current_track_index = index;

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -778,7 +778,7 @@ impl Playlist {
             }
 
             // verified that at index "at_index" the track is of the type and has the URI that was requested to be removed
-            self.remove(at_index);
+            self.handle_remove(at_index);
 
             self.send_stream_ev(UpdatePlaylistEvents::PlaylistRemoveTrack(
                 PlaylistRemoveTrackInfo {
@@ -876,7 +876,7 @@ impl Playlist {
             termusiclib::track::MediaType::LiveRadio => PlaylistTrackSource::Url(file.to_string()),
         };
 
-        self.tracks.remove(index);
+        self.handle_remove(index);
 
         self.send_stream_ev(UpdatePlaylistEvents::PlaylistRemoveTrack(
             PlaylistRemoveTrackInfo {
@@ -884,6 +884,11 @@ impl Playlist {
                 trackid,
             },
         ));
+    }
+
+    /// Internal common `remove` handling, does not send a event
+    fn handle_remove(&mut self, index: usize) {
+        self.tracks.remove(index);
 
         // Handle index
         if index <= self.current_track_index {

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::player::playlist_helpers::PlaylistTrackSource;
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
 use termusiclib::player::UpdateEvents;
 use termusiclib::player::UpdatePlaylistEvents;
 use termusiclib::player::{PlaylistAddTrackInfo, PlaylistRemoveTrackInfo};
@@ -576,7 +576,7 @@ impl Playlist {
     /// # Panics
     ///
     /// If `usize` cannot be converted to `u64`
-    pub fn remove_tracks(&mut self, tracks: PlaylistRemoveTrack) -> Result<()> {
+    pub fn remove_tracks(&mut self, tracks: PlaylistRemoveTrackIndexed) -> Result<()> {
         let at_index = usize::try_from(tracks.at_index).unwrap();
 
         if at_index >= self.tracks.len() {
@@ -687,6 +687,8 @@ impl Playlist {
         self.next_track_index.take();
         self.current_track_index = 0;
         self.need_proceed_to_next = false;
+
+        self.send_stream_ev(UpdatePlaylistEvents::PlaylistCleared);
     }
 
     /// Shuffle the playlist

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -3,8 +3,10 @@ use std::fmt::{Display, Write as _};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
+use parking_lot::RwLock;
 use pathdiff::diff_paths;
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -25,6 +27,7 @@ use termusiclib::{
     utils::{filetype_supported, get_app_config_path, get_parent_folder},
 };
 
+use crate::SharedPlaylist;
 use crate::StreamTX;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
@@ -106,6 +109,18 @@ impl Playlist {
             need_proceed_to_next: false,
             stream_tx,
         })
+    }
+
+    /// Create a new Playlist instance that is directly shared
+    ///
+    /// # Errors
+    ///
+    /// see [`new`](Self::new)
+    pub fn new_shared(
+        config: &SharedServerSettings,
+        stream_tx: StreamTX,
+    ) -> Result<SharedPlaylist> {
+        Ok(Arc::new(RwLock::new(Self::new(config, stream_tx)?)))
     }
 
     /// Advance the playlist to the next track.

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -774,7 +774,7 @@ impl Playlist {
             };
 
             if file_url != id {
-                bail!("URI mismatch, expected \"{id}\" at \"{at_index}\", found \"{file_url}\"");
+                bail!("URI mismatch, expected \"{file_url}\" at \"{at_index}\" in request, found \"{id}\" in playlist");
             }
 
             // verified that at index "at_index" the track is of the type and has the URI that was requested to be removed

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -10,7 +10,7 @@ use termusiclib::player::{
     PlaylistLoopMode, PlaylistSwapTracks, PlaylistTracksToAdd, PlaylistTracksToRemove, SpeedReply,
     StreamUpdates, UpdateMissedEvents, VolumeReply,
 };
-use termusicplayback::{PlayerCmd, PlayerCmdCallback, PlayerCmdSender, StreamTX};
+use termusicplayback::{PlayerCmd, PlayerCmdCallback, PlayerCmdSender, SharedPlaylist, StreamTX};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
@@ -23,17 +23,24 @@ pub struct MusicPlayerService {
     cmd_tx: PlayerCmdSender,
     stream_tx: StreamTX,
     config: SharedServerSettings,
+    _playlist: SharedPlaylist,
     pub(crate) player_stats: Arc<Mutex<PlayerStats>>,
 }
 
 impl MusicPlayerService {
-    pub fn new(cmd_tx: PlayerCmdSender, stream_tx: StreamTX, config: SharedServerSettings) -> Self {
+    pub fn new(
+        cmd_tx: PlayerCmdSender,
+        stream_tx: StreamTX,
+        config: SharedServerSettings,
+        playlist: SharedPlaylist,
+    ) -> Self {
         let player_stats = Arc::new(Mutex::new(PlayerStats::new()));
 
         Self {
             cmd_tx,
             player_stats,
             stream_tx,
+            _playlist: playlist,
             config,
         }
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -336,6 +336,15 @@ impl MusicPlayer for MusicPlayerService {
 
         Ok(Response::new(reply))
     }
+
+    async fn remove_deleted_tracks(&self, _: Request<Empty>) -> Result<Response<Empty>, Status> {
+        let rx = self.command_cb(PlayerCmd::PlaylistRemoveDeletedTracks)?;
+        // wait until the event was processed
+        let _ = rx.await;
+        let reply = Empty {};
+
+        Ok(Response::new(reply))
+    }
 }
 
 /// Common function to map [`Playlist`] tracks to the GRPC message types

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -4,17 +4,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::player::music_player_server::MusicPlayer;
-use termusiclib::player::playlist_helpers::{
-    PlaylistPlaySpecific, PlaylistRemoveTrackType, PlaylistTrackSource,
-};
+use termusiclib::player::playlist_helpers::{PlaylistPlaySpecific, PlaylistRemoveTrackType};
 use termusiclib::player::{
     self, stream_updates, Empty, GaplessState, GetProgressResponse, PlayState, PlayerTime,
-    PlaylistAddTrack, PlaylistLoopMode, PlaylistSwapTracks, PlaylistTracks, PlaylistTracksToAdd,
+    PlaylistLoopMode, PlaylistSwapTracks, PlaylistTracks, PlaylistTracksToAdd,
     PlaylistTracksToRemove, SpeedReply, StreamUpdates, UpdateMissedEvents, VolumeReply,
 };
-use termusicplayback::{
-    PlayerCmd, PlayerCmdCallback, PlayerCmdSender, Playlist, SharedPlaylist, StreamTX,
-};
+use termusicplayback::{PlayerCmd, PlayerCmdCallback, PlayerCmdSender, SharedPlaylist, StreamTX};
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
@@ -309,23 +305,19 @@ impl MusicPlayer for MusicPlayerService {
 
     async fn get_playlist(&self, _: Request<Empty>) -> Result<Response<PlaylistTracks>, Status> {
         let playlist = self.playlist.read();
-        let reply = playlist_to_grpc_tracks(&playlist);
+        let reply = playlist.as_grpc_playlist_tracks().unwrap();
 
         Ok(Response::new(reply))
     }
 
-    async fn shuffle_playlist(
-        &self,
-        _: Request<Empty>,
-    ) -> Result<Response<PlaylistTracks>, Status> {
+    async fn shuffle_playlist(&self, _: Request<Empty>) -> Result<Response<Empty>, Status> {
         // execute shuffle in the player thread instead of the service thread
         // this does not necessarily need to be done, but its better to have the service read-only
         let rx = self.command_cb(PlayerCmd::PlaylistShuffle)?;
         // wait until the event was processed
         let _ = rx.await;
 
-        let playlist = self.playlist.read();
-        let reply = playlist_to_grpc_tracks(&playlist);
+        let reply = Empty {};
 
         Ok(Response::new(reply))
     }
@@ -337,43 +329,5 @@ impl MusicPlayer for MusicPlayerService {
         let reply = Empty {};
 
         Ok(Response::new(reply))
-    }
-}
-
-/// Common function to map [`Playlist`] tracks to the GRPC message types
-fn playlist_to_grpc_tracks(playlist: &Playlist) -> PlaylistTracks {
-    let tracks = playlist
-        .tracks()
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, track)| {
-            let at_index = u64::try_from(idx).unwrap();
-            // TODO: refactor Track::file to be always existing
-            let Some(file) = track.file() else {
-                error!("Track did not have a file(id), skipping!");
-                return None;
-            };
-            // TODO: this should likely be a function on "Track"
-            let id = match track.media_type {
-                termusiclib::track::MediaType::Music => PlaylistTrackSource::Path(file.to_string()),
-                termusiclib::track::MediaType::Podcast => {
-                    PlaylistTrackSource::PodcastUrl(file.to_string())
-                }
-                termusiclib::track::MediaType::LiveRadio => {
-                    PlaylistTrackSource::Url(file.to_string())
-                }
-            };
-            Some(PlaylistAddTrack {
-                at_index,
-                duration: Some(track.duration().into()),
-                id: Some(id.into()),
-                optional_title: None,
-            })
-        })
-        .collect();
-
-    PlaylistTracks {
-        current_track_index: u64::try_from(playlist.get_current_track_index()).unwrap(),
-        tracks,
     }
 }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -122,13 +122,6 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
-    async fn reload_playlist(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
-        let reply = Empty {};
-        self.command(PlayerCmd::ReloadPlaylist);
-
-        Ok(Response::new(reply))
-    }
-
     async fn seek_backward(
         &self,
         _request: Request<Empty>,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -369,6 +369,12 @@ fn player_loop(
             PlayerCmd::Play => {
                 player.resume();
             }
+
+            PlayerCmd::PlaylistAddTrack(info) => {
+                if let Err(err) = player.playlist.add_tracks(info, &player.db_podcast) {
+                    error!("Error adding tracks: {err}");
+                }
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -411,6 +411,9 @@ fn player_loop(
                     error!("Error swapping tracks: {err}");
                 }
             }
+            PlayerCmd::PlaylistShuffle => {
+                player.playlist.write().shuffle();
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -238,12 +238,6 @@ fn player_loop(
                 );
             }
             PlayerCmd::GetProgress => {}
-            PlayerCmd::PlaySelected => {
-                info!("play selected");
-                player.player_save_last_position();
-                player.playlist.write().proceed_false();
-                player.next();
-            }
             PlayerCmd::SkipPrevious => {
                 info!("skip to previous track");
                 player.player_save_last_position();
@@ -393,6 +387,17 @@ fn player_loop(
                 player.resume();
             }
 
+            PlayerCmd::PlaylistPlaySpecific(info) => {
+                info!(
+                    "play specific track, idx: {} id: {:#?}",
+                    info.track_index, info.id
+                );
+                player.player_save_last_position();
+                if let Err(err) = player.playlist.write().play_specific(&info) {
+                    error!("Error setting specific track to play: {err}");
+                }
+                player.next();
+            }
             PlayerCmd::PlaylistAddTrack(info) => {
                 if let Err(err) = player.playlist.write().add_tracks(info, &player.db_podcast) {
                     error!("Error adding tracks: {err}");

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -420,6 +420,9 @@ fn player_loop(
             PlayerCmd::PlaylistShuffle => {
                 player.playlist.write().shuffle();
             }
+            PlayerCmd::PlaylistRemoveDeletedTracks => {
+                player.playlist.write().remove_deleted_items();
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -383,6 +383,11 @@ fn player_loop(
             PlayerCmd::PlaylistClear => {
                 player.playlist.clear();
             }
+            PlayerCmd::PlaylistSwapTrack(info) => {
+                if let Err(err) = player.playlist.swap_tracks(&info) {
+                    error!("Error swapping tracks: {err}");
+                }
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -380,6 +380,9 @@ fn player_loop(
                     error!("Error removing tracks: {err}");
                 }
             }
+            PlayerCmd::PlaylistClear => {
+                player.playlist.clear();
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -375,6 +375,11 @@ fn player_loop(
                     error!("Error adding tracks: {err}");
                 }
             }
+            PlayerCmd::PlaylistRemoveTrack(info) => {
+                if let Err(err) = player.playlist.remove_tracks(info) {
+                    error!("Error removing tracks: {err}");
+                }
+            }
         }
 
         cb.call();

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -105,7 +105,8 @@ async fn actual_main() -> Result<()> {
     let config = new_shared_server_settings(config);
     let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel();
     let cmd_tx = PlayerCmdSender::new(cmd_tx);
-    let (stream_tx, _) = broadcast::channel(3);
+    // Note that the channel size might quickly become too low if there is a massive delete (like removing the non-existent tracks from the playlist)
+    let (stream_tx, _) = broadcast::channel(10);
 
     let playlist =
         Playlist::new_shared(&config, stream_tx.clone()).context("Failed to load playlist")?;

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -651,11 +651,7 @@ impl Model {
     }
 
     pub fn playlist_update_library_delete(&mut self) {
-        self.playlist.remove_deleted_items();
-        if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(e.context("player sync playlist"));
-        }
-        self.playlist_sync();
+        self.command(TuiCmd::Playlist(PlaylistCmd::RemoveDeletedItems));
     }
 
     pub fn playlist_update_title(&mut self) {

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -602,12 +602,9 @@ impl Model {
         self.command(TuiCmd::Playlist(PlaylistCmd::Clear));
     }
 
+    /// Shuffle the whole playlist
     pub fn playlist_shuffle(&mut self) {
-        self.playlist.shuffle();
-        if let Err(e) = self.player_sync_playlist() {
-            self.mount_error_popup(e.context("player sync playlist"));
-        }
-        self.playlist_sync();
+        self.command(TuiCmd::Playlist(PlaylistCmd::Shuffle));
     }
 
     /// Send command to swap 2 indexes. Does nothing if either index is out-of-bounds.

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -16,7 +16,8 @@ use termusiclib::player::playlist_helpers::{
     PlaylistTrackSource,
 };
 use termusiclib::player::{
-    PlaylistAddTrackInfo, PlaylistLoopModeInfo, PlaylistRemoveTrackInfo, PlaylistSwapInfo,
+    PlaylistAddTrackInfo, PlaylistLoopModeInfo, PlaylistRemoveTrackInfo, PlaylistShuffledInfo,
+    PlaylistSwapInfo,
 };
 use termusiclib::track::Track;
 use termusiclib::types::{GSMsg, Id, Msg, PLMsg};
@@ -452,6 +453,15 @@ impl Model {
 
         self.playlist.swap(index_a, index_b)?;
 
+        self.playlist_sync();
+
+        Ok(())
+    }
+
+    /// Handle when the playlist has been shuffled and so has new order of tracks
+    pub fn handle_playlist_shuffled(&mut self, shuffled: PlaylistShuffledInfo) -> Result<()> {
+        self.playlist
+            .load_from_grpc(shuffled.tracks, &self.podcast.db_podcast)?;
         self.playlist_sync();
 
         Ok(())

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -724,6 +724,7 @@ impl Model {
         self.general_search_update_show(Model::build_table(filtered_music));
     }
 
+    /// Select the given index in the playlist list component
     pub fn playlist_locate(&mut self, index: usize) {
         assert!(self
             .app
@@ -733,6 +734,17 @@ impl Model {
                 AttrValue::Payload(PropPayload::One(PropValue::Usize(index))),
             )
             .is_ok());
+    }
+
+    /// Get the current selected index in the playlist list component
+    pub fn playlist_get_selected_index(&self) -> Option<usize> {
+        // the index on a "Table" can be set via "AttrValue::Payload(PropPayload::One(PropValue::Usize(val)))", but reading that is stale
+        // as that value is only read in the "Table", not removed or updated, but "state" is
+        let Ok(State::One(StateValue::Usize(val))) = self.app.state(&Id::Playlist) else {
+            return None;
+        };
+
+        Some(val)
     }
 
     pub fn playlist_get_random_tracks(&mut self, quantity: u32) -> Vec<TrackDB> {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -318,6 +318,9 @@ impl UI {
             PlaylistCmd::AddTrack(tracks) => {
                 self.playback.add_to_playlist(tracks).await?;
             }
+            PlaylistCmd::RemoveTrack(tracks) => {
+                self.playback.remove_from_playlist(tracks).await?;
+            }
         }
 
         Ok(())
@@ -394,6 +397,9 @@ impl UI {
         match ev {
             UpdatePlaylistEvents::PlaylistAddTrack(playlist_add_track) => {
                 self.model.handle_playlist_add(playlist_add_track)?;
+            }
+            UpdatePlaylistEvents::PlaylistRemoveTrack(playlist_remove_track) => {
+                self.model.handle_playlist_remove(&playlist_remove_track);
             }
         }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -334,6 +334,14 @@ impl UI {
             PlaylistCmd::SwapTrack(info) => {
                 self.playback.swap_tracks(info).await?;
             }
+            PlaylistCmd::Shuffle => {
+                let new_tracks = self.playback.shuffle_playlist().await?;
+                self.model
+                    .playlist
+                    .load_from_grpc(new_tracks, &self.model.podcast.db_podcast)?;
+
+                self.model.playlist_sync();
+            }
         }
 
         Ok(())

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -342,6 +342,9 @@ impl UI {
             PlaylistCmd::PlaySpecific(info) => {
                 self.playback.play_specific(info).await?;
             }
+            PlaylistCmd::RemoveDeletedItems => {
+                self.playback.remove_deleted_tracks().await?;
+            }
         }
 
         Ok(())

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -112,7 +112,9 @@ impl UI {
             if self.model.layout != TermusicLayout::Podcast {
                 self.model.lyric_update();
             }
-            self.handle_stream_events(&mut stream_updates)?;
+            if let Err(err) = self.handle_stream_events(&mut stream_updates) {
+                self.model.mount_error_popup(err);
+            }
             if progress_interval == 0 {
                 self.model.run();
             }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -261,7 +261,6 @@ impl UI {
                     self.model.config_server.write().settings.player.loop_mode = res;
                 }
                 TuiCmd::ReloadConfig => self.playback.reload_config().await?,
-                TuiCmd::ReloadPlaylist => self.playback.reload_playlist().await?,
                 TuiCmd::SeekBackward => {
                     let pprogress = self.playback.seek_backward().await?;
                     self.model.progress_update(

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -331,12 +331,7 @@ impl UI {
                 self.playback.swap_tracks(info).await?;
             }
             PlaylistCmd::Shuffle => {
-                let new_tracks = self.playback.shuffle_playlist().await?;
-                self.model
-                    .playlist
-                    .load_from_grpc(new_tracks, &self.model.podcast.db_podcast)?;
-
-                self.model.playlist_sync();
+                self.playback.shuffle_playlist().await?;
             }
             PlaylistCmd::PlaySpecific(info) => {
                 self.playback.play_specific(info).await?;
@@ -436,11 +431,8 @@ impl UI {
             UpdatePlaylistEvents::PlaylistSwapTracks(swapped_tracks) => {
                 self.model.handle_playlist_swap_tracks(&swapped_tracks)?;
             }
-            UpdatePlaylistEvents::PlaylistShuffled => {
-                // NOTE: the current implementation will reload the playlist on this client, even if this client was
-                // the one that had requested the shuffle and already applied the returned playlist values
-                self.model
-                    .command(TuiCmd::Playlist(PlaylistCmd::SelfReloadPlaylist));
+            UpdatePlaylistEvents::PlaylistShuffled(shuffled) => {
+                self.model.handle_playlist_shuffled(shuffled)?;
             }
         }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -102,6 +102,8 @@ impl UI {
     async fn run_inner(&mut self) -> Result<()> {
         let mut stream_updates = self.playback.subscribe_to_stream_updates().await?;
 
+        self.load_playlist().await?;
+
         // Main loop
         let mut progress_interval = 0;
         while !self.model.quit {
@@ -422,6 +424,16 @@ impl UI {
                 self.model.handle_playlist_swap_tracks(&swapped_tracks)?;
             }
         }
+
+        Ok(())
+    }
+
+    /// Load the playlist from the server
+    async fn load_playlist(&mut self) -> Result<()> {
+        let tracks = self.playback.get_playlist().await?;
+        self.model
+            .playlist
+            .load_from_grpc(tracks, &self.model.podcast.db_podcast)?;
 
         Ok(())
     }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -401,7 +401,7 @@ impl UI {
                 self.model.handle_playlist_add(playlist_add_track)?;
             }
             UpdatePlaylistEvents::PlaylistRemoveTrack(playlist_remove_track) => {
-                self.model.handle_playlist_remove(&playlist_remove_track);
+                self.model.handle_playlist_remove(&playlist_remove_track)?;
             }
             UpdatePlaylistEvents::PlaylistCleared => {
                 self.model.handle_playlist_clear();

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -35,6 +35,7 @@ use music_player_client::Playback;
 use std::time::Duration;
 use sysinfo::System;
 use termusiclib::player::music_player_client::MusicPlayerClient;
+use termusiclib::player::playlist_helpers::PlaylistRemoveTrackType;
 use termusiclib::player::PlayerProgress;
 use termusiclib::player::StreamUpdates;
 use termusiclib::player::UpdateEvents;
@@ -319,7 +320,14 @@ impl UI {
                 self.playback.add_to_playlist(tracks).await?;
             }
             PlaylistCmd::RemoveTrack(tracks) => {
-                self.playback.remove_from_playlist(tracks).await?;
+                self.playback
+                    .remove_from_playlist(PlaylistRemoveTrackType::Indexed(tracks))
+                    .await?;
+            }
+            PlaylistCmd::Clear => {
+                self.playback
+                    .remove_from_playlist(PlaylistRemoveTrackType::Clear)
+                    .await?;
             }
         }
 
@@ -400,6 +408,9 @@ impl UI {
             }
             UpdatePlaylistEvents::PlaylistRemoveTrack(playlist_remove_track) => {
                 self.model.handle_playlist_remove(&playlist_remove_track);
+            }
+            UpdatePlaylistEvents::PlaylistCleared => {
+                self.model.handle_playlist_clear();
             }
         }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -260,9 +260,6 @@ impl UI {
                     let res = self.playback.cycle_loop().await?;
                     self.model.config_server.write().settings.player.loop_mode = res;
                 }
-                TuiCmd::PlaySelected => {
-                    self.playback.play_selected().await?;
-                }
                 TuiCmd::ReloadConfig => self.playback.reload_config().await?,
                 TuiCmd::ReloadPlaylist => self.playback.reload_playlist().await?,
                 TuiCmd::SeekBackward => {
@@ -341,6 +338,9 @@ impl UI {
                     .load_from_grpc(new_tracks, &self.model.podcast.db_podcast)?;
 
                 self.model.playlist_sync();
+            }
+            PlaylistCmd::PlaySpecific(info) => {
+                self.playback.play_specific(info).await?;
             }
         }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -329,6 +329,9 @@ impl UI {
                     .remove_from_playlist(PlaylistRemoveTrackType::Clear)
                     .await?;
             }
+            PlaylistCmd::SwapTrack(info) => {
+                self.playback.swap_tracks(info).await?;
+            }
         }
 
         Ok(())
@@ -414,6 +417,9 @@ impl UI {
             }
             UpdatePlaylistEvents::PlaylistLoopMode(loop_mode) => {
                 self.model.handle_playlist_loopmode(&loop_mode)?;
+            }
+            UpdatePlaylistEvents::PlaylistSwapTracks(swapped_tracks) => {
+                self.model.handle_playlist_swap_tracks(&swapped_tracks)?;
             }
         }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -412,6 +412,9 @@ impl UI {
             UpdatePlaylistEvents::PlaylistCleared => {
                 self.model.handle_playlist_clear();
             }
+            UpdatePlaylistEvents::PlaylistLoopMode(loop_mode) => {
+                self.model.handle_playlist_loopmode(&loop_mode)?;
+            }
         }
 
         Ok(())

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -39,7 +39,7 @@ use termusiclib::track::{MediaType, Track};
 #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
 use termusiclib::ueberzug::UeInstance;
 
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -411,13 +411,6 @@ impl Model {
         self.command(TuiCmd::GetProgress);
         self.progress_update_title();
         self.lyric_update_title();
-    }
-
-    /// Save the playlist and have the server reload the playlist.
-    pub fn player_sync_playlist(&mut self) -> Result<()> {
-        self.playlist.save()?;
-        self.command(TuiCmd::ReloadPlaylist);
-        Ok(())
     }
 
     pub fn player_update_current_track_after(&mut self) {

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -266,7 +266,12 @@ impl Model {
         // I dont like this workaround, but until the tui has its own playlist impl, this has to do.
         let (stream_tx, _stream_rx) = broadcast::channel(1);
 
-        let playlist = Playlist::new(&config_server, stream_tx).expect("Failed to load playlist");
+        let playlist = {
+            let mut playlist = Playlist::new(&config_server, stream_tx);
+            playlist.load_apply().expect("Failed to load playlist");
+
+            playlist
+        };
         let app = Self::init_app(&tree, &config_tui);
 
         // This line is required, in order to show the playing message for the first track

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -51,6 +51,7 @@ use termusiclib::songtag::SongTag;
 use termusiclib::taskpool::TaskPool;
 use termusiclib::utils::get_app_config_path;
 use termusicplayback::Playlist;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
 use tui_realm_treeview::Tree;
 use tuirealm::event::NoUserEvent;
@@ -262,7 +263,10 @@ impl Model {
         ));
         let (tx_to_main, rx_to_main) = mpsc::channel();
 
-        let playlist = Playlist::new(&config_server).expect("Failed to load playlist");
+        // I dont like this workaround, but until the tui has its own playlist impl, this has to do.
+        let (stream_tx, _stream_rx) = broadcast::channel(1);
+
+        let playlist = Playlist::new(&config_server, stream_tx).expect("Failed to load playlist");
         let app = Self::init_app(&tree, &config_tui);
 
         // This line is required, in order to show the playing message for the first track

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -266,12 +266,7 @@ impl Model {
         // I dont like this workaround, but until the tui has its own playlist impl, this has to do.
         let (stream_tx, _stream_rx) = broadcast::channel(1);
 
-        let playlist = {
-            let mut playlist = Playlist::new(&config_server, stream_tx);
-            playlist.load_apply().expect("Failed to load playlist");
-
-            playlist
-        };
+        let playlist = Playlist::new(&config_server, stream_tx);
         let app = Self::init_app(&tree, &config_tui);
 
         // This line is required, in order to show the playing message for the first track

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -862,18 +862,10 @@ impl Model {
                 self.player_previous();
             }
             PLMsg::SwapDown(index) => {
-                self.playlist.swap_down(*index);
-                self.playlist_sync();
-                if let Err(e) = self.player_sync_playlist() {
-                    self.mount_error_popup(e.context("playlist sync playlist"));
-                }
+                self.playlist_swap_down(*index);
             }
             PLMsg::SwapUp(index) => {
-                self.playlist.swap_up(*index);
-                self.playlist_sync();
-                if let Err(e) = self.player_sync_playlist() {
-                    self.mount_error_popup(e.context("playlist sync playlist"));
-                }
+                self.playlist_swap_up(*index);
             }
             PLMsg::AddRandomAlbum => {
                 self.playlist_add_random_album();

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::playlist_helpers::PlaylistAddTrack;
-use termusiclib::player::{Empty, GetProgressResponse, PlayerProgress, PlaylistTracksToAdd};
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
+use termusiclib::player::{
+    Empty, GetProgressResponse, PlayerProgress, PlaylistTracksToAdd, PlaylistTracksToRemove,
+};
 use termusicplayback::Status;
 use tokio_stream::{Stream, StreamExt as _};
 use tonic::transport::Channel;
@@ -158,6 +160,14 @@ impl Playback {
     pub async fn add_to_playlist(&mut self, info: PlaylistAddTrack) -> Result<()> {
         let request = tonic::Request::new(PlaylistTracksToAdd::from(info));
         let response = self.client.add_to_playlist(request).await?;
+        info!("Got response from server: {response:?}");
+
+        Ok(())
+    }
+
+    pub async fn remove_from_playlist(&mut self, info: PlaylistRemoveTrack) -> Result<()> {
+        let request = tonic::Request::new(PlaylistTracksToRemove::from(info));
+        let response = self.client.remove_from_playlist(request).await?;
         info!("Got response from server: {response:?}");
 
         Ok(())

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -201,4 +201,12 @@ impl Playback {
 
         Ok(response.into_inner())
     }
+
+    pub async fn remove_deleted_tracks(&mut self) -> Result<()> {
+        let request = tonic::Request::new(Empty {});
+        let response = self.client.remove_deleted_tracks(request).await?;
+        info!("Got response from server: {response:?}");
+
+        Ok(())
+    }
 }

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -5,8 +5,8 @@ use termusiclib::player::playlist_helpers::{
     PlaylistAddTrack, PlaylistRemoveTrackType, PlaylistSwapTrack,
 };
 use termusiclib::player::{
-    Empty, GetProgressResponse, PlayerProgress, PlaylistSwapTracks, PlaylistTracksToAdd,
-    PlaylistTracksToRemove,
+    Empty, GetProgressResponse, PlayerProgress, PlaylistSwapTracks, PlaylistTracks,
+    PlaylistTracksToAdd, PlaylistTracksToRemove,
 };
 use termusicplayback::Status;
 use tokio_stream::{Stream, StreamExt as _};
@@ -182,5 +182,14 @@ impl Playback {
         info!("Got response from server: {response:?}");
 
         Ok(())
+    }
+
+    pub async fn get_playlist(&mut self) -> Result<PlaylistTracks> {
+        let request = tonic::Request::new(Empty {});
+        let response = self.client.get_playlist(request).await?;
+        // This might be massively spamming the log
+        info!("Got response from server: {response:?}");
+
+        Ok(response.into_inner())
     }
 }

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -126,14 +126,6 @@ impl Playback {
         Ok(())
     }
 
-    pub async fn reload_playlist(&mut self) -> Result<()> {
-        let request = tonic::Request::new(Empty {});
-        let response = self.client.reload_playlist(request).await?;
-        let response = response.into_inner();
-        info!("Got response from server: {response:?}");
-        Ok(())
-    }
-
     pub async fn play_specific(&mut self, info: PlaylistPlaySpecific) -> Result<()> {
         let request = tonic::Request::new(info.into());
         let response = self.client.play_specific(request).await?;

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -185,13 +185,12 @@ impl Playback {
         Ok(response.into_inner())
     }
 
-    pub async fn shuffle_playlist(&mut self) -> Result<PlaylistTracks> {
+    pub async fn shuffle_playlist(&mut self) -> Result<()> {
         let request = tonic::Request::new(Empty {});
         let response = self.client.shuffle_playlist(request).await?;
-        // This might be massively spamming the log
         info!("Got response from server: {response:?}");
 
-        Ok(response.into_inner())
+        Ok(())
     }
 
     pub async fn remove_deleted_tracks(&mut self) -> Result<()> {

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -192,4 +192,13 @@ impl Playback {
 
         Ok(response.into_inner())
     }
+
+    pub async fn shuffle_playlist(&mut self) -> Result<PlaylistTracks> {
+        let request = tonic::Request::new(Empty {});
+        let response = self.client.shuffle_playlist(request).await?;
+        // This might be massively spamming the log
+        info!("Got response from server: {response:?}");
+
+        Ok(response.into_inner())
+    }
 }

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::player::music_player_client::MusicPlayerClient;
 use termusiclib::player::playlist_helpers::{
-    PlaylistAddTrack, PlaylistRemoveTrackType, PlaylistSwapTrack,
+    PlaylistAddTrack, PlaylistPlaySpecific, PlaylistRemoveTrackType, PlaylistSwapTrack,
 };
 use termusiclib::player::{
     Empty, GetProgressResponse, PlayerProgress, PlaylistSwapTracks, PlaylistTracks,
@@ -134,9 +134,9 @@ impl Playback {
         Ok(())
     }
 
-    pub async fn play_selected(&mut self) -> Result<()> {
-        let request = tonic::Request::new(Empty {});
-        let response = self.client.play_selected(request).await?;
+    pub async fn play_specific(&mut self, info: PlaylistPlaySpecific) -> Result<()> {
+        let request = tonic::Request::new(info.into());
+        let response = self.client.play_specific(request).await?;
         let response = response.into_inner();
         info!("Got response from server: {response:?}");
         Ok(())

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackType};
 use termusiclib::player::{
     Empty, GetProgressResponse, PlayerProgress, PlaylistTracksToAdd, PlaylistTracksToRemove,
 };
@@ -165,7 +165,7 @@ impl Playback {
         Ok(())
     }
 
-    pub async fn remove_from_playlist(&mut self, info: PlaylistRemoveTrack) -> Result<()> {
+    pub async fn remove_from_playlist(&mut self, info: PlaylistRemoveTrackType) -> Result<()> {
         let request = tonic::Request::new(PlaylistTracksToRemove::from(info));
         let response = self.client.remove_from_playlist(request).await?;
         info!("Got response from server: {response:?}");

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result};
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackType};
+use termusiclib::player::playlist_helpers::{
+    PlaylistAddTrack, PlaylistRemoveTrackType, PlaylistSwapTrack,
+};
 use termusiclib::player::{
-    Empty, GetProgressResponse, PlayerProgress, PlaylistTracksToAdd, PlaylistTracksToRemove,
+    Empty, GetProgressResponse, PlayerProgress, PlaylistSwapTracks, PlaylistTracksToAdd,
+    PlaylistTracksToRemove,
 };
 use termusicplayback::Status;
 use tokio_stream::{Stream, StreamExt as _};
@@ -168,6 +171,14 @@ impl Playback {
     pub async fn remove_from_playlist(&mut self, info: PlaylistRemoveTrackType) -> Result<()> {
         let request = tonic::Request::new(PlaylistTracksToRemove::from(info));
         let response = self.client.remove_from_playlist(request).await?;
+        info!("Got response from server: {response:?}");
+
+        Ok(())
+    }
+
+    pub async fn swap_tracks(&mut self, info: PlaylistSwapTrack) -> Result<()> {
+        let request = tonic::Request::new(PlaylistSwapTracks::from(info));
+        let response = self.client.swap_tracks(request).await?;
         info!("Got response from server: {response:?}");
 
         Ok(())

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use termusiclib::config::v2::server::LoopMode;
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::{Empty, GetProgressResponse, PlayerProgress};
+use termusiclib::player::playlist_helpers::PlaylistAddTrack;
+use termusiclib::player::{Empty, GetProgressResponse, PlayerProgress, PlaylistTracksToAdd};
 use termusicplayback::Status;
 use tokio_stream::{Stream, StreamExt as _};
 use tonic::transport::Channel;
@@ -152,5 +153,13 @@ impl Playback {
         let response = response.into_inner().map(|res| res.map_err(Into::into));
         info!("Got response from server: {response:?}");
         Ok(response)
+    }
+
+    pub async fn add_to_playlist(&mut self, info: PlaylistAddTrack) -> Result<()> {
+        let request = tonic::Request::new(PlaylistTracksToAdd::from(info));
+        let response = self.client.add_to_playlist(request).await?;
+        info!("Got response from server: {response:?}");
+
+        Ok(())
     }
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,4 +1,4 @@
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
 
 #[allow(clippy::doc_link_with_quotes)]
 /// Enum for Commands to send to the [`MusicPlayerClient` "Actor"](crate::ui::music_player_client).
@@ -32,5 +32,6 @@ pub enum TuiCmd {
 #[derive(Clone, Debug)]
 pub enum PlaylistCmd {
     AddTrack(PlaylistAddTrack),
-    RemoveTrack(PlaylistRemoveTrack),
+    RemoveTrack(PlaylistRemoveTrackIndexed),
+    Clear,
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -37,4 +37,5 @@ pub enum PlaylistCmd {
     Clear,
     SwapTrack(PlaylistSwapTrack),
     Shuffle,
+    RemoveDeletedItems,
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,4 +1,4 @@
-use termusiclib::player::playlist_helpers::PlaylistAddTrack;
+use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrack};
 
 #[allow(clippy::doc_link_with_quotes)]
 /// Enum for Commands to send to the [`MusicPlayerClient` "Actor"](crate::ui::music_player_client).
@@ -32,4 +32,5 @@ pub enum TuiCmd {
 #[derive(Clone, Debug)]
 pub enum PlaylistCmd {
     AddTrack(PlaylistAddTrack),
+    RemoveTrack(PlaylistRemoveTrack),
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -37,4 +37,7 @@ pub enum PlaylistCmd {
     SwapTrack(PlaylistSwapTrack),
     Shuffle,
     RemoveDeletedItems,
+
+    /// Re-Request the playlist tracks and state
+    SelfReloadPlaylist,
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,4 +1,6 @@
-use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
+use termusiclib::player::playlist_helpers::{
+    PlaylistAddTrack, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
+};
 
 #[allow(clippy::doc_link_with_quotes)]
 /// Enum for Commands to send to the [`MusicPlayerClient` "Actor"](crate::ui::music_player_client).
@@ -34,4 +36,5 @@ pub enum PlaylistCmd {
     AddTrack(PlaylistAddTrack),
     RemoveTrack(PlaylistRemoveTrackIndexed),
     Clear,
+    SwapTrack(PlaylistSwapTrack),
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,5 +1,5 @@
 use termusiclib::player::playlist_helpers::{
-    PlaylistAddTrack, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
+    PlaylistAddTrack, PlaylistPlaySpecific, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
 };
 
 #[allow(clippy::doc_link_with_quotes)]
@@ -24,8 +24,6 @@ pub enum TuiCmd {
     GetProgress,
     ReloadConfig,
     ReloadPlaylist,
-    /// Play the selected track in the playlist (`current_track_index`)
-    PlaySelected,
 
     Playlist(PlaylistCmd),
 }
@@ -33,6 +31,7 @@ pub enum TuiCmd {
 /// Enum for Commands to send specificly for Playlist
 #[derive(Clone, Debug)]
 pub enum PlaylistCmd {
+    PlaySpecific(PlaylistPlaySpecific),
     AddTrack(PlaylistAddTrack),
     RemoveTrack(PlaylistRemoveTrackIndexed),
     Clear,

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -37,4 +37,5 @@ pub enum PlaylistCmd {
     RemoveTrack(PlaylistRemoveTrackIndexed),
     Clear,
     SwapTrack(PlaylistSwapTrack),
+    Shuffle,
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -39,5 +39,6 @@ pub enum PlaylistCmd {
     RemoveDeletedItems,
 
     /// Re-Request the playlist tracks and state
+    #[allow(dead_code)] // replace with "expect" on 1.81 upgrade
     SelfReloadPlaylist,
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -23,7 +23,6 @@ pub enum TuiCmd {
 
     GetProgress,
     ReloadConfig,
-    ReloadPlaylist,
 
     Playlist(PlaylistCmd),
 }

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,3 +1,5 @@
+use termusiclib::player::playlist_helpers::PlaylistAddTrack;
+
 #[allow(clippy::doc_link_with_quotes)]
 /// Enum for Commands to send to the [`MusicPlayerClient` "Actor"](crate::ui::music_player_client).
 // This is completely different from playback's PlayerCmd, as the tui may need to handle stuff differently and not need all variants
@@ -22,4 +24,12 @@ pub enum TuiCmd {
     ReloadPlaylist,
     /// Play the selected track in the playlist (`current_track_index`)
     PlaySelected,
+
+    Playlist(PlaylistCmd),
+}
+
+/// Enum for Commands to send specificly for Playlist
+#[derive(Clone, Debug)]
+pub enum PlaylistCmd {
+    AddTrack(PlaylistAddTrack),
 }


### PR DESCRIPTION
This PR refactors the playlist handling to have all playlist state handling completely done server-side, no more `ReloadPlaylist` send from the TUI and no more touching `playlist.log` from the TUI. Some more details:
- doing this required that `Playlist` be shared between `GeneralPlayer`(player thread) and the grpc service, which introduced a lot of `.write()`, `.read()` & `drop(playlist)` noise
- change cryptic function `PlaySelected` to `PlaySpecific` with a index attached, this makes it a lot clearer what this function should do

I know this is quite a big PR but i didnt want to split it into multiple parts as it would otherwise be mixed in terms of calling conventions.

Known Issues:
- events from the TUI are asynchronously handled, as in: the event is send, but the TUI is not blocked until the event has been received via the stream, which can result in some more specific cases:
- ~~if a user sends a `PlaySpecific` request, and then moves the selected / highlighted list item before the event is received, the selected list item will become the currently playing index again (making for a little bad user experience)~~ Fixed in a later commit
- ~~on shuffle, currently the TUI gets the playlist twice, once from executing the shuffle command, and once when getting the shuffle event as there is currently no way to know if both are for the same state (more discussion on this necessary)~~ fixed in a later commit
- there can be a little lag between the user in the TUI executing a event and before the finished result of that action is reflected in the TUI, while still being able to navigate & execute more events from the TUI (ie the user deletes a track from the playlist, moves to another track, then sometime later gets the event that one track was removed)

Most of these known issues should not *really* be a problem for the way termusic currently has worked, as it still requires to run on the same machine, which will make the lag for now negligible. (also because indexes are send and verified via track ids to be the same before applying any event)

Please note that this PR is marked as a DRAFT to facilitate some more testing before merging.

re #152

fixes #130 (as now the full playlist can actually be loaded, though track information needs to be added still)