### PR TITLE
Remove `allow(clippy::must_use_candidate)` from lib

### DIFF
--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -21,12 +21,14 @@ pub type SharedTuiSettings = Arc<RwLock<TuiOverlay>>;
 
 /// Create a new [`SharedServerSettings`] without having to also depend on [`parking_lot`]
 #[inline]
+#[must_use]
 pub fn new_shared_server_settings(settings: ServerOverlay) -> SharedServerSettings {
     Arc::new(RwLock::new(settings))
 }
 
 /// Create a new [`SharedTuiSettings`] without having to also depend on [`parking_lot`]
 #[inline]
+#[must_use]
 pub fn new_shared_tui_settings(settings: TuiOverlay) -> SharedTuiSettings {
     Arc::new(RwLock::new(settings))
 }

--- a/lib/src/config/server_overlay.rs
+++ b/lib/src/config/server_overlay.rs
@@ -23,6 +23,7 @@ pub struct ServerOverlay {
 
 impl ServerOverlay {
     /// Get the Library scan depth, either the overwrite if present, otherwise the config itself
+    #[must_use]
     pub fn get_library_scan_depth(&self) -> ScanDepth {
         if let Some(v) = self.library_scan_depth {
             v
@@ -32,6 +33,7 @@ impl ServerOverlay {
     }
 
     /// Get whether to enable the discord status
+    #[must_use]
     pub fn get_discord_status_enable(&self) -> bool {
         if self.disable_discord_status {
             false

--- a/lib/src/config/tui_overlay.rs
+++ b/lib/src/config/tui_overlay.rs
@@ -17,6 +17,7 @@ impl TuiOverlay {
     /// Get whether the coverart should be hidden or not, either the overwrite if present, otherwise the config itself
     ///
     /// true => hidden
+    #[must_use]
     pub fn get_coverart_hidden(&self) -> bool {
         if let Some(overwrite) = self.coverart_hidden_overwrite {
             overwrite

--- a/lib/src/config/v2/mod.rs
+++ b/lib/src/config/v2/mod.rs
@@ -1,4 +1,2 @@
-#![warn(clippy::must_use_candidate)]
-
 pub mod server;
 pub mod tui;

--- a/lib/src/config/v2/mod.rs
+++ b/lib/src/config/v2/mod.rs
@@ -1,2 +1,4 @@
+#![warn(clippy::must_use_candidate)]
+
 pub mod server;
 pub mod tui;

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -149,6 +149,7 @@ impl ServerConfigVersionedDefaulted<'_> {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
+    #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         let versioned = match self {
             ServerConfigVersionedDefaulted::Versioned(versioned) => versioned,
@@ -174,6 +175,7 @@ impl ServerConfigVersioned<'_> {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
+    #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         match self {
             ServerConfigVersioned::V2(v) => v.into_owned(),

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -87,11 +87,13 @@ pub enum SeekStep {
 
 impl SeekStep {
     #[allow(clippy::missing_panics_doc)] // const unwrap
+    #[must_use]
     pub fn default_both() -> Self {
         Self::Both(NonZeroU32::new(5).unwrap())
     }
 
     #[allow(clippy::missing_panics_doc)] // const unwrap
+    #[must_use]
     pub fn default_depends() -> Self {
         Self::Depends {
             short_tracks: NonZeroU32::new(5).unwrap(),
@@ -102,6 +104,7 @@ impl SeekStep {
     /// Get Seek Step, depending on track-length
     ///
     /// directly returns a i64, though the value is never negative returned from here
+    #[must_use]
     pub fn get_step(&self, track_len: u64) -> i64 {
         match self {
             SeekStep::Both(v) => v.get().into(),
@@ -152,6 +155,7 @@ pub enum PositionYesNo {
 
 impl PositionYesNo {
     /// Get the time before saving the track position, if enabled
+    #[must_use]
     pub fn get_time(&self, media_type: MediaType) -> Option<u64> {
         match self {
             PositionYesNo::Simple(v) => match v {
@@ -167,6 +171,7 @@ impl PositionYesNo {
     }
 
     /// Get if the current value means "it is enabled"
+    #[must_use]
     pub fn is_enabled(&self) -> bool {
         match self {
             PositionYesNo::Simple(v) => *v == PositionYesNoLower::Yes,
@@ -189,6 +194,7 @@ pub enum RememberLastPosition {
 
 impl RememberLastPosition {
     /// Get the time before saving the track position, if enabled
+    #[must_use]
     pub fn get_time(&self, media_type: MediaType) -> Option<u64> {
         match self {
             RememberLastPosition::All(v) => v.get_time(media_type),
@@ -204,6 +210,7 @@ impl RememberLastPosition {
     ///
     /// use case is in the restore of the last position
     #[allow(clippy::needless_pass_by_value)] // "MediaType" is a 1-byte copy
+    #[must_use]
     pub fn is_enabled_for(&self, media_type: MediaType) -> bool {
         match self {
             RememberLastPosition::All(v) => v.is_enabled(),
@@ -308,6 +315,7 @@ pub enum LoopMode {
 }
 
 impl LoopMode {
+    #[must_use]
     pub fn display(self, display_symbol: bool) -> &'static str {
         if display_symbol {
             match self {
@@ -325,11 +333,13 @@ impl LoopMode {
     }
 
     /// Convert the current enum variant into its number representation
+    #[must_use]
     pub fn discriminant(&self) -> u8 {
         (*self) as u8
     }
 
     /// Try to convert the input number representation to a variant
+    #[must_use]
     pub fn tryfrom_discriminant(num: u8) -> Option<Self> {
         Some(match num {
             0 => Self::Single,

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -168,6 +168,7 @@ impl TuiConfigVersionedDefaulted<'_> {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
+    #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         let versioned = match self {
             TuiConfigVersionedDefaulted::Versioned(versioned) => versioned,
@@ -193,6 +194,7 @@ impl TuiConfigVersioned<'_> {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
+    #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         match self {
             TuiConfigVersioned::V2(v) => v.into_owned(),

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -1432,12 +1432,14 @@ impl KeyBinding {
 
     /// Get the inner key
     #[inline]
+    #[must_use]
     pub fn get(&self) -> tuievents::KeyEvent {
         self.key_event
     }
 
     /// Get the Current Modifier, and the string representation of the key
     #[inline]
+    #[must_use]
     pub fn mod_key(&self) -> (tuievents::KeyModifiers, String) {
         (
             self.key_event.modifiers,

--- a/lib/src/config/v2/tui/mod.rs
+++ b/lib/src/config/v2/tui/mod.rs
@@ -56,6 +56,7 @@ impl TuiSettings {
     }
 
     /// Get the resolved com-settings, if resolved
+    #[must_use]
     pub fn get_com(&self) -> Option<&ComSettings> {
         self.com_resolved.as_ref()
     }

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -27,6 +27,7 @@ pub struct ThemeWrap {
 }
 
 impl ThemeWrap {
+    #[must_use]
     pub fn get_color_from_theme(&self, color: ColorTermusic) -> Color {
         match color {
             ColorTermusic::Reset => Color::Reset,
@@ -52,106 +53,127 @@ impl ThemeWrap {
     }
 
     #[inline]
+    #[must_use]
     pub fn library_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.library.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn library_background(&self) -> Color {
         self.get_color_from_theme(self.style.library.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn library_highlight(&self) -> Color {
         self.get_color_from_theme(self.style.library.highlight_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn library_border(&self) -> Color {
         self.get_color_from_theme(self.style.library.border_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn playlist_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.playlist.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn playlist_background(&self) -> Color {
         self.get_color_from_theme(self.style.playlist.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn playlist_highlight(&self) -> Color {
         self.get_color_from_theme(self.style.playlist.highlight_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn playlist_border(&self) -> Color {
         self.get_color_from_theme(self.style.playlist.border_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn progress_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.progress.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn progress_background(&self) -> Color {
         self.get_color_from_theme(self.style.progress.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn progress_border(&self) -> Color {
         self.get_color_from_theme(self.style.progress.border_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn lyric_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.lyric.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn lyric_background(&self) -> Color {
         self.get_color_from_theme(self.style.lyric.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn lyric_border(&self) -> Color {
         self.get_color_from_theme(self.style.lyric.border_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn important_popup_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.important_popup.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn important_popup_background(&self) -> Color {
         self.get_color_from_theme(self.style.important_popup.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn important_popup_border(&self) -> Color {
         self.get_color_from_theme(self.style.important_popup.border_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn fallback_foreground(&self) -> Color {
         self.get_color_from_theme(self.style.fallback.foreground_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn fallback_background(&self) -> Color {
         self.get_color_from_theme(self.style.fallback.background_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn fallback_highlight(&self) -> Color {
         self.get_color_from_theme(self.style.fallback.highlight_color)
     }
 
     #[inline]
+    #[must_use]
     pub fn fallback_border(&self) -> Color {
         self.get_color_from_theme(self.style.fallback.border_color)
     }
@@ -180,6 +202,7 @@ pub struct ThemeColor {
 
 impl ThemeColor {
     /// Create a new instance with those values
+    #[must_use]
     pub const fn new(r: u8, g: u8, b: u8) -> Self {
         Self { r, g, b }
     }
@@ -207,6 +230,7 @@ impl ThemeColor {
 
     /// Convert to hex prefix + 6 length string
     #[inline]
+    #[must_use]
     pub fn to_hex(&self) -> String {
         format!("#{:02x}{:02x}{:02x}", self.r, self.g, self.b)
     }
@@ -285,6 +309,7 @@ impl ThemeColors {
     /// Get the full default theme, including names.
     ///
     /// This function is different from [`Self::default`] as the trait impl is also used for filling empty places
+    #[must_use]
     pub fn full_default() -> Self {
         Self {
             name: "Termusic Default".to_string(),

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -52,6 +52,7 @@ impl AsRef<str> for ColorTermusic {
 }
 
 impl ColorTermusic {
+    #[must_use]
     pub const fn as_usize(self) -> usize {
         self as usize
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,7 +3,8 @@
 #![warn(clippy::all, clippy::correctness)]
 #![warn(rust_2018_idioms)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
+// TODO: work to remove the following lints
+#![allow(clippy::missing_errors_doc)]
 
 pub mod config;
 pub mod invidious;

--- a/lib/src/podcast/episode.rs
+++ b/lib/src/podcast/episode.rs
@@ -28,6 +28,7 @@ pub struct Episode {
 
 impl Episode {
     /// Formats the duration in seconds into an HH:MM:SS format.
+    #[must_use]
     pub fn format_duration(&self) -> String {
         match self.duration {
             Some(dur) => {

--- a/lib/src/podcast/mod.rs
+++ b/lib/src/podcast/mod.rs
@@ -71,6 +71,7 @@ pub struct PodcastFeed {
 }
 
 impl PodcastFeed {
+    #[must_use]
     pub fn new(id: Option<i64>, url: &str, title: Option<String>) -> Self {
         Self {
             id,

--- a/lib/src/podcast/podcast.rs
+++ b/lib/src/podcast/podcast.rs
@@ -27,6 +27,7 @@ pub struct Podcast {
 
 impl Podcast {
     // Counts and returns the number of unplayed episodes in the podcast.
+    #[must_use]
     pub fn num_unplayed(&self) -> usize {
         self.episodes
             .iter()

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -72,6 +72,7 @@ impl Lyric {
     /// # Panics
     ///
     /// if `time` cannot be represented as a [`i64`]
+    #[must_use]
     pub fn get_text(&self, time: Duration) -> Option<&str> {
         if self.captions.is_empty() {
             return None;
@@ -102,6 +103,7 @@ impl Lyric {
     /// Get a index for the next lowest caption from `time` (in milliseconds)
     ///
     /// This function takes `self.offset` into account.
+    #[must_use]
     pub fn get_index(&self, time: i64) -> Option<usize> {
         if self.captions.is_empty() {
             return None;
@@ -150,6 +152,7 @@ impl Lyric {
     }
 
     /// Format current [`Lyric`] as a LRC file
+    #[must_use]
     pub fn as_lrc_text(&self) -> String {
         let mut result: String = String::new();
         if self.offset != 0 {

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -129,28 +129,34 @@ pub async fn search(search_str: &str, tx_tageditor: Sender<SearchLyricState>) {
 }
 
 impl SongTag {
+    #[must_use]
     pub fn artist(&self) -> Option<&str> {
         self.artist.as_deref()
     }
 
+    #[must_use]
     pub fn album(&self) -> Option<&str> {
         self.album.as_deref()
     }
 
     /// Optionally return the title of the song
     /// If `None` it wasn't able to read the tags
+    #[must_use]
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
 
+    #[must_use]
     pub fn lang_ext(&self) -> Option<&str> {
         self.lang_ext.as_deref()
     }
 
+    #[must_use]
     pub const fn service_provider(&self) -> ServiceProvider {
         self.service_provider
     }
 
+    #[must_use]
     pub const fn url(&self) -> Option<&UrlTypes> {
         self.url.as_ref()
     }

--- a/lib/src/taskpool.rs
+++ b/lib/src/taskpool.rs
@@ -7,6 +7,7 @@ use tokio_util::sync::CancellationToken;
 /// Manages a taskpool of a given size of how many task to execute at once.
 ///
 /// Also cancels all tasks spawned by this pool on [`Drop`]
+#[must_use]
 pub struct TaskPool {
     /// Semaphore to manage how many active tasks there at a time
     semaphore: Arc<Semaphore>,

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -308,6 +308,7 @@ impl Track {
         bail!("cycle lyrics error")
     }
 
+    #[must_use]
     pub const fn parsed_lyric(&self) -> Option<&Lyric> {
         self.parsed_lyric.as_ref()
     }
@@ -324,10 +325,12 @@ impl Track {
         self.lyric_selected_index = index;
     }
 
+    #[must_use]
     pub const fn lyric_selected_index(&self) -> usize {
         self.lyric_selected_index
     }
 
+    #[must_use]
     pub fn lyric_selected(&self) -> Option<&Id3Lyrics> {
         if self.lyric_frames.is_empty() {
             return None;
@@ -338,10 +341,12 @@ impl Track {
         None
     }
 
+    #[must_use]
     pub fn lyric_frames_is_empty(&self) -> bool {
         self.lyric_frames.is_empty()
     }
 
+    #[must_use]
     pub fn lyric_frames_len(&self) -> usize {
         if self.lyric_frames.is_empty() {
             return 0;
@@ -349,6 +354,7 @@ impl Track {
         self.lyric_frames.len()
     }
 
+    #[must_use]
     pub fn lyric_frames(&self) -> Option<Vec<Id3Lyrics>> {
         if self.lyric_frames.is_empty() {
             return None;
@@ -356,15 +362,18 @@ impl Track {
         Some(self.lyric_frames.clone())
     }
 
+    #[must_use]
     pub const fn picture(&self) -> Option<&Picture> {
         self.picture.as_ref()
     }
+    #[must_use]
     pub fn album_photo(&self) -> Option<&str> {
         self.album_photo.as_deref()
     }
 
     /// Optionally return the artist of the song
     /// If `None` it wasn't able to read the tags
+    #[must_use]
     pub fn artist(&self) -> Option<&str> {
         self.artist.as_deref()
     }
@@ -375,6 +384,7 @@ impl Track {
 
     /// Optionally return the song's album
     /// If `None` failed to read the tags
+    #[must_use]
     pub fn album(&self) -> Option<&str> {
         self.album.as_deref()
     }
@@ -383,6 +393,7 @@ impl Track {
         self.album = Some(album.to_string());
     }
 
+    #[must_use]
     pub fn genre(&self) -> Option<&str> {
         self.genre.as_deref()
     }
@@ -394,6 +405,7 @@ impl Track {
 
     /// Optionally return the title of the song
     /// If `None` it wasn't able to read the tags
+    #[must_use]
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
     }
@@ -403,6 +415,7 @@ impl Track {
     }
 
     /// Get the full Path or URI of the track, if its a local file
+    #[must_use]
     pub fn file(&self) -> Option<&str> {
         match &self.location {
             LocationType::Path(path_buf) => path_buf.to_str(),
@@ -429,14 +442,17 @@ impl Track {
         }
     }
 
+    #[must_use]
     pub const fn duration(&self) -> Duration {
         self.duration
     }
 
+    #[must_use]
     pub fn duration_formatted(&self) -> String {
         Self::duration_formatted_short(&self.duration)
     }
 
+    #[must_use]
     pub fn duration_formatted_short(d: &Duration) -> String {
         let duration_hour = d.as_secs() / 3600;
         let duration_min = (d.as_secs() % 3600) / 60;

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -109,6 +109,7 @@ pub enum MediaType {
 impl Track {
     /// Create a new [`MediaType::Podcast`] track
     #[allow(clippy::cast_sign_loss)]
+    #[must_use]
     pub fn from_episode(ep: &Episode) -> Self {
         let lyric_frames: Vec<Id3Lyrics> = Vec::new();
         let mut podcast_localfile: Option<String> = None;
@@ -232,6 +233,7 @@ impl Track {
     }
 
     /// Create a new [`MediaType::LiveRadio`] track
+    #[must_use]
     pub fn new_radio(url: &str) -> Self {
         let mut track = Self::new(LocationType::Uri(url.to_string()), MediaType::LiveRadio);
         track.artist = Some("Radio".to_string());
@@ -240,6 +242,7 @@ impl Track {
         track
     }
 
+    #[must_use]
     fn new(location: LocationType, media_type: MediaType) -> Self {
         let duration = Duration::from_secs(0);
         let lyric_frames: Vec<Id3Lyrics> = Vec::new();

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -761,6 +761,7 @@ impl YoutubeOptions {
         Ok(())
     }
 
+    #[must_use]
     pub const fn page(&self) -> u32 {
         self.page
     }

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -12,6 +12,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use crate::config::ServerOverlay;
 
+#[must_use]
 pub fn get_pin_yin(input: &str) -> String {
     let mut b = String::new();
     for (index, f) in input.to_pinyin().enumerate() {
@@ -30,6 +31,7 @@ pub fn get_pin_yin(input: &str) -> String {
 }
 
 // TODO: decide filetype supported by backend instead of in library
+#[must_use]
 pub fn filetype_supported(current_node: &str) -> bool {
     let p = Path::new(current_node);
 
@@ -52,6 +54,7 @@ pub fn filetype_supported(current_node: &str) -> bool {
     }
 }
 
+#[must_use]
 pub fn is_playlist(current_node: &str) -> bool {
     let p = Path::new(current_node);
 
@@ -66,6 +69,7 @@ pub fn is_playlist(current_node: &str) -> bool {
 }
 
 /// Get the parent path of the given `path`, if there is none use the tempdir
+#[must_use]
 pub fn get_parent_folder(path: &Path) -> Cow<'_, Path> {
     if path.is_dir() {
         return path.into();
@@ -233,6 +237,7 @@ pub fn absolute_path(path: &Path) -> std::io::Result<Cow<'_, Path>> {
 /// `.\somewhere` -> `C:\somewhere`
 ///
 /// in the future consider replacing with [`std::path::absolute`] once stable
+#[must_use]
 pub fn absolute_path_base<'a>(path: &'a Path, base: &Path) -> Cow<'a, Path> {
     if path.is_absolute() {
         Cow::Borrowed(path)
@@ -242,6 +247,7 @@ pub fn absolute_path_base<'a>(path: &'a Path, base: &Path) -> Cow<'a, Path> {
 }
 
 /// Generate `len` random ascii character (a-z0-9)
+#[must_use]
 pub fn random_ascii(len: usize) -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)

--- a/lib/src/xywh.rs
+++ b/lib/src/xywh.rs
@@ -152,6 +152,7 @@ impl Xywh {
         Self::safe_guard_width_or_height(height, term_height * 2)
     }
 
+    #[must_use]
     pub fn get_terminal_size_u32() -> (u32, u32) {
         let (term_width, term_height) = viuer::terminal_size();
         (u32::from(term_width), u32::from(term_height))


### PR DESCRIPTION
This PR un-ignores the `clippy::must_use_candidate` lint and adds it everywhere suggested.

Might conflict with #436 