### PR TITLE
fix(tui::ui::components::xywh::show_image): force viuer to only use the protocol we probed for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
+- Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.
 
 ### [V0.10.0]
 - Released on: March 8, 2025.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change(tui): rename cli option `--disable-cover`  to `--hide-cover`
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
 - Fix(tui): set `ueberzug` command to `--silent`.
+- Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 
 ### [V0.10.0]
 - Released on: March 8, 2025.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4508,6 +4508,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "ctrlc",
  "dirs",
  "escaper",
  "flexi_logger",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -26,6 +26,7 @@ termusic-playback.workspace = true # = {path = "playback/"}
 anyhow.workspace = true
 bytes.workspace = true
 clap.workspace = true
+ctrlc.workspace = true
 dirs.workspace = true
 id3.workspace = true # = "1"
 image.workspace = true # = "0.24"

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -271,6 +271,11 @@ impl Model {
                     y: xywh.y as i16,
                     width: Some(xywh.width),
                     height: None,
+                    // Force the specific protocol we probed for earlier
+                    use_iterm: self.viuer_supported == ViuerSupported::ITerm,
+                    use_kitty: self.viuer_supported == ViuerSupported::Kitty,
+                    #[cfg(feature = "cover-viuer-sixel")]
+                    use_sixel: self.viuer_supported == ViuerSupported::Sixel,
                     ..viuer::Config::default()
                 };
                 viuer::print(img, &config).context("viuer::print")?;


### PR DESCRIPTION
This is necessary as viuer will always probe for all enabled protocols on each print until it finds a supported one, but because of likely improper implementation, it could cause a infinite loop of waiting for a response which never comes, freezing the TUI.

re #449

@Porkepix could you test this PR without `--disable-cover` or `--hide-cover` and with features `cover`(all) enabled across multiple TUI starts & tracks?

PS: this PR is marked as DRAFT until confirmed that it fixes the issue.