### PR TITLE
Use `thiserror` when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,6 +4590,7 @@ dependencies = [
  "serde_yaml",
  "shellexpand",
  "textwrap",
+ "thiserror 2.0.10",
  "tokio",
  "tokio-util",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ termusic-lib = { path = "lib/", version = "0.9.1" }
 termusic-playback = { path = "playback/", version = "0.9.1", default-features = false }
 ahash = "^0.8"
 anyhow = { version = "1.0", features = ["backtrace"] }
+thiserror = "2.0"
 async-channel = "2.2"
 async-trait = "0.1"
 base64 = "0.22"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 [dependencies]
 ahash.workspace = true #   = "^0.8"
 anyhow.workspace = true
+thiserror.workspace = true
 base64.workspace = true
 bytes.workspace = true #   = "1"
 chrono.workspace = true #   = "^0.4.23"

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -110,7 +110,8 @@ impl ServerConfigVersionedDefaulted<'_> {
             settings
         };
 
-        let new_settings = ServerSettings::try_from(old_settings)?;
+        let new_settings = ServerSettings::try_from(old_settings)
+            .context("Failed to convert server config from v1 to v2 config")?;
 
         // save the file directly to not have to re-do the convertion again, even if config does not change
         Self::save_file(v2_path, &new_settings)?;

--- a/lib/src/config/v2/tui/keys/conflict.rs
+++ b/lib/src/config/v2/tui/keys/conflict.rs
@@ -1,5 +1,3 @@
-use std::{error::Error, fmt::Display};
-
 use ahash::HashMap;
 
 use super::KeyBinding;
@@ -41,27 +39,14 @@ impl KeyPath {
     }
 }
 
-// TODO: upgrade errors with what config-key has errored
-// TODO: consider upgrading this with "thiserror"
 /// Error for when [`Key`] parsing fails
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("Key Conflict: '{key_path_first}' and '{key_path_second}', key: '{key}'")]
 pub struct KeyConflictError {
     pub key_path_first: String,
     pub key_path_second: String,
     pub key: KeyBinding,
 }
-
-impl Display for KeyConflictError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Key Conflict: '{}' and '{}', key: '{}'",
-            self.key_path_first, self.key_path_second, self.key
-        )
-    }
-}
-
-impl Error for KeyConflictError {}
 
 pub(super) type KeyHashMap = HashMap<&'static KeyBinding, &'static str>;
 pub(super) type KeyHashMapOwned = HashMap<KeyBinding, String>;

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -22,7 +22,7 @@ pub struct KeysCheckError {
 
 impl Display for KeysCheckError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
+        writeln!(
             f,
             "There are {} Key Conflict Errors: [",
             self.errored_keys.len()

--- a/lib/src/songtag/service.rs
+++ b/lib/src/songtag/service.rs
@@ -4,7 +4,7 @@ use lofty::picture::Picture;
 
 use super::SongTag;
 
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO: change this to "expected" if MSRV is 1.81
 #[derive(Debug, Clone, Copy)]
 pub enum SongTagServiceErrorWhere {
     SearchRecording,
@@ -26,48 +26,23 @@ impl Display for SongTagServiceErrorWhere {
     }
 }
 
-// TODO: use thiserror
-#[allow(dead_code)]
-#[derive(Debug)]
+/// General [`SongTag`] Error with common variants
+#[derive(Debug, thiserror::Error)]
 pub enum SongTagServiceError<T> {
     /// Indicate a method is not supported to be called
     ///
     /// (which function, service name)
+    #[error("Function \"{0}\" is not supported by service \"{1}\"")]
     NotSupported(SongTagServiceErrorWhere, &'static str),
     /// Indicate that a given [`SongTag`] was for a different service
     ///
     /// (file was for, actual service)
+    #[error("Given song was for service \"{0}\", but given to \"{1}\"")]
     IncorrectService(String, &'static str),
 
     /// Any other error like broken connection
-    Other(T),
-}
-
-impl<T> Display for SongTagServiceError<T>
-where
-    T: Display,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SongTagServiceError::NotSupported(error_where, service_name) => write!(
-                f,
-                "Function \"{error_where}\" is not supported by service \"{service_name}\""
-            ),
-            SongTagServiceError::IncorrectService(origin, service_name) => write!(
-                f,
-                "Given song was for service \"{origin}\", but given to \"{service_name}\""
-            ),
-            SongTagServiceError::Other(err) => Display::fmt(err, f),
-        }
-    }
-}
-
-impl<T> std::error::Error for SongTagServiceError<T> where T: std::error::Error {}
-
-impl<T> From<T> for SongTagServiceError<T> {
-    fn from(value: T) -> Self {
-        Self::Other(value)
-    }
+    #[error(transparent)]
+    Other(#[from] T),
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -617,7 +617,7 @@ fn get_playlist_path() -> Result<PathBuf> {
     Ok(path)
 }
 
-// TODO: consider upgrading this with "thiserror"
+// NOTE: this is not "thiserror" due to custom "Display" impl (the "Option" handling)
 /// Error for when [`Playlist::add_track`] fails
 #[derive(Debug)]
 pub enum PlaylistAddError {
@@ -655,9 +655,16 @@ impl Display for PlaylistAddError {
     }
 }
 
-impl Error for PlaylistAddError {}
+impl Error for PlaylistAddError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Self::ReadError(orig, _) = self {
+            return Some(orig.as_ref());
+        }
 
-// TODO: consider upgrading this with "thiserror"
+        None
+    }
+}
+
 /// Error for when [`Playlist::add_playlist`] fails
 #[derive(Debug, Default)]
 pub struct PlaylistAddErrorVec(Vec<PlaylistAddError>);


### PR DESCRIPTION
This PR switches some of our Error implementations to use `thiserror::Error` to lessen the boilerplate.
Some errors cannot be easily converted 1:1 as `thiserror` either does not support it, or it would be more work than not using `thiserror`, like errors with `Vec`s of Errors or custom `Display` impls.
Additionally, while i was at it i looked at the messages again and tried to improve them a little.