### PR TITLE
feat(playback::rusty): change all sample types from i16 to f32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix(tui): on track change, dont select "current track" playlist item if the old "current track" was not selected.
 - Fix(tui): re-select the (approximately) same playlist item after a shuffle.
 - Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
+- Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -119,8 +119,8 @@ impl Sink {
         let source = source
             .track_position()
             .custom_speed(1.0)
-            .pausable(false)
             .amplify(1.0)
+            .pausable(false)
             .skippable()
             // as of rodio 0.20.x, "stoppable" is the same as "skippable"
             // .stoppable()
@@ -153,9 +153,8 @@ impl Sink {
                     *controls.position.write() = src.inner().inner().inner().inner().get_pos();
 
                     let amp = src.inner_mut();
-                    amp.set_factor(*controls.volume.lock());
-                    amp.inner_mut()
-                        .set_paused(controls.pause.load(Ordering::SeqCst));
+                    amp.inner_mut().set_factor(*controls.volume.lock());
+                    amp.set_paused(controls.pause.load(Ordering::SeqCst));
 
                     amp.inner_mut()
                         .inner_mut()

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -125,11 +125,9 @@ impl Sink {
             // as of rodio 0.20.x, "stoppable" is the same as "skippable"
             // .stoppable()
             .periodic_access(Duration::from_millis(500), move |src| {
-                progress_tx
-                    .send(PlayerInternalCmd::Progress(
-                        src.inner().inner().inner().inner().get_pos(),
-                    ))
-                    .ok();
+                let _ = progress_tx.send(PlayerInternalCmd::Progress(
+                    src.inner().inner().inner().inner().get_pos(),
+                ));
             })
             .periodic_access(Duration::from_millis(5), move |src| {
                 let src = src.inner_mut();

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -117,8 +117,6 @@ impl Sink {
         #[cfg(feature = "rusty-soundtouch")]
         let controls_tempo = self.controls.clone();
 
-        let start_played = AtomicBool::new(false);
-
         let progress_tx = self.picmd_tx.clone();
         let source = source
             .track_position()
@@ -167,8 +165,6 @@ impl Sink {
                             .inner_mut()
                             .set_factor(*controls.speed.lock());
                     }
-
-                    start_played.store(true, Ordering::SeqCst);
                 }
             });
 

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::{Mutex, RwLock};
-use rodio::cpal::FromSample;
-use rodio::{queue, source::Done, Sample, Source};
+use rodio::{queue, source::Done, Source};
 use rodio::{OutputStreamHandle, PlayError};
 
+use super::source::SampleType;
 #[allow(unused_imports)] // used for "rusty-soundtouch"
 use super::source::SourceExt as _;
 use super::PlayerInternalCmd;
@@ -103,9 +103,7 @@ impl Sink {
     #[allow(clippy::cast_possible_wrap)]
     pub fn append<S>(&self, source: S)
     where
-        S: Source + Send + 'static,
-        f32: FromSample<S::Item>,
-        S::Item: Sample + Send,
+        S: Source<Item = SampleType> + Send + 'static,
     {
         // Wait for queue to flush then resume stopped playback
         if self.controls.stopped.load(Ordering::SeqCst) {
@@ -172,8 +170,7 @@ impl Sink {
 
                     start_played.store(true, Ordering::SeqCst);
                 }
-            })
-            .convert_samples();
+            });
 
         #[cfg(feature = "rusty-soundtouch")]
         let source =

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -148,6 +148,8 @@ impl Sink {
                             *to_clear -= 1;
                             // reset position to be at 0, otherwise the position could be stale if there is no new source
                             *controls.position.write() = Duration::ZERO;
+
+                            return;
                         }
                     }
                     *controls.position.write() = src.inner().inner().inner().inner().get_pos();

--- a/playback/src/backends/rusty/source/custom_speed.rs
+++ b/playback/src/backends/rusty/source/custom_speed.rs
@@ -1,0 +1,118 @@
+use std::time::Duration;
+
+use rodio::Source;
+
+use super::SampleType;
+
+#[allow(clippy::needless_return)]
+pub fn custom_speed<I>(input: I, initial_speed: f32) -> CustomSpeed<I>
+where
+    I: Source<Item = SampleType>,
+{
+    #[cfg(not(feature = "rusty-soundtouch"))]
+    return CustomSpeed::Rodio(input.speed(initial_speed));
+    #[cfg(feature = "rusty-soundtouch")]
+    return CustomSpeed::SoundTouch(super::soundtouch::soundtouch(input, initial_speed));
+}
+
+/// A custom [`Source`] implementation to abstract away which speed module gets chosen.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum CustomSpeed<I> {
+    Rodio(rodio::source::Speed<I>),
+    #[cfg(feature = "rusty-soundtouch")]
+    SoundTouch(super::soundtouch::SoundTouchSource<I>),
+}
+
+impl<I> Iterator for CustomSpeed<I>
+where
+    I: Source<Item = SampleType>,
+{
+    type Item = SampleType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.as_source_mut().next()
+    }
+}
+
+impl<I> ExactSizeIterator for CustomSpeed<I> where I: Source<Item = SampleType> + ExactSizeIterator {}
+
+impl<I> Source for CustomSpeed<I>
+where
+    I: Source<Item = SampleType>,
+{
+    fn current_frame_len(&self) -> Option<usize> {
+        self.as_source().current_frame_len()
+    }
+
+    fn channels(&self) -> u16 {
+        self.as_source().channels()
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.as_source().sample_rate()
+    }
+
+    fn total_duration(&self) -> Option<std::time::Duration> {
+        self.as_source().total_duration()
+    }
+
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), rodio::source::SeekError> {
+        self.as_source_mut().try_seek(pos)
+    }
+}
+
+impl<I> CustomSpeed<I>
+where
+    I: Source<Item = SampleType>,
+{
+    #[inline]
+    fn as_source(&self) -> &dyn Source<Item = SampleType> {
+        match self {
+            CustomSpeed::Rodio(speed) => speed,
+            #[cfg(feature = "rusty-soundtouch")]
+            CustomSpeed::SoundTouch(soundtouch) => soundtouch,
+        }
+    }
+
+    #[inline]
+    fn as_source_mut(&mut self) -> &mut dyn Source<Item = SampleType> {
+        match self {
+            CustomSpeed::Rodio(speed) => speed,
+            #[cfg(feature = "rusty-soundtouch")]
+            CustomSpeed::SoundTouch(soundtouch) => soundtouch,
+        }
+    }
+
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        match self {
+            CustomSpeed::Rodio(speed) => speed.inner(),
+            #[cfg(feature = "rusty-soundtouch")]
+            CustomSpeed::SoundTouch(soundtouch) => soundtouch.inner(),
+        }
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    #[expect(dead_code)]
+    pub fn inner_mut(&mut self) -> &mut I {
+        match self {
+            CustomSpeed::Rodio(speed) => speed.inner_mut(),
+            #[cfg(feature = "rusty-soundtouch")]
+            CustomSpeed::SoundTouch(soundtouch) => soundtouch.inner_mut(),
+        }
+    }
+
+    /// Modifies the speed factor.
+    #[inline]
+    pub fn set_factor(&mut self, factor: f32) {
+        match self {
+            CustomSpeed::Rodio(speed) => speed.set_factor(factor),
+            #[cfg(feature = "rusty-soundtouch")]
+            CustomSpeed::SoundTouch(soundtouch) => soundtouch.set_factor(f64::from(factor)),
+        }
+    }
+}

