### PR TITLE
fix(lib::config::v2): save config if the path does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix: correctly write LRC milliseconds.
 - Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
 - Fix: fix accidental invertion of `is_absolute` for path playlist values causing items to not have the correct path.
+- Fix: create and save config if it does not exist, without needing a successful connect first.
 - Fix(tui): base "no lyrics available" message on the same value as actual parsed lyrics.
 - Fix(tui): not being able to parse themes that use `0x` as the prefix.
 - Fix(tui): change that the default Theme is not using bad colors.

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -84,6 +84,13 @@ impl ServerConfigVersionedDefaulted<'_> {
             }
         }
 
+        // if path does not exist, create default instance and save it
+        if !path.exists() {
+            let config = ServerSettings::default();
+            Self::save_file(path, &config)?;
+            return Ok(Self::Unversioned(config));
+        }
+
         let data: Self = Figment::new().merge(Toml::file(path)).extract()?;
 
         Ok(data)

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -86,6 +86,11 @@ impl TuiConfigVersionedDefaulted<'_> {
 
         let mut data: Self = if let Some(data) = data {
             data
+        } else if !path.exists() {
+            // if path does not exist, create default instance and save it
+            let config = TuiSettings::default();
+            Self::save_file(path, &config)?;
+            Self::Unversioned(config)
         } else {
             Figment::new().merge(Toml::file(path)).extract()?
         };


### PR DESCRIPTION
This way, the config can be changed if the TUI cant connect.

re https://github.com/tramhao/termusic/issues/402#issuecomment-2691390722