### PR TITLE
chore(workflows/build): set extra cache key with rust version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev gstreamer-player-1
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust }}
 
       - name: Run cargo check
         run: cargo check --workspace --features cover,all-backends
@@ -90,6 +92,8 @@ jobs:
             # brew install mpv
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust }}
 
       - name: Run cargo check
         run: cargo check --workspace
@@ -119,6 +123,8 @@ jobs:
         run: choco install protoc
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.rust }}
 
       - name: Run cargo check
         run: cargo check --workspace


### PR DESCRIPTION
As with different rust versions, rust will always re-compile fully. And if there is only one key, the other run may fully need to re-compile.

Note that at current, the extra keys are only necessary for the `linux` tests, but in the future, if something changes on the other tests, it is available too.

PS: this is marked DRAFT as i wanna confirm the CI runs correctly before potentially merging.