### PR TITLE
fix(lib::ueberzug): let the ueberzug command inherit stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix(tui): not having the current theme selected when entering Theme preview tab.
 - Fix(tui): actually report any errors when adding to the playlist. (Like "invalid file type")
 - Fix(tui): sort Music-Library content Alphanumerically.
+- Fix(tui): let `ueberzug` command inherit `stdout` to display chafa.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -96,8 +96,6 @@ impl UeInstance {
     }
 
     fn run_ueberzug_cmd(&mut self, cmd: &str) -> Result<()> {
-        // error!("using x11 output for ueberzugpp");
-
         let Some(ueberzug) = self.try_wait_spawn(["layer"])? else {
             return Ok(());
         };
@@ -111,7 +109,7 @@ impl UeInstance {
     }
 
     fn run_ueberzug_cmd_sixel(&mut self, cmd: &str) -> Result<()> {
-        // error!("using sixel output for ueberzugpp");
+        // debug!("ueberzug forced sixel");
 
         let Some(ueberzug) = self.try_wait_spawn(
             ["layer"],
@@ -142,7 +140,7 @@ impl UeInstance {
         let mut cmd = Command::new("ueberzug");
         cmd.args(args)
             .stdin(Stdio::piped())
-            .stdout(Stdio::null()) // ueberzug does not output to stdout
+            .stdout(Stdio::inherit()) // ueberzug may need this for chafa output
             .stderr(Stdio::piped());
 
         match cmd.spawn() {


### PR DESCRIPTION
Let the `ueberzug` command inherit `stdout`, which is required for outputs like `chafa`.

re #438