### PR TITLE
Tag-Editor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix(tui): in Tag-Editor, show index of lyric frame and either description or as fallback the set language. (no more empty "Select Lyric" texts)
 - Fix(tui): in Tag-Editor, properly reflect selected index in the "Delete" Lyric option. (no more 0/99 if empty; no more always maxed)
 - Fix(tui): in Tag-Editor, fix messed-up lyric text display if the text contains `\r`(carriage returns).
+- Fix(tui): in Tag-Editor, change "Search" to not be blocking anymore and give feedback that something is happening.
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix(tui): consistent numbering of results in a search popup.
 - Fix(tui): let `ueberzug` command inherit `stdout` to display chafa.
 - Fix(tui): in Tag-Editor, show index of lyric frame and either description or as fallback the set language. (no more empty "Select Lyric" texts)
+- Fix(tui): in Tag-Editor, properly reflect selected index in the "Delete" Lyric option. (no more 0/99 if empty; no more always maxed)
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix(tui): let `ueberzug` command inherit `stdout` to display chafa.
 - Fix(tui): in Tag-Editor, show index of lyric frame and either description or as fallback the set language. (no more empty "Select Lyric" texts)
 - Fix(tui): in Tag-Editor, properly reflect selected index in the "Delete" Lyric option. (no more 0/99 if empty; no more always maxed)
+- Fix(tui): in Tag-Editor, fix messed-up lyric text display if the text contains `\r`(carriage returns).
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix(tui): sort Music-Library content Alphanumerically.
 - Fix(tui): consistent numbering of results in a search popup.
 - Fix(tui): let `ueberzug` command inherit `stdout` to display chafa.
