### PR TITLE
Less Clippy broad `allow(unused)` and remove some unused lints

### DIFF
--- a/lib/src/config/v1/mod.rs
+++ b/lib/src/config/v1/mod.rs
@@ -67,7 +67,6 @@ pub enum Loop {
     Random,
 }
 
-#[allow(clippy::non_ascii_literal)]
 impl Loop {
     pub fn display(self, display_symbol: bool) -> String {
         if display_symbol {

--- a/lib/src/invidious.rs
+++ b/lib/src/invidious.rs
@@ -87,7 +87,6 @@ impl Default for Instance {
     }
 }
 
-#[allow(unused)]
 impl Instance {
     pub async fn new(query: &str) -> Result<(Self, Vec<YoutubeVideo>)> {
         let client = ClientBuilder::new()

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -97,6 +97,16 @@ pub mod const_unknown {
         UNKNOWN_GENRE "no type",
         UNKNOWN_FILE "Unknown File",
     }
+
+    // TODO: use this for database migration
+    /// This is the old string that was used as default for "artist" & "album"
+    ///
+    /// this value is currently unused, but this will stay here as a reminder until the database is migrated to use NULL values
+    #[allow(unused)]
+    pub const OLD_UNSUPPORTED: &str = "Unsupported?";
+
+    // NOTE: previously artist & album were `OLD_UNSUPPORTED`, but now they are `UNKNOWN_ARTIST` or `UNKNOWN_ALBUM`, these values will stay until the database is migrated to use NULL instead
+    // even after, it is likely the `UNKNOWN_` values will continue to exist for display purposes
 }
 use const_unknown::{UNKNOWN_ALBUM, UNKNOWN_ARTIST, UNKNOWN_FILE, UNKNOWN_GENRE, UNKNOWN_TITLE};
 

--- a/lib/src/podcast/db/episode_db.rs
+++ b/lib/src/podcast/db/episode_db.rs
@@ -1,5 +1,3 @@
-use std::path::{Path, PathBuf};
-
 use chrono::{DateTime, Utc};
 use rusqlite::{named_params, params, Connection, Row};
 
@@ -19,6 +17,7 @@ pub struct EpisodeDB {
     pub pubdate: Option<DateTime<Utc>>,
     pub duration: Option<i64>,
     pub played: bool,
+    #[allow(dead_code)]
     pub hidden: bool,
     pub last_position: Option<i64>,
     pub image_url: Option<String>,
@@ -26,6 +25,7 @@ pub struct EpisodeDB {
 
 impl EpisodeDB {
     /// Try to convert a given row to a [`EpisodeDB`] instance, using column names to resolve the values
+    #[allow(dead_code)]
     pub fn try_from_row_named(row: &Row<'_>) -> Result<Self, rusqlite::Error> {
         // NOTE: all the names in "get" below are the *column names* as defined in migrations/001.sql#table_episodes (pseudo link)
         Ok(Self {
@@ -159,6 +159,7 @@ impl<'a> EpisodeDBInsertable<'a> {
 /// Delete a episode by id
 ///
 /// This also deletes all associated files (not removing the actual files)!
+#[allow(dead_code)]
 pub fn delete_episode(id: PodcastDBId, con: &Connection) -> Result<usize, rusqlite::Error> {
     let mut stmt = con.prepare_cached("DELETE FROM episodes WHERE id = ?;")?;
     stmt.execute(params![id])

--- a/lib/src/podcast/db/file_db.rs
+++ b/lib/src/podcast/db/file_db.rs
@@ -6,6 +6,7 @@ use super::PodcastDBId;
 
 /// A struct representing a episode file (downloaded) in the database
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct FileDB {
     pub id: PodcastDBId,
     pub episode_id: PodcastDBId,
@@ -14,6 +15,7 @@ pub struct FileDB {
 
 impl FileDB {
     /// Try to convert a given row to a [`FileDB`] instance, using column names to resolve the values
+    #[allow(dead_code)]
     pub fn try_from_row_named(row: &Row<'_>) -> Result<Self, rusqlite::Error> {
         // NOTE: all the names in "get" below are the *column names* as defined in migrations/001.sql#table_files (pseudo link)
         let path = PathBuf::from(row.get::<_, String>("path")?);

--- a/lib/src/podcast/db/migration.rs
+++ b/lib/src/podcast/db/migration.rs
@@ -4,10 +4,6 @@ use semver::Version;
 
 /// The Current Database schema version this application is meant to run against
 pub(super) const DB_VERSION: u32 = 1;
-/// The Lowest Database schema version this application supports migration up against
-///
-/// Expection being "0" as that indicates a fresh database
-const LOWEST_MIGRATEABLE_VERSION: u32 = 1;
 
 /// Helper function to get the `user_version` with a single function call
 #[inline]
@@ -31,19 +27,13 @@ fn set_user_version(conn: &Connection, version: u32) -> Result<u32> {
 
 /// Create / Migrate everything in the database, if necessary
 pub(super) fn migrate(conn: &Connection) -> Result<()> {
-    let mut user_version: u32 = get_user_version(conn)?;
+    let user_version: u32 = get_user_version(conn)?;
 
     if user_version > DB_VERSION {
         bail!(
             "Expected Database version to be lower or equal to {DB_VERSION}, found {user_version}!"
         );
     }
-
-    // if user_version < LOWEST_MIGRATEABLE_VERSION && user_version != 0 {
-    //     warn!("Found Database, but had lower than lowest migrateable version, resetting! Version: {user_version}");
-
-    //     bail!("Incompatible Database version: {user_version}");
-    // }
 
     // only execute migrations if not already done so
     if user_version != DB_VERSION {
@@ -57,7 +47,7 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
 
 /// The Function that actually applies creations / migrations, checks / preparation is done in the function above
 ///
-/// Migrates from [`LOWEST_MIGRATEABLE_VERSION`] / `0` to [`DB_VERSION`]
+/// Migrates from `0` to [`DB_VERSION`]
 #[allow(unused_assignments)] // for future possible migrations
 fn apply_migrations(conn: &Connection, mut user_version: u32) -> Result<()> {
     // do all migrations in steps, this way everyone is in the same state and had the same things applied, even for new things

--- a/lib/src/podcast/db/mod.rs
+++ b/lib/src/podcast/db/mod.rs
@@ -3,11 +3,10 @@ use std::time::Duration;
 
 use ahash::AHashMap;
 use anyhow::{anyhow, Context, Result};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use episode_db::{EpisodeDB, EpisodeDBInsertable};
 use file_db::{FileDB, FileDBInsertable};
 use rusqlite::{params, Connection};
-use semver::Version;
 
 use super::{Episode, EpisodeNoId, Podcast, PodcastNoId, RE_ARTICLES};
 use crate::track::Track;

--- a/lib/src/podcast/db/mod.rs
+++ b/lib/src/podcast/db/mod.rs
@@ -128,7 +128,7 @@ impl Database {
     pub fn update_podcast(&self, pod_id: PodcastDBId, podcast: &PodcastNoId) -> Result<SyncResult> {
         PodcastDBInsertable::from(podcast).update_podcast(pod_id, &self.conn)?;
 
-        let result = self.update_episodes(pod_id, &podcast.title, &podcast.episodes)?;
+        let result = self.update_episodes(pod_id, &podcast.episodes)?;
         Ok(result)
     }
 
@@ -143,7 +143,6 @@ impl Database {
     fn update_episodes(
         &self,
         podcast_id: PodcastDBId,
-        podcast_title: &str,
         episodes: &[EpisodeNoId],
     ) -> Result<SyncResult> {
         let old_episodes = self.get_episodes(podcast_id, true)?;

--- a/lib/src/podcast/mod.rs
+++ b/lib/src/podcast/mod.rs
@@ -1,6 +1,5 @@
 // Thanks to the author of shellcaster(https://github.com/jeff-hughes/shellcaster). Most parts of following code are taken from it.
 
-#[allow(unused)]
 pub mod db;
 #[allow(clippy::module_name_repetitions)]
 pub mod episode;

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -39,13 +39,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
-// TODO: use this for database migration
-/// This is the old string that was used as default for "artist" & "album"
-///
-/// this value is currently unused, but this will stay here as a reminder until the database is migrated
-#[allow(unused)]
-pub const UNSUPPORTED: &str = "Unsupported?";
-
 /// Location types for a Track, could be a local file with [`LocationType::Path`] or a remote URI with [`LocationType::Uri`]
 #[derive(Clone, Debug, PartialEq)]
 pub enum LocationType {

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -287,7 +287,6 @@ pub fn display_with(
 }
 
 #[cfg(test)]
-#[allow(clippy::non_ascii_literal)]
 mod tests {
     use std::fmt::{Display, Write};
 

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -143,7 +143,6 @@ pub struct SelectStates {
     pub tab_open: bool,
 }
 
-#[allow(unused)]
 impl SelectStates {
     /// ### `next_choice`
     ///
@@ -228,7 +227,6 @@ pub struct InputStates {
     pub cursor: usize,    // Input position
 }
 
-#[allow(unused)]
 impl InputStates {
     /// ### `append`
     ///
@@ -326,8 +324,8 @@ pub struct KeyCombo {
     pub states_input: InputStates,
 }
 
-#[allow(unused)]
 impl KeyCombo {
+    #[allow(dead_code)]
     pub fn input_len(mut self, ilen: usize) -> Self {
         self.attr(Attribute::InputLength, AttrValue::Length(ilen));
         self
@@ -368,6 +366,7 @@ impl KeyCombo {
         self
     }
 
+    #[allow(dead_code)]
     pub fn background(mut self, bg: Color) -> Self {
         self.attr(Attribute::Background, AttrValue::Color(bg));
         self
@@ -399,6 +398,7 @@ impl KeyCombo {
         self
     }
 
+    #[allow(dead_code)]
     pub fn inactive(mut self, s: Style) -> Self {
         self.attr(Attribute::FocusStyle, AttrValue::Style(s));
         self
@@ -589,19 +589,25 @@ impl KeyCombo {
         render.render_stateful_widget(list, chunks[1], &mut state);
     }
 
+    /// Get the style for the closed normal, focused, non-invalid color
+    fn get_normal_closed_style(&self) -> Style {
+        let foreground = self
+            .props
+            .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
+            .unwrap_color();
+        let background = self
+            .props
+            .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
+            .unwrap_color();
+
+        Style::default().bg(background).fg(foreground)
+    }
+
     /// ### `render_closed_tab`
     ///
     /// Render component when tab is closed
     fn render_closed_tab(&self, render: &mut Frame<'_>, area: Rect) {
         // Render select
-        let mut foreground = self
-            .props
-            .get_or(Attribute::Foreground, AttrValue::Color(Color::Reset))
-            .unwrap_color();
-        let mut background = self
-            .props
-            .get_or(Attribute::Background, AttrValue::Color(Color::Reset))
-            .unwrap_color();
         let inactive_style = self
             .props
             .get(Attribute::FocusStyle)
@@ -611,7 +617,7 @@ impl KeyCombo {
             .get_or(Attribute::Focus, AttrValue::Flag(false))
             .unwrap_flag();
         let mut style = if focus {
-            Style::default().bg(background).fg(foreground)
+            self.get_normal_closed_style()
         } else {
             inactive_style.unwrap_or_default()
         };
@@ -647,8 +653,6 @@ impl KeyCombo {
                 .map(AttrValue::unwrap_style)
             {
                 block = block.border_style(style_invalid);
-                foreground = style_invalid.fg.unwrap_or(Color::Reset);
-                background = style_invalid.bg.unwrap_or(Color::Reset);
                 style = style_invalid;
             }
         }

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -583,7 +583,6 @@ impl Model {
         self.app.active(&Id::DBListSearchTracks).ok();
     }
 
-    #[allow(unused)]
     pub fn database_reload(&mut self) {
         assert!(self
             .app

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -41,8 +41,8 @@ struct Counter {
     props: Props,
 }
 
-#[allow(unused)]
 impl Counter {
+    #[allow(dead_code)]
     pub fn label<S>(mut self, label: S) -> Self
     where
         S: AsRef<str>,

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -39,7 +39,7 @@ use crate::ui::{Model, Msg, TEMsg, TFMsg};
 #[derive(Default)]
 struct Counter {
     props: Props,
-    states: OwnStates,
+    states: CounterState,
 }
 
 #[allow(unused)]
@@ -175,20 +175,8 @@ impl MockComponent for Counter {
 }
 
 #[derive(Default)]
-struct OwnStates {
+struct CounterState {
     counter: isize,
-}
-
-// impl Default for OwnStates {
-//     fn default() -> Self {
-//         Self { counter: 0 }
-//     }
-// }
-#[allow(unused)]
-impl OwnStates {
-    fn incr(&mut self) {
-        self.counter += 1;
-    }
 }
 
 // -- Counter components

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -39,7 +39,6 @@ use crate::ui::{Model, Msg, TEMsg, TFMsg};
 #[derive(Default)]
 struct Counter {
     props: Props,
-    states: CounterState,
 }
 
 #[allow(unused)]
@@ -84,6 +83,12 @@ impl Counter {
         self.attr(Attribute::Borders, AttrValue::Borders(b));
         self
     }
+
+    pub fn get_state(&self) -> isize {
+        self.props
+            .get_or(Attribute::Value, AttrValue::Number(99))
+            .unwrap_number()
+    }
 }
 
 impl MockComponent for Counter {
@@ -91,10 +96,7 @@ impl MockComponent for Counter {
         // Check if visible
         if self.props.get_or(Attribute::Display, AttrValue::Flag(true)) == AttrValue::Flag(true) {
             // Get properties
-            let value = self
-                .props
-                .get_or(Attribute::Value, AttrValue::Number(99))
-                .unwrap_number();
+            let value = self.get_state();
             let text = format!("Delete ({value})");
 
             let alignment = self
@@ -160,7 +162,7 @@ impl MockComponent for Counter {
     }
 
     fn state(&self) -> State {
-        State::One(StateValue::Isize(self.states.counter))
+        State::One(StateValue::Isize(self.get_state()))
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
@@ -172,11 +174,6 @@ impl MockComponent for Counter {
             _ => CmdResult::None,
         }
     }
-}
-
-#[derive(Default)]
-struct CounterState {
-    counter: isize,
 }
 
 // -- Counter components

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -355,7 +355,6 @@ fn embed_downloaded_lrc(path: &Path, file_fullname: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::non_ascii_literal)]
 mod tests {
 
     use crate::ui::model::youtube_options::extract_filepath;


### PR DESCRIPTION
This PR mainly focuses on doing less broad `allow(unused)`, by moving to more strict `allow(dead_code)` where necessary, or even complete code removal (or moving of code).
Also removes some lints that were not necessary anymore.