### PR TITLE
Custom Errors for `songtag` models (parsing)

### DIFF
--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -94,7 +94,7 @@ impl SongTagService for Api {
             .map_err(anyhow::Error::from)?;
 
         to_song_info(&result).map_err(|err| {
-            SongTagServiceError::Other(err.context("convert result to songtag array"))
+            SongTagServiceError::Other(anyhow!(err).context("Parse result into SongTag Array"))
         })
     }
 
@@ -129,8 +129,9 @@ impl SongTagService for Api {
             .await
             .map_err(anyhow::Error::from)?;
 
-        let (accesskey, id) = to_lyric_id_accesskey(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("lyric + accesskey")))?;
+        let (accesskey, id) = to_lyric_id_accesskey(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract accesskey and id from result"))
+        })?;
 
         let query_params = vec![
             ("charset", "utf8"),
@@ -152,8 +153,9 @@ impl SongTagService for Api {
             .await
             .map_err(anyhow::Error::from)?;
 
-        to_lyric(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("get lyric text from response")))
+        to_lyric(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract Lyric text from result"))
+        })
     }
 
     async fn get_picture(
@@ -195,8 +197,9 @@ impl SongTagService for Api {
             .await
             .map_err(anyhow::Error::from)?;
 
-        let pic_url = to_pic_url(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("get picture url")))?;
+        let pic_url = to_pic_url(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract picture url from result"))
+        })?;
 
         let result = self
             .client
@@ -249,7 +252,9 @@ impl SongTagService for Api {
             .map_err(anyhow::Error::from)?;
 
         to_song_url(&result).map_err(|err| {
-            SongTagServiceError::Other(err.context("get download url from response"))
+            SongTagServiceError::Other(
+                anyhow!(err).context("Extract recording download url from result"),
+            )
         })
     }
 }