--- a/playback/src/backends/rusty/source/mod.rs
+++ b/playback/src/backends/rusty/source/mod.rs
@@ -7,6 +7,9 @@ pub mod soundtouch;
 
 pub mod async_ring;
 
+/// Our sample type we choose to use across all places
+pub type SampleType = f32;
+
 /// Extension trait for [`Source`] for additional custom modifiers
 #[allow(clippy::module_name_repetitions)]
 #[allow(dead_code)] // currently only used for "rusty-soundtouch"

--- a/playback/src/backends/rusty/source/mod.rs
+++ b/playback/src/backends/rusty/source/mod.rs
@@ -6,6 +6,7 @@ use rodio::{Sample, Source};
 pub mod soundtouch;
 
 pub mod async_ring;
+mod custom_speed;
 
 /// Our sample type we choose to use across all places
 pub type SampleType = f32;
@@ -17,14 +18,13 @@ pub trait SourceExt: Source
 where
     Self::Item: Sample,
 {
-    /// Modify samples to sound similar as 1.0 speed when sped-up or slowed-down via [`::soundtouch`] (via `libSoundTouch`)
-    #[cfg(feature = "rusty-soundtouch")]
-    fn soundtouch(self, factor: f32) -> soundtouch::SoundTouchSource<Self>
+    /// A custom [`Source`] implementation to abstract away which speed module gets chosen.
+    fn custom_speed(self, initial_speed: f32) -> custom_speed::CustomSpeed<Self>
     where
         Self: Sized,
         Self: Source<Item = f32>,
     {
-        soundtouch::soundtouch(self, factor)
+        custom_speed::custom_speed(self, initial_speed)
     }
 }
 

--- a/playback/src/backends/rusty/source/soundtouch/mod.rs
+++ b/playback/src/backends/rusty/source/soundtouch/mod.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, time::Duration};
 use rodio::Source;
 use soundtouch::{Setting, SoundTouch};
 
+/// Modify samples to sound similar as 1.0 speed when sped-up or slowed-down via [`::soundtouch`] (via `libSoundTouch`)
 pub fn soundtouch<I>(input: I, rate: f32) -> SoundTouchSource<I>
 where
     I: Source<Item = f32>,
@@ -107,6 +108,18 @@ impl<I> SoundTouchSource<I>
 where
     I: Source<Item = f32>,
 {
+    /// Returns a reference to the inner source.
+    #[inline]
+    pub fn inner(&self) -> &I {
+        &self.input
+    }
+
+    /// Returns a mutable reference to the inner source.
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.input
+    }
+
     /// Modifies the speed factor.
     #[inline]
     pub fn set_factor(&mut self, factor: f64) {


### PR DESCRIPTION
This PR changes all places we interact with samples to use Sample-Type `f32` instead of the previous `i16`, reasons are (by order):
- in the next version of rodio, Sources will only work on `f32` (https://github.com/RustAudio/rodio/pull/700, possibly rodio `0.21.0`)
- symphonia decodes into `f32` in many formats to my knowledge (but later got converted by us)
- soundtouch already forces use of `f32` samples in the chain, if enabled
- audio systems (like pipewire, pulseaudio) basically also operate on f32 anyway

This means we just have to do less conversions and are better ready for the next rodio version.