### PR TITLE
playback: remove dependency `async_channel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,6 @@ name = "termusic-playback"
 version = "0.10.0"
 dependencies = [
  "anyhow",
- "async-channel",
  "async-trait",
  "base64",
  "discord-rich-presence",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ termusic-playback = { path = "playback/", version = "0.10.0", default-features =
 ahash = "^0.8"
 anyhow = { version = "1.0.97", features = ["backtrace"] }
 thiserror = "2.0.12"
-async-channel = "2.2"
 async-trait = "0.1.88"
 base64 = "0.22"
 bytes = "1.10"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -22,7 +22,6 @@ doctest = false
 [dependencies]
 termusic-lib.workspace = true
 anyhow.workspace = true
-async-channel.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 discord-rich-presence.workspace = true

--- a/playback/src/backends/gstreamer/mod.rs
+++ b/playback/src/backends/gstreamer/mod.rs
@@ -183,7 +183,7 @@ impl GStreamerBackend {
 
         let eos_watcher_clone = eos_watcher.clone();
 
-        // Asynchronous channel to communicate with main() with
+        // Asynchronous channel to communicate internal events
         let (main_tx, main_rx) = mpsc::channel(3);
         let message_tx = main_tx.clone();
 
@@ -200,8 +200,6 @@ impl GStreamerBackend {
             .build()
             .expect("make scaletempo error");
 
-        // let sink = gst::ElementFactory::make_with_name("autoaudiosink",
-        // Some("autoaudiosink")).unwrap();
         let sink = gst::ElementFactory::make("autoaudiosink")
             .name("audiosink")
             .build()
@@ -224,11 +222,6 @@ impl GStreamerBackend {
         bin.add_pad(&ghost_pad).expect("bin add pad failed");
         playbin.set_property("audio-sink", &bin);
 
-        // let sink = gst::ElementFactory::make("autoaudiosink")
-        //     .build()
-        //     .expect("audio sink make error");
-
-        // playbin.set_property("audio-sink", &sink);
         // Set flags to show Audio and Video but ignore Subtitles
         let flags = playbin.property_value("flags");
         let flags_class = FlagsClass::with_type(flags.type_()).unwrap();

--- a/playback/src/backends/gstreamer/mod.rs
+++ b/playback/src/backends/gstreamer/mod.rs
@@ -335,15 +335,15 @@ impl GStreamerBackend {
             gst::MessageView::Error(e) => error!("GStreamer Error: {}", e.error()),
             gst::MessageView::Tag(tag) => {
                 if let Some(title) = tag.tags().get::<gst::tags::Title>() {
-                    info!("  Title: {}", title.get());
+                    info!("Title: {}", title.get());
                     *media_title.lock() = title.get().into();
                 }
                 // if let Some(artist) = tag.tags().get::<gst::tags::Artist>() {
-                //     info!("  Artist: {}", artist.get());
+                //     info!("Artist: {}", artist.get());
                 //     // *media_title.lock() = artist.get().to_string();
                 // }
                 // if let Some(album) = tag.tags().get::<gst::tags::Album>() {
-                //     info!("  Album: {}", album.get());
+                //     info!("Album: {}", album.get());
                 //     // *media_title.lock() = album.get().to_string();
                 // }
             }
@@ -393,7 +393,7 @@ impl GStreamerBackend {
                     }
                 }
                 PlayerInternalCmd::AboutToFinish => {
-                    info!("about to finish received by gstreamer internal !!!!!");
+                    info!("about to finish received by gstreamer internal");
                     if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
                         error!("error in sending AboutToFinish: {e}");
                     }

--- a/playback/src/backends/gstreamer/mod.rs
+++ b/playback/src/backends/gstreamer/mod.rs
@@ -20,8 +20,8 @@ use tokio::sync::mpsc;
 
 use crate::{MediaInfo, PlayerCmd, PlayerProgress, PlayerTrait, Speed, Volume};
 
-/// This trait allows for easy conversion of a path to a URI
-pub trait PathToURI {
+/// This trait allows for easy conversion of a path to a URI for gstreamer
+trait PathToURI {
     fn to_uri(&self) -> String;
 }
 


### PR DESCRIPTION
This PR removes dependency `async_channel` as we already depend on tokio, so we can just use `tokio::sync::mpsc` instead.
Additionally includes some slight formatting changes:
- remove outdated commented-out code
- align variable names with other backends
- convert channel proxy thread to task
- dont have a trait pub that is specific to the backend