--- a/lib/src/songtag/kugou/model.rs
+++ b/lib/src/songtag/kugou/model.rs
@@ -61,10 +61,7 @@ fn check_status(value: &Value, expected: usize) -> Result<()> {
         return Err(KugouParseError::MissingProperty(FIELD));
     };
     if !status.eq(&expected) {
-        let errcode = value
-            .get("errcode")
-            .and_then(Value::as_str)
-            .map(ToString::to_string);
+        let errcode = value.get("errcode").map(Value::to_string);
 
         return Err(KugouParseError::UnexpectedStatus {
             field: FIELD,

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -257,7 +257,7 @@ fn time_lrc(time_stamp: u64) -> impl std::fmt::Display {
 }
 
 impl FromStr for Lyric {
-    type Err = anyhow::Error;
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut offset: i64 = 0;

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -95,7 +95,7 @@ impl SongTagService for Api {
             .map_err(anyhow::Error::from)?;
 
         to_song_info(&result).map_err(|err| {
-            SongTagServiceError::Other(err.context("convert result to songtag array"))
+            SongTagServiceError::Other(anyhow!(err).context("Parse result into SongTag Array"))
         })
     }
 
@@ -130,8 +130,9 @@ impl SongTagService for Api {
             .await
             .map_err(anyhow::Error::from)?;
 
-        to_lyric(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("get lyric text from response")))
+        to_lyric(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract Lyric text from result"))
+        })
     }
 
     async fn get_picture(
@@ -159,8 +160,9 @@ impl SongTagService for Api {
             .await
             .map_err(anyhow::Error::from)?;
 
-        let pic_url = to_pic_url(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("get picture url")))?;
+        let pic_url = to_pic_url(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract picture url from result"))
+        })?;
         let url = format!("https:{pic_url}");
 
         let result = self

--- a/lib/src/songtag/migu/model.rs
+++ b/lib/src/songtag/migu/model.rs
@@ -24,25 +24,83 @@ use crate::songtag::UrlTypes;
  * SOFTWARE.
  */
 use super::super::{ServiceProvider, SongTag};
-use anyhow::{anyhow, bail, Result};
 use serde_json::{from_str, json, Value};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MiguParseError {
+    #[error("Expected field \"{field}\" to have value \"{expected}\", got \"{got}\", error message: \"{errmsg:#?}\"")]
+    UnexpectedStatus {
+        field: &'static str,
+        got: String,
+        errmsg: Option<String>,
+        expected: &'static str,
+    },
+
+    #[error("Expected property \"{0}\" to exist")]
+    MissingProperty(&'static str),
+
+    #[error(transparent)]
+    ParseError(#[from] serde_json::Error),
+}
+
+type Result<T> = std::result::Result<T, MiguParseError>;
+
+/// Get the given `field`, otherwise return as [`MissingProperty`](MiguParseError::MissingProperty) Error
+fn get_code_prop<'a>(value: &'a Value, field: &'static str) -> Result<&'a Value> {
+    let Some(value) = value.get(field) else {
+        return Err(MiguParseError::MissingProperty(field));
+    };
+
+    Ok(value)
+}
+
+/// Check the `msg` property for if there was a error
+fn check_msg(value: &Value) -> Result<()> {
+    let msg = get_code_prop(value, "msg")?;
+
+    // english for the chinese characters: "success"
+    if !msg.eq(&"成功") {
+        let message = msg.as_str().unwrap_or("<none>");
+
+        return Err(MiguParseError::UnexpectedStatus {
+            field: "msg",
+            got: message.to_string(),
+            errmsg: None,
+            expected: "成功",
+        });
+    }
+
+    Ok(())
+}
+
+/// Check the `success` property for if there was a error
+fn check_success(value: &Value) -> Result<()> {
+    let success = get_code_prop(value, "success")?;
+
+    if !success.eq(&true) {
+        let message = success.to_string();
+
+        return Err(MiguParseError::UnexpectedStatus {
+            field: "success",
+            got: message,
+            errmsg: None,
+            expected: "true",
+        });
+    }
+
+    Ok(())
+}
 
 /// Try to get the lyric lrc content from the given result
 pub fn to_lyric(json: &str) -> Result<String> {
-    let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
+    let value = from_str::<Value>(json)?;
 
-    // english for the chinese characters: "success"
-    if value.get("msg").is_none() || !value.get("msg").is_some_and(|v| v.eq(&"成功")) {
-        let message = value.get("msg").and_then(Value::as_str).unwrap_or("<none>");
-        bail!(
-            "Failed to get lyric text, \"msg\" does not exist or is not \"sucess\" Errcode: {message}"
-        );
-    }
+    check_msg(&value)?;
 
     let lyric = value
         .get("lyric")
         .and_then(Value::as_str)
-        .ok_or(anyhow!("property \"lyric\" does not exist in result!"))?
+        .ok_or(MiguParseError::MissingProperty("lyric"))?
         .to_owned();
 
     Ok(lyric)
@@ -50,20 +108,14 @@ pub fn to_lyric(json: &str) -> Result<String> {
 
 /// Try to get the picture url from the json response
 pub fn to_pic_url(json: &str) -> Result<String> {
-    let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
+    let value = from_str::<Value>(json)?;
 
-    // english for the chinese characters: "success"
-    if value.get("msg").is_none() || !value.get("msg").is_some_and(|v| v.eq(&"成功")) {
-        let message = value.get("msg").and_then(Value::as_str).unwrap_or("<none>");
-        bail!(
-            "Failed to get picure url, \"msg\" does not exist or is not \"sucess\" Errcode: {message}"
-        );
-    }
+    check_msg(&value)?;
 
     let pic_url = value
         .get("largePic")
         .and_then(Value::as_str)
-        .ok_or(anyhow!("property \"largePic\" does not exist in result!"))?
+        .ok_or(MiguParseError::MissingProperty("largePic"))?
         .to_owned();
 
     Ok(pic_url)
@@ -71,22 +123,14 @@ pub fn to_pic_url(json: &str) -> Result<String> {
 
 /// Try to get individual [`SongTag`]s from the json response
 pub fn to_song_info(json: &str) -> Result<Vec<SongTag>> {
-    let value = from_str::<Value>(json).map_err(anyhow::Error::from)?;
+    let value = from_str::<Value>(json)?;
 
-    if value.get("success").is_none() || !value.get("success").is_some_and(|v| v.eq(&true)) {
-        let message = value
-            .get("success")
-            .and_then(Value::as_str)
-            .unwrap_or("<none>");
-        bail!(
-            "Failed to get songinfo, \"success\" does not exist or is not \"true\" Errcode: {message}"
-        );
-    }
+    check_success(&value)?;
 
     let array = value
         .get("musics")
         .and_then(Value::as_array)
-        .ok_or(anyhow!("property \"musics\" does not exist in result!"))?;
+        .ok_or(MiguParseError::MissingProperty("musics"))?;
 
     let mut vec: Vec<SongTag> = Vec::new();
 

--- a/lib/src/songtag/migu/model.rs
+++ b/lib/src/songtag/migu/model.rs
@@ -60,11 +60,11 @@ fn check_msg(value: &Value) -> Result<()> {
 
     // english for the chinese characters: "success"
     if !msg.eq(&"成功") {
-        let message = msg.as_str().unwrap_or("<none>");
+        let message = msg.to_string();
 
         return Err(MiguParseError::UnexpectedStatus {
             field: "msg",
-            got: message.to_string(),
+            got: message,
             errmsg: None,
             expected: "成功",
         });

--- a/lib/src/songtag/netease_v2/mod.rs
+++ b/lib/src/songtag/netease_v2/mod.rs
@@ -172,7 +172,7 @@ impl SongTagService for Api {
         let result = response.text().await.map_err(anyhow::Error::from)?;
 
         to_song_info(&result).map_err(|err| {
-            SongTagServiceError::Other(err.context("convert result to songtag array"))
+            SongTagServiceError::Other(anyhow!(err).context("Parse result into SongTag Array"))
         })
     }
 
@@ -207,8 +207,9 @@ impl SongTagService for Api {
 
         let result = response.text().await.map_err(anyhow::Error::from)?;
 
-        to_lyric(&result)
-            .map_err(|err| SongTagServiceError::Other(err.context("get lyric text from response")))
+        to_lyric(&result).map_err(|err| {
+            SongTagServiceError::Other(anyhow!(err).context("Extract Lyric text from result"))
+        })
     }
 
     async fn get_picture(
@@ -273,7 +274,9 @@ impl SongTagService for Api {
         let result = response.text().await.map_err(anyhow::Error::from)?;
 
         to_song_url(&result).map_err(|err| {
-            SongTagServiceError::Other(err.context("get download url from response"))
+            SongTagServiceError::Other(
+                anyhow!(err).context("Extract recording download url from result"),
+            )
         })
     }
 }

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -170,7 +170,11 @@ impl UeInstance {
         let child = match self.ueberzug {
             UeInstanceState::New => self.spawn_cmd(args)?,
             UeInstanceState::Child(ref mut v) => v,
-            UeInstanceState::Error => return on_error().map(|()| None),
+            UeInstanceState::Error => {
+                trace!("Not re-trying ueberzug, because it has a permanent error!");
+
+                return Ok(None);
+            }
         };
 
         if let Some(exit_status) = child.try_wait()? {
@@ -212,15 +216,6 @@ impl UeInstance {
         // even though that branch never reaches here
         Ok(Some(self.ueberzug.unwrap_child_mut()))
     }
-}
-
-/// Small helper to always print a message and return a consistent return
-#[inline]
-#[allow(clippy::unnecessary_wraps)]
-fn on_error() -> Result<()> {
-    trace!("Not re-trying ueberzug, because it has a permanent error!");
-
-    Ok(())
 }
 
 /// Map a given error to include extra context

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -220,7 +220,6 @@ impl UeInstance {
 
 /// Map a given error to include extra context
 #[inline]
-#[allow(clippy::needless_pass_by_value)]
 fn map_err(err: anyhow::Error) -> anyhow::Error {
     err.context("Failed to run Ueberzug")
 }


### PR DESCRIPTION
This PR adds custom errors with `thiserror` for songtag models / parsing.

Note that `anyhow` is still used for all songtag's main error type, to keep some backtrace.

This is a extension on #431 