### PR TITLE
refuse kill if another instance is running

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -32,6 +32,7 @@ use parking_lot::Mutex;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use std::{error::Error, path::Path};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
@@ -70,6 +71,8 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+pub static SERVER_PID: OnceLock<Pid> = OnceLock::new();
 
 /// Handles CLI args, potentially starts termusic-server, then runs UI loop
 #[tokio::main]
@@ -140,6 +143,9 @@ async fn actual_main() -> Result<()> {
     }
 
     println!("Server process ID: {pid}");
+    SERVER_PID
+        .set(Pid::from_u32(pid))
+        .unwrap_or_else(|_| error!("Could not set SERVER_PID."));
 
     // this is a bad implementation, but there is no way to currently only shut off stderr / stdout
     // see https://github.com/emabee/flexi_logger/issues/142

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -175,7 +175,7 @@ impl UI {
                     clients += 1;
                 }
             }
-            if clients == 1 && target.is_some() {
+            if clients <= 1 && target.is_some() {
                 #[cfg(not(target_os = "windows"))]
                 if let Some(s) = target {
                     s.kill_with(sysinfo::Signal::Term);


### PR DESCRIPTION
This solves the issue:
#472 

This will:
1. on quit, probe for `termusic` instances at the same time `termusic` iterates over processes
2. count them if they are not spawned by `termusic` by looking up PID.
3. if there are two or more externally spawned processes, it will skip killing the server.

My code is not very elegant, so I'd like some simple feedback if possible. Thank you!