### PR TITLE
fix(lib::ueberzug): silence stdout output

### DIFF
--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -96,7 +96,7 @@ impl UeInstance {
     }
 
     fn run_ueberzug_cmd(&mut self, cmd: &str) -> Result<()> {
-        let Some(ueberzug) = self.try_wait_spawn(["layer"])? else {
+        let Some(ueberzug) = self.try_wait_spawn(["layer", "--silent"])? else {
             return Ok(());
         };
 
@@ -112,7 +112,7 @@ impl UeInstance {
         // debug!("ueberzug forced sixel");
 
         let Some(ueberzug) = self.try_wait_spawn(
-            ["layer"],
+            ["layer", "--silent"],
             // ["layer", "--silent", "--no-cache", "--output", "sixel"]
             // ["layer", "--sixel"]
             // ["--sixel"]


### PR DESCRIPTION
`ueberzugpp` does not output to stdout, but to stderr from my testing, which is not a problem, but `ueberzugpp-new` currently outputs to stdout instead of stderr, messing-up the display.
This should not be breaking as both projects also output logs to `/tmp/ueberzug-USER.log`.

For context, i opened a issue in the `ueberzugpp-new` repo https://github.com/jstkdng/ueberzugpp-new/issues/5.

re #440