+- Fix(tui): in Tag-Editor, show index of lyric frame and either description or as fallback the set language. (no more empty "Select Lyric" texts)
 
 ### [V0.9.1]
 - Released on: August 21, 2024.

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -161,6 +161,11 @@ impl SongTag {
         self.url.as_ref()
     }
 
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.song_id
+    }
+
     // get lyric by lyric_id
     pub async fn fetch_lyric(&self) -> Result<Option<String>> {
         let lyric_string = match self.service_provider {

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -288,7 +288,7 @@ impl Model {
                 song.set_lyric_selected_index(song.lyric_selected_index() - 1);
             }
             match song.save_tag() {
-                Ok(()) => self.init_by_song(&song),
+                Ok(()) => self.init_by_song(song),
                 Err(e) => {
                     self.mount_error_popup(e);
                 }

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -25,7 +25,7 @@ use termusiclib::config::SharedTuiSettings;
 use tui_realm_stdlib::utils::get_block;
 use tuirealm::command::{Cmd, CmdResult};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers, NoUserEvent};
-use tuirealm::props::{Alignment, Borders, Color, Style, TextModifiers};
+use tuirealm::props::{Alignment, Borders, Color, PropPayload, PropValue, Style, TextModifiers};
 use tuirealm::ratatui::layout::Rect;
 use tuirealm::ratatui::widgets::{BorderType, Paragraph};
 use tuirealm::{
@@ -54,8 +54,15 @@ impl Counter {
         self
     }
 
-    pub fn value(mut self, n: usize) -> Self {
-        self.attr(Attribute::Value, AttrValue::Length(n));
+    pub fn value(mut self, n: Option<usize>) -> Self {
+        if let Some(n) = n {
+            self.attr(
+                Attribute::Value,
+                AttrValue::Payload(PropPayload::One(PropValue::Usize(n))),
+            );
+        } else {
+            self.attr(Attribute::Value, AttrValue::Payload(PropPayload::None));
+        }
         self
     }
 
@@ -84,10 +91,15 @@ impl Counter {
         self
     }
 
-    pub fn get_state(&self) -> usize {
-        self.props
-            .get_or(Attribute::Value, AttrValue::Length(99))
-            .unwrap_length()
+    pub fn get_state(&self) -> Option<usize> {
+        match self
+            .props
+            .get(Attribute::Value)
+            .map(|v| v.unwrap_payload())?
+        {
+            PropPayload::One(PropValue::Usize(v)) => Some(v),
+            _ => None,
+        }
     }
 }
 
@@ -97,7 +109,11 @@ impl MockComponent for Counter {
         if self.props.get_or(Attribute::Display, AttrValue::Flag(true)) == AttrValue::Flag(true) {
             // Get properties
             let value = self.get_state();
-            let text = format!("Delete ({value})");
+            let text = if let Some(value) = value {
+                format!("Delete Selected ({value})")
+            } else {
+                "Delete Selected (-)".to_string()
+            };
 
             let alignment = self
                 .props
@@ -162,7 +178,11 @@ impl MockComponent for Counter {
     }
 
     fn state(&self) -> State {
-        State::One(StateValue::Usize(self.get_state()))
+        let Some(state) = self.get_state() else {
+            return State::None;
+        };
+
+        State::One(StateValue::Usize(state))
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
@@ -185,7 +205,7 @@ pub struct TECounterDelete {
 }
 
 impl TECounterDelete {
-    pub fn new(initial_value: usize, config: SharedTuiSettings) -> Self {
+    pub fn new(initial_value: Option<usize>, config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Counter::default()

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -54,8 +54,8 @@ impl Counter {
         self
     }
 
-    pub fn value(mut self, n: isize) -> Self {
-        self.attr(Attribute::Value, AttrValue::Number(n));
+    pub fn value(mut self, n: usize) -> Self {
+        self.attr(Attribute::Value, AttrValue::Length(n));
         self
     }
 
@@ -84,10 +84,10 @@ impl Counter {
         self
     }
 
-    pub fn get_state(&self) -> isize {
+    pub fn get_state(&self) -> usize {
         self.props
-            .get_or(Attribute::Value, AttrValue::Number(99))
-            .unwrap_number()
+            .get_or(Attribute::Value, AttrValue::Length(99))
+            .unwrap_length()
     }
 }
 
@@ -162,7 +162,7 @@ impl MockComponent for Counter {
     }
 
     fn state(&self) -> State {
-        State::One(StateValue::Isize(self.get_state()))
+        State::One(StateValue::Usize(self.get_state()))
     }
 
     fn perform(&mut self, cmd: Cmd) -> CmdResult {
@@ -185,7 +185,7 @@ pub struct TECounterDelete {
 }
 
 impl TECounterDelete {
-    pub fn new(initial_value: isize, config: SharedTuiSettings) -> Self {
+    pub fn new(initial_value: usize, config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Counter::default()

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -340,6 +340,10 @@ impl Model {
                 song.set_album(album);
             }
 
+            let tracker_id = song_tag.id();
+            self.download_tracker.increase_one(tracker_id);
+
+            // TODO: consider a way to not do it "block_on"
             // this needs to be wrapped as this is not running another thread but some main-runtime thread and so needs to inform the runtime to hand-off other tasks
             // though i am not fully sure if that is 100% the case, this avoid the panic though
             let (lyric_string, artwork) = tokio::task::block_in_place(move || {
@@ -347,6 +351,8 @@ impl Model {
                     tokio::join!(song_tag.fetch_lyric(), song_tag.fetch_photo())
                 })
             });
+
+            self.download_tracker.decrease_one(tracker_id);
 
             if let Ok(Some(lyric_string)) = lyric_string {
                 song.set_lyric(&lyric_string, lang_ext);

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -291,7 +291,7 @@ impl Model {
                 song.set_genre(&genre);
             }
             song.save_tag()?;
-            self.init_by_song(&song);
+            self.init_by_song(song);
             self.playlist_update_library_delete();
         }
         Ok(())
@@ -333,7 +333,7 @@ impl Model {
             }
 
             song.save_tag()?;
-            self.init_by_song(&song);
+            self.init_by_song(song);
             self.playlist_update_library_delete();
             // self.library_sync(song.file());
         }

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -42,7 +42,7 @@ impl Model {
             TEMsg::TESelectLyricOk(index) => {
                 if let Some(mut song) = self.tageditor_song.clone() {
                     song.set_lyric_selected_index(*index);
-                    self.init_by_song(&song);
+                    self.init_by_song(song);
                 }
             }
             TEMsg::TESearch => {

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -340,16 +340,34 @@ impl Model {
 
         let vec_lang: Vec<PropValue> = lf
             .into_iter()
-            .map(|lyric| PropValue::Str(lyric.description))
+            .enumerate()
+            .map(|(idx, v)| {
+                let val = v.description;
+                // match idx with Delete counter
+                let idx = idx + 1;
+                if val.is_empty() {
+                    format!("{idx} - {}", v.lang)
+                } else {
+                    format!("{idx} - {val}")
+                }
+            })
+            .map(PropValue::Str)
             .collect();
 
         let vec_lang_len = vec_lang.len();
-        let Some(vec_lang_selected) = s.lyric_selected() else {
+        // get access to "Lyric" instance for text and modified description for display
+        let (Some(vec_lang_selected), Some(selected_desc)) =
+            (s.lyric_selected(), vec_lang.get(s.lyric_selected_index()))
+        else {
             // this should not happen as if it is Some above, there should be at least one entry in the vec.
             self.init_by_song_no_lyric();
             return;
         };
-        let selected_description = &vec_lang_selected.description;
+        // TODO: replace with tui-realm "as_str" once available
+        let PropValue::Str(selected_desc) = selected_desc else {
+            unreachable!()
+        };
+        let selected_description = format!("Lyrics for {selected_desc}");
 
         let vec_lyric = vec_lang_selected
             .text
@@ -378,7 +396,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::TextareaLyric),
                 Attribute::Title,
-                AttrValue::Title((format!("{selected_description} Lyrics"), Alignment::Left))
+                AttrValue::Title((selected_description, Alignment::Left))
             )
             .is_ok());
 
@@ -420,7 +438,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::TextareaLyric),
                 Attribute::Title,
-                AttrValue::Title(("Empty Lyric".to_string(), Alignment::Left))
+                AttrValue::Title(("Empty Lyrics".to_string(), Alignment::Left))
             )
             .is_ok());
         assert!(self

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -219,7 +219,7 @@ impl Model {
         )?;
         self.app.remount(
             Id::TagEditor(IdTagEditor::CounterDelete),
-            Box::new(TECounterDelete::new(5, self.config_tui.clone())),
+            Box::new(TECounterDelete::new(None, self.config_tui.clone())),
             Vec::new(),
         )?;
         self.app.remount(
@@ -389,7 +389,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::CounterDelete),
                 Attribute::Value,
-                AttrValue::Length(selected_index_display),
+                AttrValue::Payload(PropPayload::One(PropValue::Usize(selected_index_display))),
             )
             .is_ok());
         assert!(self
@@ -430,7 +430,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::CounterDelete),
                 Attribute::Value,
-                AttrValue::Length(0),
+                AttrValue::Payload(PropPayload::None),
             )
             .is_ok());
 

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -372,7 +372,7 @@ impl Model {
 
         let vec_lyric = vec_lang_selected
             .text
-            .split('\n')
+            .lines()
             .map(|line| PropValue::TextSpan(TextSpan::from(line)))
             .collect();
 

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -354,10 +354,10 @@ impl Model {
             .map(PropValue::Str)
             .collect();
 
-        let vec_lang_len = vec_lang.len();
+        let selected_index = s.lyric_selected_index();
         // get access to "Lyric" instance for text and modified description for display
         let (Some(vec_lang_selected), Some(selected_desc)) =
-            (s.lyric_selected(), vec_lang.get(s.lyric_selected_index()))
+            (s.lyric_selected(), vec_lang.get(selected_index))
         else {
             // this should not happen as if it is Some above, there should be at least one entry in the vec.
             self.init_by_song_no_lyric();
@@ -368,6 +368,7 @@ impl Model {
             unreachable!()
         };
         let selected_description = format!("Lyrics for {selected_desc}");
+        let selected_index_display = selected_index + 1;
 
         let vec_lyric = vec_lang_selected
             .text
@@ -388,7 +389,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::CounterDelete),
                 Attribute::Value,
-                AttrValue::Length(vec_lang_len),
+                AttrValue::Length(selected_index_display),
             )
             .is_ok());
         assert!(self

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -29,7 +29,6 @@ use crate::ui::components::{
 use crate::ui::model::Model;
 use crate::ui::utils::{draw_area_in_absolute, draw_area_top_right_absolute};
 use anyhow::Result;
-use std::convert::TryFrom;
 use std::path::Path;
 use termusiclib::track::Track;
 use termusiclib::types::{Id, IdTagEditor};
@@ -357,16 +356,14 @@ impl Model {
                 )),
             )
             .is_ok());
-        if let Ok(vec_lang_len_isize) = isize::try_from(vec_lang.len()) {
-            assert!(self
-                .app
-                .attr(
-                    &Id::TagEditor(IdTagEditor::CounterDelete),
-                    Attribute::Value,
-                    AttrValue::Number(vec_lang_len_isize),
-                )
-                .is_ok());
-        }
+        assert!(self
+            .app
+            .attr(
+                &Id::TagEditor(IdTagEditor::CounterDelete),
+                Attribute::Value,
+                AttrValue::Length(vec_lang.len()),
+            )
+            .is_ok());
         let mut vec_lyric: Vec<TextSpan> = vec![];
         if let Some(f) = s.lyric_selected() {
             for line in f.text.split('\n') {
@@ -416,7 +413,7 @@ impl Model {
             .attr(
                 &Id::TagEditor(IdTagEditor::CounterDelete),
                 Attribute::Value,
-                AttrValue::Number(0),
+                AttrValue::Length(0),
             )
             .is_ok());
 

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -375,7 +375,7 @@ impl Model {
         let vec_lyric = vec_lang_selected
             .text
             .lines()
-            .map(|line| PropValue::TextSpan(TextSpan::from(line)))
+            .map(|line| PropValue::TextSpan(TextSpan::from(line.trim())))
             .collect();
 
         assert!(self

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -252,7 +252,7 @@ impl Model {
         self.app
             .active(&Id::TagEditor(IdTagEditor::InputArtist))
             .ok();
-        self.init_by_song(&track);
+        self.init_by_song(track);
 
         if let Err(err) = self.update_photo() {
             self.mount_error_popup(err.context("update_photo"));
@@ -285,10 +285,12 @@ impl Model {
         }
     }
 
-    // initialize the value in tageditor based on info from Song
+    /// Set the Lyric section of the tag-editor to the Lyrics based on the provided Track
     #[allow(clippy::too_many_lines)]
-    pub fn init_by_song(&mut self, s: &Track) {
-        self.tageditor_song = Some(s.clone());
+    pub fn init_by_song(&mut self, s: Track) {
+        self.tageditor_song = Some(s);
+        // Unwrap safe as we literally just assigned it
+        let s = self.tageditor_song.as_ref().unwrap();
         if let Some(artist) = s.artist() {
             assert!(self
                 .app
@@ -411,6 +413,7 @@ impl Model {
             .is_ok());
     }
 
+    /// Set the Lyric section of the tag-editor to "No Lyrics" (ie clear state)
     fn init_by_song_no_lyric(&mut self) {
         assert!(self
             .app


### PR DESCRIPTION
This PR improves the Tag-Editor experience by:
- doing less work (less clones, iterations)
- have the search be non-blocking and have feedback (via download spinner & "Loading.." table text)
- fix possible messed-up display if lyric text was split with `\r\n`
- properly reflect `Delete` Lyric index of the selected index (instead of having based on the length of the array), now it matches the actual behavior of only removing the selected lyric frame (instead of the implied all)
- in Lyric Selection, display the index of the frame (beginning from 1) and if description is empty, fallback to language.

To make the search task non-block, i also changed the `DownloadTracker` to be Send-able across Tasks & Threads.