### PR TITLE
Option to disable cover features at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## ChangeLog
 
+### next
+
+- Change(tui): rename cli option `--disable-cover`  to `--hide-cover`
+- Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
+
 ### [V0.10.0]
 - Released on: March 8, 2025.
 - Change: move the "no backend selected" compile error to the "-server" package instead of "-playback" (no need to specify a feature when compiling "termusic"(tui) now)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change(tui): rename cli option `--disable-cover`  to `--hide-cover`
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
+- Fix(tui): set `ueberzug` command to `--silent`.
 
 ### [V0.10.0]
 - Released on: March 8, 2025.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can optionally install [yt-dlp](https://github.com/yt-dlp/yt-dlp/) and [FFmp
 #### Album cover support
 
 To display covers in the terminal itself, feature `cover` can be enabled.
-To only enable specific protocols for cover support, see [Cargo.toml#features](./Cargo.toml).
+To only enable specific protocols for cover support, see [tui/Cargo.toml#features](./tui/Cargo.toml).
 
 Feature `cover-ueberzug` will require some ueberzug implementation to be present at runtime.
 

--- a/lib/src/config/tui_overlay.rs
+++ b/lib/src/config/tui_overlay.rs
@@ -11,6 +11,11 @@ pub struct TuiOverlay {
     ///
     /// (disables ueberzug, sixel, iterm, kitty image displaying)
     pub coverart_hidden_overwrite: Option<bool>,
+
+    /// Enable/Disable checking for cover support.
+    ///
+    /// If `false`, will treat as if no cover features are compiled-in.
+    pub cover_features: bool,
 }
 
 impl TuiOverlay {
@@ -24,5 +29,11 @@ impl TuiOverlay {
         } else {
             self.settings.coverart.hidden
         }
+    }
+
+    /// Get whether cover features should be enabled or not, regardless if they are compiled-in or not.
+    #[must_use]
+    pub fn cover_features_enabled(&self) -> bool {
+        self.cover_features
     }
 }

--- a/lib/src/ueberzug.rs
+++ b/lib/src/ueberzug.rs
@@ -45,6 +45,8 @@ pub struct UeInstance {
 
 impl Default for UeInstance {
     fn default() -> Self {
+        info!("Potentially using ueberzug");
+
         Self {
             ueberzug: UeInstanceState::New,
         }

--- a/lib/src/xywh.rs
+++ b/lib/src/xywh.rs
@@ -59,8 +59,8 @@ impl Default for Xywh {
         let width = 20_u32;
         let height = 20_u32;
         let (term_width, term_height) = Self::get_terminal_size_u32();
-        let x = term_width - 1;
-        let y = term_height - 9;
+        let x = term_width.saturating_sub(1);
+        let y = term_height.saturating_sub(9);
 
         Self {
             x_between_1_100: 100,

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -34,8 +34,11 @@ pub struct Args {
     /// With no `MUSIC_DIRECTORY`, use config in `~/.config/termusic/config.toml`,
     /// default is ~/Music.
     pub music_directory: Option<PathBuf>,
-    /// Not showing album cover. default is showing.  
+    /// Not showing album cover. default is showing.
     #[arg(short = 'c', long)]
+    pub hide_cover: bool,
+    /// Disable cover support, even if compiled-in.
+    #[arg(long)]
     pub disable_cover: bool,
     /// Not showing discord representation. default is showing.
     #[arg(short, long)]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -252,11 +252,12 @@ fn get_config(args: &cli::Args) -> Result<CombinedSettings> {
 
     let config_tui = TuiConfigVersionedDefaulted::from_config_path()?.into_settings();
 
-    let coverart_hidden_overwrite = if args.disable_cover { Some(true) } else { None };
+    let coverart_hidden_overwrite = if args.hide_cover { Some(true) } else { None };
 
     let overlay_tui = TuiOverlay {
         settings: config_tui,
         coverart_hidden_overwrite,
+        cover_features: !args.disable_cover,
     };
 
     Ok(CombinedSettings {

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -242,7 +242,7 @@ impl Model {
         match self.viuer_supported {
             ViuerSupported::NotSupported => {
                 #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
-                {
+                if let Some(instance) = self.ueberzug_instance.as_mut() {
                     let mut cache_file = dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
                     cache_file.push("termusic");
                     if !cache_file.exists() {
@@ -254,8 +254,7 @@ impl Model {
                         anyhow::bail!("cover file is not saved correctly");
                     }
                     if let Some(file) = cache_file.as_path().to_str() {
-                        self.ueberzug_instance
-                            .draw_cover_ueberzug(file, &xywh, false)?;
+                        instance.draw_cover_ueberzug(file, &xywh, false)?;
                     }
                 }
             }
@@ -304,7 +303,9 @@ impl Model {
             }
             ViuerSupported::NotSupported => {
                 #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
-                self.ueberzug_instance.clear_cover_ueberzug()?;
+                if let Some(instance) = self.ueberzug_instance.as_mut() {
+                    instance.clear_cover_ueberzug()?;
+                }
             }
         }
         Ok(())

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -224,6 +224,9 @@ impl Model {
         let (tx3, rx3): (Sender<SearchLyricState>, Receiver<SearchLyricState>) = mpsc::channel();
 
         let viuer_supported = get_viuer_support();
+
+        info!("Using viuer protocol {:#?}", viuer_supported);
+
         let db = DataBase::new(&config_server.read()).expect("Open Library Database");
         let db_criteria = SearchCriteria::Artist;
         let terminal = TerminalBridge::new_crossterm().expect("Could not initialize terminal");


### PR DESCRIPTION
This PR moves existing cli option `--disable-cover` to `--hide-cover` and adds a new `--disable-cover` which will make the TUI behave as if no cover features are compiled-in.
Additionally:
- dont init a ueberzug instance if viuer supports it.
- Log which viuer protocol is used and if ueberzug gets activated.
- random fix when terminal size / height is 0 (instead of a panic)

re #449 and likely #451