### PR TITLE
fix(playback::rusty::sink::append): track time before speed change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix: change Lyric::adjust_offset to not work invertedly for below 10 seconds anymore.
 - Fix: fix accidental invertion of `is_absolute` for path playlist values causing items to not have the correct path.
 - Fix: create and save config if it does not exist, without needing a successful connect first.
+- Fix: in `rusty` backen, correctly track the time before speed change.
 - Fix(tui): base "no lyrics available" message on the same value as actual parsed lyrics.
 - Fix(tui): not being able to parse themes that use `0x` as the prefix.
 - Fix(tui): change that the default Theme is not using bad colors.

--- a/playback/src/rusty_backend/sink.rs
+++ b/playback/src/rusty_backend/sink.rs
@@ -122,8 +122,8 @@ impl Sink {
 
         let progress_tx = self.picmd_tx.clone();
         let source = source
-            .speed(1.0)
             .track_position()
+            .speed(1.0)
             .pausable(false)
             .amplify(1.0)
             .skippable()
@@ -131,7 +131,7 @@ impl Sink {
             .periodic_access(Duration::from_millis(500), move |src| {
                 progress_tx
                     .send(PlayerInternalCmd::Progress(
-                        src.inner().inner().inner().inner().get_pos(),
+                        src.inner().inner().inner().inner().inner().get_pos(),
                     ))
                     .ok();
             })
@@ -154,7 +154,8 @@ impl Sink {
                             *controls.position.write() = Duration::ZERO;
                         }
                     }
-                    *controls.position.write() = src.inner().inner().inner().inner().get_pos();
+                    *controls.position.write() =
+                        src.inner().inner().inner().inner().inner().get_pos();
 
                     let amp = src.inner_mut().inner_mut();
                     amp.set_factor(*controls.volume.lock());
@@ -164,7 +165,6 @@ impl Sink {
                     #[cfg(not(feature = "rusty-soundtouch"))]
                     {
                         amp.inner_mut()
-                            .inner_mut()
                             .inner_mut()
                             .set_factor(*controls.speed.lock());
                     }


### PR DESCRIPTION
to match behavior with other backends and to be what would be expected of knowing where in the track we are.

This also fixes #102 to my knowledge, unless i missed something.

This had been messed-up by me in 397a123f30899215813c031a492688e09472d58e.