### PR TITLE
Add `Native` Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@
 - Change: updated MSRV to 1.82.
 - Change(tui): rename cli option `--disable-cover`  to `--hide-cover`
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
+- Feat(tui): add native theme support. Useful for example for `pywal`.
 - Feat(server): for rusty backend, add feature `rusty-simd` to enable SIMD instructions for decoding.
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.
-- Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix(tui): on track change, dont select "current track" playlist item if the old "current track" was not selected.
 - Fix(tui): re-select the (approximately) same playlist item after a shuffle.
+- Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -193,13 +193,13 @@ pub enum ThemeColorParseError {
 #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(try_from = "String")]
 #[serde(into = "String")]
-pub struct ThemeColor {
+pub struct ThemeColorHex {
     pub r: u8,
     pub g: u8,
     pub b: u8,
 }
 
-impl ThemeColor {
+impl ThemeColorHex {
     /// Create a new instance with those values
     #[must_use]
     pub const fn new(r: u8, g: u8, b: u8) -> Self {
@@ -235,7 +235,7 @@ impl ThemeColor {
     }
 }
 
-impl TryFrom<String> for ThemeColor {
+impl TryFrom<String> for ThemeColorHex {
     type Error = ThemeColorParseError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
@@ -243,7 +243,7 @@ impl TryFrom<String> for ThemeColor {
     }
 }
 
-impl TryFrom<&str> for ThemeColor {
+impl TryFrom<&str> for ThemeColorHex {
     type Error = ThemeColorParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -251,14 +251,14 @@ impl TryFrom<&str> for ThemeColor {
     }
 }
 
-impl From<ThemeColor> for String {
-    fn from(val: ThemeColor) -> Self {
-        ThemeColor::to_hex(&val)
+impl From<ThemeColorHex> for String {
+    fn from(val: ThemeColorHex) -> Self {
+        ThemeColorHex::to_hex(&val)
     }
 }
 
-impl From<ThemeColor> for Color {
-    fn from(val: ThemeColor) -> Self {
+impl From<ThemeColorHex> for Color {
+    fn from(val: ThemeColorHex) -> Self {
         Color::Rgb(val.r, val.g, val.b)
     }
 }
@@ -348,15 +348,15 @@ impl ThemeColors {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ThemePrimary {
-    pub background: ThemeColor,
-    pub foreground: ThemeColor,
+    pub background: ThemeColorHex,
+    pub foreground: ThemeColorHex,
 }
 
 impl Default for ThemePrimary {
     fn default() -> Self {
         Self {
-            background: ThemeColor::new(0x10, 0x14, 0x21),
-            foreground: ThemeColor::new(0xff, 0xfb, 0xf6),
+            background: ThemeColorHex::new(0x10, 0x14, 0x21),
+            foreground: ThemeColorHex::new(0xff, 0xfb, 0xf6),
         }
     }
 }
@@ -375,14 +375,14 @@ impl TryFrom<YAMLThemePrimary> for ThemePrimary {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ThemeCursor {
-    pub text: ThemeColor,
-    pub cursor: ThemeColor,
+    pub text: ThemeColorHex,
+    pub cursor: ThemeColorHex,
 }
 
 impl Default for ThemeCursor {
     fn default() -> Self {
         Self {
-            text: ThemeColor::new(0x1e, 0x1e, 0x1e),
+            text: ThemeColorHex::new(0x1e, 0x1e, 0x1e),
             cursor: default_fff(),
         }
     }
@@ -402,27 +402,27 @@ impl TryFrom<YAMLThemeCursor> for ThemeCursor {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ThemeNormal {
-    pub black: ThemeColor,
-    pub red: ThemeColor,
-    pub green: ThemeColor,
-    pub yellow: ThemeColor,
-    pub blue: ThemeColor,
-    pub magenta: ThemeColor,
-    pub cyan: ThemeColor,
-    pub white: ThemeColor,
+    pub black: ThemeColorHex,
+    pub red: ThemeColorHex,
+    pub green: ThemeColorHex,
+    pub yellow: ThemeColorHex,
+    pub blue: ThemeColorHex,
+    pub magenta: ThemeColorHex,
+    pub cyan: ThemeColorHex,
+    pub white: ThemeColorHex,
 }
 
 impl Default for ThemeNormal {
     fn default() -> Self {
         Self {
-            black: ThemeColor::new(0x2e, 0x2e, 0x2e),
-            red: ThemeColor::new(0xeb, 0x41, 0x29),
-            green: ThemeColor::new(0xab, 0xe0, 0x47),
-            yellow: ThemeColor::new(0xf6, 0xc7, 0x44),
-            blue: ThemeColor::new(0x47, 0xa0, 0xf3),
-            magenta: ThemeColor::new(0x7b, 0x5c, 0xb0),
-            cyan: ThemeColor::new(0x64, 0xdb, 0xed),
-            white: ThemeColor::new(0xe5, 0xe9, 0xf0),
+            black: ThemeColorHex::new(0x2e, 0x2e, 0x2e),
+            red: ThemeColorHex::new(0xeb, 0x41, 0x29),
+            green: ThemeColorHex::new(0xab, 0xe0, 0x47),
+            yellow: ThemeColorHex::new(0xf6, 0xc7, 0x44),
+            blue: ThemeColorHex::new(0x47, 0xa0, 0xf3),
+            magenta: ThemeColorHex::new(0x7b, 0x5c, 0xb0),
+            cyan: ThemeColorHex::new(0x64, 0xdb, 0xed),
+            white: ThemeColorHex::new(0xe5, 0xe9, 0xf0),
         }
     }
 }
@@ -447,26 +447,26 @@ impl TryFrom<YAMLThemeNormal> for ThemeNormal {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ThemeBright {
-    pub black: ThemeColor,
-    pub red: ThemeColor,
-    pub green: ThemeColor,
-    pub yellow: ThemeColor,
-    pub blue: ThemeColor,
-    pub magenta: ThemeColor,
-    pub cyan: ThemeColor,
-    pub white: ThemeColor,
+    pub black: ThemeColorHex,
+    pub red: ThemeColorHex,
+    pub green: ThemeColorHex,
+    pub yellow: ThemeColorHex,
+    pub blue: ThemeColorHex,
+    pub magenta: ThemeColorHex,
+    pub cyan: ThemeColorHex,
+    pub white: ThemeColorHex,
 }
 
 impl Default for ThemeBright {
     fn default() -> Self {
         Self {
-            black: ThemeColor::new(0x56, 0x56, 0x56),
-            red: ThemeColor::new(0xec, 0x53, 0x57),
-            green: ThemeColor::new(0xc0, 0xe1, 0x7d),
-            yellow: ThemeColor::new(0xf9, 0xda, 0x6a),
-            blue: ThemeColor::new(0x49, 0xa4, 0xf8),
-            magenta: ThemeColor::new(0xa4, 0x7d, 0xe9),
-            cyan: ThemeColor::new(0x99, 0xfa, 0xf2),
+            black: ThemeColorHex::new(0x56, 0x56, 0x56),
+            red: ThemeColorHex::new(0xec, 0x53, 0x57),
+            green: ThemeColorHex::new(0xc0, 0xe1, 0x7d),
+            yellow: ThemeColorHex::new(0xf9, 0xda, 0x6a),
+            blue: ThemeColorHex::new(0x49, 0xa4, 0xf8),
+            magenta: ThemeColorHex::new(0xa4, 0x7d, 0xe9),
+            cyan: ThemeColorHex::new(0x99, 0xfa, 0xf2),
             white: default_fff(),
         }
     }
@@ -500,17 +500,17 @@ fn default_author() -> String {
 }
 
 #[inline]
-fn default_fff() -> ThemeColor {
-    ThemeColor::new(0xFF, 0xFF, 0xFF)
+fn default_fff() -> ThemeColorHex {
+    ThemeColorHex::new(0xFF, 0xFF, 0xFF)
 }
 
 mod v1_interop {
     use super::{
-        ThemeBright, ThemeColor, ThemeColors, ThemeCursor, ThemeNormal, ThemePrimary, ThemeWrap,
+        ThemeBright, ThemeColorHex, ThemeColors, ThemeCursor, ThemeNormal, ThemePrimary, ThemeWrap,
     };
     use crate::config::v1;
 
-    impl From<v1::AlacrittyColor> for ThemeColor {
+    impl From<v1::AlacrittyColor> for ThemeColorHex {
         fn from(value: v1::AlacrittyColor) -> Self {
             Self {
                 r: value.r,
@@ -620,37 +620,37 @@ mod tests {
     use super::ThemeColors;
 
     mod theme_color {
-        use super::super::ThemeColor;
+        use super::super::ThemeColorHex;
 
         #[test]
         fn should_parse_hashtag() {
             assert_eq!(
-                ThemeColor::new(1, 2, 3),
-                ThemeColor::from_hex("#010203").unwrap()
+                ThemeColorHex::new(1, 2, 3),
+                ThemeColorHex::from_hex("#010203").unwrap()
             );
             assert_eq!(
-                ThemeColor::new(255, 255, 255),
-                ThemeColor::from_hex("#ffffff").unwrap()
+                ThemeColorHex::new(255, 255, 255),
+                ThemeColorHex::from_hex("#ffffff").unwrap()
             );
             assert_eq!(
-                ThemeColor::new(0, 0, 0),
-                ThemeColor::from_hex("#000000").unwrap()
+                ThemeColorHex::new(0, 0, 0),
+                ThemeColorHex::from_hex("#000000").unwrap()
             );
         }
 
         #[test]
         fn should_parse_0x() {
             assert_eq!(
-                ThemeColor::new(1, 2, 3),
-                ThemeColor::from_hex("0x010203").unwrap()
+                ThemeColorHex::new(1, 2, 3),
+                ThemeColorHex::from_hex("0x010203").unwrap()
             );
             assert_eq!(
-                ThemeColor::new(255, 255, 255),
-                ThemeColor::from_hex("0xffffff").unwrap()
+                ThemeColorHex::new(255, 255, 255),
+                ThemeColorHex::from_hex("0xffffff").unwrap()
             );
             assert_eq!(
-                ThemeColor::new(0, 0, 0),
-                ThemeColor::from_hex("0x000000").unwrap()
+                ThemeColorHex::new(0, 0, 0),
+                ThemeColorHex::from_hex("0x000000").unwrap()
             );
         }
     }

--- a/lib/src/config/v2/tui/theme/mod.rs
+++ b/lib/src/config/v2/tui/theme/mod.rs
@@ -5,9 +5,8 @@ use std::{fs::File, io::BufReader, num::ParseIntError, path::Path};
 use serde::{Deserialize, Serialize};
 use tuirealm::props::Color;
 
-use crate::config::{
-    v1::AlacrittyColor,
-    yaml_theme::{YAMLTheme, YAMLThemeBright, YAMLThemeCursor, YAMLThemeNormal, YAMLThemePrimary},
+use crate::config::yaml_theme::{
+    YAMLTheme, YAMLThemeBright, YAMLThemeCursor, YAMLThemeNormal, YAMLThemePrimary,
 };
 
 use styles::ColorTermusic;
@@ -249,16 +248,6 @@ impl TryFrom<&str> for ThemeColor {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::from_hex(value)
-    }
-}
-
-impl From<AlacrittyColor> for ThemeColor {
-    fn from(value: AlacrittyColor) -> Self {
-        Self {
-            r: value.r,
-            g: value.g,
-            b: value.b,
-        }
     }
 }
 
@@ -516,8 +505,20 @@ fn default_fff() -> ThemeColor {
 }
 
 mod v1_interop {
-    use super::{ThemeBright, ThemeColors, ThemeCursor, ThemeNormal, ThemePrimary, ThemeWrap};
+    use super::{
+        ThemeBright, ThemeColor, ThemeColors, ThemeCursor, ThemeNormal, ThemePrimary, ThemeWrap,
+    };
     use crate::config::v1;
+
+    impl From<v1::AlacrittyColor> for ThemeColor {
+        fn from(value: v1::AlacrittyColor) -> Self {
+            Self {
+                r: value.r,
+                g: value.g,
+                b: value.b,
+            }
+        }
+    }
 
     impl From<&v1::Alacritty> for ThemeColors {
         fn from(value: &v1::Alacritty) -> Self {

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -62,10 +62,8 @@ impl ColorTermusic {
 impl From<ColorTermusic> for Color {
     fn from(value: ColorTermusic) -> Self {
         match value {
-            ColorTermusic::Reset | ColorTermusic::Foreground | ColorTermusic::Background => {
-                Color::Reset
-            }
-            ColorTermusic::Black => Color::Black,
+            ColorTermusic::Reset => Color::Reset,
+            ColorTermusic::Background | ColorTermusic::Black => Color::Black,
             ColorTermusic::Red => Color::Red,
             ColorTermusic::Green => Color::Green,
             ColorTermusic::Yellow => Color::Yellow,
@@ -80,7 +78,7 @@ impl From<ColorTermusic> for Color {
             ColorTermusic::LightBlue => Color::LightBlue,
             ColorTermusic::LightMagenta => Color::LightMagenta,
             ColorTermusic::LightCyan => Color::LightCyan,
-            ColorTermusic::LightWhite => Color::White,
+            ColorTermusic::Foreground | ColorTermusic::LightWhite => Color::White,
         }
     }
 }

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use tuirealm::props::Color;
 
 /// All values correspond to the Theme's selected color for that
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
@@ -55,6 +56,32 @@ impl ColorTermusic {
     #[must_use]
     pub const fn as_usize(self) -> usize {
         self as usize
+    }
+}
+
+impl From<ColorTermusic> for Color {
+    fn from(value: ColorTermusic) -> Self {
+        match value {
+            ColorTermusic::Reset | ColorTermusic::Foreground | ColorTermusic::Background => {
+                Color::Reset
+            }
+            ColorTermusic::Black => Color::Black,
+            ColorTermusic::Red => Color::Red,
+            ColorTermusic::Green => Color::Green,
+            ColorTermusic::Yellow => Color::Yellow,
+            ColorTermusic::Blue => Color::Blue,
+            ColorTermusic::Magenta => Color::Magenta,
+            ColorTermusic::Cyan => Color::Cyan,
+            ColorTermusic::White => Color::Gray,
+            ColorTermusic::LightBlack => Color::DarkGray,
+            ColorTermusic::LightRed => Color::LightRed,
+            ColorTermusic::LightGreen => Color::LightGreen,
+            ColorTermusic::LightYellow => Color::LightYellow,
+            ColorTermusic::LightBlue => Color::LightBlue,
+            ColorTermusic::LightMagenta => Color::LightMagenta,
+            ColorTermusic::LightCyan => Color::LightCyan,
+            ColorTermusic::LightWhite => Color::White,
+        }
     }
 }
 

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -33,6 +33,9 @@ use termusiclib::config::v2::tui::theme::ThemeColors;
 use termusiclib::types::{ConfigEditorMsg, Id, IdConfigEditor, IdKey, KFMsg, Msg};
 use termusiclib::utils::get_app_config_path;
 
+/// How many Themes there are without actual files and always exist
+pub const THEMES_WITHOUT_FILES: usize = 2;
+
 impl Model {
     #[allow(clippy::too_many_lines)]
     pub fn update_config_editor(&mut self, msg: ConfigEditorMsg) -> Option<Msg> {
@@ -376,9 +379,14 @@ impl Model {
 
             return;
         }
+        if index == 1 {
+            self.preview_theme_apply(ThemeColors::full_native(), 1);
 
-        // idx - 1 as 0 table-entry is termusic default, which always exists
-        if let Some(theme_filename) = self.config_editor.themes.get(index - 1) {
+            return;
+        }
+
+        // idx - THEMES_WITHOUT_FILES as 0 until THEMES_WITHOUT_FILES table-entries are termusic themes without files, which always exists
+        if let Some(theme_filename) = self.config_editor.themes.get(index - THEMES_WITHOUT_FILES) {
             match get_app_config_path() {
                 Ok(mut theme_path) => {
                     theme_path.push("themes");

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,3 +1,4 @@
+use crate::ui::components::config_editor::update::THEMES_WITHOUT_FILES;
 use crate::ui::components::{CEHeader, ConfigSavePopup, GlobalListener};
 use include_dir::DirEntry;
 use termusiclib::config::v2::server::{PositionYesNo, PositionYesNoLower, RememberLastPosition};
@@ -2054,13 +2055,17 @@ impl Model {
         table
             .add_col(TextSpan::new(0.to_string()))
             .add_col(TextSpan::new("Termusic Default"));
+        table.add_row();
+        table
+            .add_col(TextSpan::new(1.to_string()))
+            .add_col(TextSpan::new("Native"));
 
         for (idx, record) in self.config_editor.themes.iter().enumerate() {
             table.add_row();
 
-            // idx + 1 as 0 entry is termusic default
+            // idx + X as 0 until X entries are termusic default, always existing themes
             table
-                .add_col(TextSpan::new((idx + 1).to_string()))
+                .add_col(TextSpan::new((idx + THEMES_WITHOUT_FILES).to_string()))
                 .add_col(TextSpan::new(record));
         }
 
@@ -2081,8 +2086,8 @@ impl Model {
             if let Some(current_file_name) = self.config_editor.theme.theme.file_name.as_ref() {
                 for (idx, name) in self.config_editor.themes.iter().enumerate() {
                     if name == current_file_name {
-                        // idx + 1 as 0 entry is termusic default
-                        index = Some(idx + 1);
+                        // idx + X as 0 until X entries are termusic default, always existing themes
+                        index = Some(idx + THEMES_WITHOUT_FILES);
                         break;
                     }
                 }


### PR DESCRIPTION
This PR adds a `Native` theme that just passes-through the ASCII Colors instead of setting custom RGB ones.
This allows the usage of the terminal's theme directly, for example useful for `pywal`.

This PR adds a new possible `native` value to `tui.toml` `theme`, which before could only accept hex numbers.
This does NOT allow `native` as a valid value from custom themes(`YAMLTheme`), only for the `tui.toml`.

Due to this being implemented as a normal "Fake" / "No File" Theme, it completely integrates with the selection and preview of themes without having to do much extra.

I think this qualifies as fixes #342.