### PR TITLE
De-duplicate lints into workspace-lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ lto = true
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
-unsafe_code = "forbid"
+unsafe_code = "deny"
 
 [workspace.lints.clippy]
 correctness = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,12 @@ lto = true
 # panic = 'abort'
 # opt-level = 'z'
 # codegen-units = 1
+
+[workspace.lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+correctness = { level = "warn", priority = -1 }
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -84,3 +84,6 @@ default = []
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,8 +1,5 @@
-#![forbid(unsafe_code)]
 #![recursion_limit = "2048"]
-#![warn(clippy::all, clippy::correctness)]
-#![warn(rust_2018_idioms)]
-#![warn(clippy::pedantic)]
+// TODO: work to remove the following lints
 #![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
 
 pub mod config;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "2048"]
 // TODO: work to remove the following lints
 #![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
 

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -65,3 +65,6 @@ all-backends = ["gst", "mpv"]
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -22,11 +22,7 @@
  * SOFTWARE.
  */
 
-// #![forbid(unsafe_code)]
 #![recursion_limit = "2048"]
-#![warn(clippy::all, clippy::correctness)]
-#![warn(rust_2018_idioms)]
-#![warn(clippy::pedantic)]
 
 #[cfg(feature = "gst")]
 mod gstreamer_backend;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -22,8 +22,6 @@
  * SOFTWARE.
  */
 
-#![recursion_limit = "2048"]
-
 #[cfg(feature = "gst")]
 mod gstreamer_backend;
 #[cfg(feature = "mpv")]

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -258,7 +258,7 @@ impl GeneralPlayer {
 // demonstrates how to make a minimal window to allow use of media keys on the command line
 // ref: https://github.com/Sinono3/souvlaki/blob/master/examples/print_events.rs
 #[cfg(target_os = "windows")]
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation, unsafe_code)]
 mod windows {
     use std::io::Error;
     use std::mem;

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -79,3 +79,6 @@ pretty_assertions.workspace = true # = "1"
 # hound = "3.4"
 # ringbuf = "0.3"
 # clap = { version = "3.1", default-features = false, features = ["std"] }
+
+[lints]
+workspace = true

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,8 +1,4 @@
-#![forbid(unsafe_code)]
 #![recursion_limit = "2048"]
-#![warn(clippy::all, clippy::correctness)]
-#![warn(rust_2018_idioms)]
-#![warn(clippy::pedantic)]
 /**
  * MIT License
  *

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "2048"]
 /**
  * MIT License
  *


### PR DESCRIPTION
This PR moves most top-level lint settings to be workspace-wide lints.

Also removes the `recursion_limit` setting as it does not seem to be necessary, and the default `128` *should* be enough.