### PR TITLE
Add support for Unix Domain Sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### next
 - Change: updated MSRV to 1.82.
+- Change: support Unix Domain Sockets in addition to HTTP transport. (Note that UDS is only available for `unix` targets)
+- Change: change default transport protocol to be UDS on `unix` systems.
 - Change(tui): rename cli option `--disable-cover`  to `--hide-cover`.
 - Change(tui): dont depend on `termusicplayback` anymore.
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,6 +4911,7 @@ dependencies = [
  "termusic-playback",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
 ]
 

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -370,8 +370,8 @@ impl Default for ComSettings {
     }
 }
 
-impl From<ComSettings> for SocketAddr {
-    fn from(value: ComSettings) -> Self {
+impl From<&ComSettings> for SocketAddr {
+    fn from(value: &ComSettings) -> Self {
         Self::new(value.address, value.port)
     }
 }

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -350,11 +350,66 @@ impl LoopMode {
     }
 }
 
-/// Settings for the gRPC server (and potentially future ways to communicate)
+/// Error for when [`ComProtocol`] parsing fails
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum ComProtocolParseError {
+    #[error("Expected \"uds\" or \"http\", found \"{0}\"")]
+    UnknownValue(String),
+}
+
+/// The Protocol to use for the server-client communication
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub enum ComProtocol {
+    HTTP,
+    /// Unix socket
+    UDS,
+}
+
+impl TryFrom<String> for ComProtocol {
+    type Error = ComProtocolParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for ComProtocol {
+    type Error = ComProtocolParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let lowercase = value.to_ascii_lowercase();
+        Ok(match lowercase.as_str() {
+            "http" => Self::HTTP,
+            "uds" => Self::UDS,
+            _ => return Err(ComProtocolParseError::UnknownValue(lowercase)),
+        })
+    }
+}
+
+impl From<ComProtocol> for String {
+    fn from(val: ComProtocol) -> Self {
+        match val {
+            ComProtocol::HTTP => "http",
+            ComProtocol::UDS => "uds",
+        }
+        .to_string()
+    }
+}
+
+/// Settings for the gRPC server (and potentially future ways to communicate)
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 // for now, require that both port and ip are specified at once
-// #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
+#[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct ComSettings {
+    // General Settings
+    pub protocol: ComProtocol,
+
+    // UDS settings
+    pub socket_path: PathBuf,
+
+    // Below are HTTP settings
     /// gRPC server Port
     pub port: u16,
     /// gRPC server interface / address
@@ -363,7 +418,17 @@ pub struct ComSettings {
 
 impl Default for ComSettings {
     fn default() -> Self {
+        // TODO: maybe default to include user id like "termusic-1000.socket"?
+        let socket_path = std::env::temp_dir().join("termusic.socket");
+
         Self {
+            #[cfg(unix)]
+            protocol: ComProtocol::UDS,
+            #[cfg(not(unix))]
+            protocol: ComProtocol::HTTP,
+
+            socket_path,
+
             port: 50101,
             address: "::1".parse().unwrap(),
         }
@@ -442,8 +507,11 @@ mod v1_interop {
         #[allow(clippy::cast_possible_truncation)] // checked casts
         fn try_from(value: v1::Settings) -> Result<Self, Self::Error> {
             let com_settings = ComSettings {
+                // when coming from v1, continue using http until manually changed
+                protocol: super::ComProtocol::HTTP,
                 port: value.player_port,
                 address: value.player_interface,
+                ..Default::default()
             };
 
             let podcast_settings = PodcastSettings {
@@ -507,6 +575,8 @@ mod v1_interop {
         use pretty_assertions::assert_eq;
         use std::path::PathBuf;
 
+        use crate::config::v2::server::ComProtocol;
+
         use super::*;
 
         #[test]
@@ -532,8 +602,10 @@ mod v1_interop {
             assert_eq!(
                 converted.com,
                 ComSettings {
+                    protocol: ComProtocol::HTTP,
                     port: 50101,
-                    address: "::1".parse().unwrap()
+                    address: "::1".parse().unwrap(),
+                    ..Default::default()
                 }
             );
 

--- a/lib/src/config/v2/tui/mod.rs
+++ b/lib/src/config/v2/tui/mod.rs
@@ -36,7 +36,7 @@ impl TuiSettings {
         match self.com {
             MaybeComSettings::ComSettings(ref v) => {
                 // this could likely be avoided, but for simplicity this is set
-                self.com_resolved = Some(*v);
+                self.com_resolved = Some(v.clone());
                 return Ok(());
             }
             MaybeComSettings::Same => (),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ parking_lot.workspace = true
 serde.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tonic.workspace = true
 clap.workspace = true
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -7,12 +7,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Context as _, Result};
 use clap::Parser;
 use music_player_service::MusicPlayerService;
 use parking_lot::Mutex;
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
-use termusiclib::config::v2::server::ScanDepth;
+use termusiclib::config::v2::server::{ComProtocol, ScanDepth};
 use termusiclib::config::{new_shared_server_settings, ServerOverlay, SharedServerSettings};
 use termusiclib::player::music_player_server::MusicPlayerServer;
 use termusiclib::player::{GetProgressResponse, PlayerProgress, PlayerTime, RunningStatus};
@@ -24,6 +24,8 @@ use termusicplayback::{
 };
 use tokio::runtime::Handle;
 use tokio::sync::{broadcast, oneshot};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tonic::transport::server::TcpIncoming;
 use tonic::transport::Server;
 
@@ -130,8 +132,10 @@ async fn actual_main() -> Result<()> {
     })
     .expect("Error setting Ctrl-C handler");
 
-    let (tcp_stream, addr) = tcp_stream(&config).await?;
-    info!("Server listening on {}", addr);
+    let service_cancel_token = CancellationToken::new();
+
+    let join_handle =
+        start_service(&config, music_player_service, service_cancel_token.clone()).await?;
 
     let tokio_handle = Handle::current();
     let (player_handle_os_tx, player_handle_os_rx) = oneshot::channel();
@@ -153,13 +157,7 @@ async fn actual_main() -> Result<()> {
 
     ticker_thread(cmd_tx_ticker)?;
 
-    tokio::spawn(
-        Server::builder()
-            .add_service(MusicPlayerServer::new(music_player_service))
-            .serve_with_incoming(tcp_stream),
-    );
-
-    info!("Server started and listening on {}", addr);
+    info!("Server ready");
 
     // await the oneshot completing in a async fashion
     player_handle_os_rx.await??;
@@ -167,10 +165,56 @@ async fn actual_main() -> Result<()> {
     // and by doing this after the oneshot we can be sure the thread is actually exited, or exiting
     let _ = player_handle.join();
 
+    // ensure cleanup of the service tasks happens before main exits
+    service_cancel_token.cancel();
+    let _ = join_handle.await;
+
     // Graceful exit log
     info!("Bye");
 
     Ok(())
+}
+
+/// Start the [`MusicPlayerService`] with the according transport protocol.
+async fn start_service(
+    config: &SharedServerSettings,
+    music_player_service: MusicPlayerService,
+    cancel_token: CancellationToken,
+) -> Result<JoinHandle<Result<(), tonic::transport::Error>>> {
+    // otherwise the MutexGuard would be held across await points
+    let protocol = config.read().settings.com.protocol;
+    let handle = match protocol {
+        ComProtocol::HTTP => {
+            let (tcp_stream, addr) = tcp_stream(config).await?;
+            info!("Server listening on {addr}");
+
+            tokio::spawn(
+                Server::builder()
+                    .add_service(MusicPlayerServer::new(music_player_service))
+                    .serve_with_incoming_shutdown(tcp_stream, cancel_token.cancelled_owned()),
+            )
+        }
+        #[cfg(unix)]
+        ComProtocol::UDS => {
+            // TODO: unlink socket file if it already exists
+            let (uds_stream, addr) = uds::uds_stream(config).await?;
+            info!("Server listening on {addr}");
+
+            tokio::spawn(
+                Server::builder()
+                    .add_service(MusicPlayerServer::new(music_player_service))
+                    .serve_with_incoming_shutdown(uds_stream, cancel_token.cancelled_owned()),
+            )
+        }
+        #[cfg(not(unix))]
+        ComProtocol::UDS => {
+            // runtime error to not plaster "cfg(unix)" everywhere and because the default for those systems is "HTTP"
+            // and windows in tonic(and lower) will support uds soon-ish
+            unimplemented!("UDS/Unix Domain Sockets are only implemented for unix targets")
+        }
+    };
+
+    Ok(handle)
 }
 
 /// Create the TCP Stream for HTTP requests.
@@ -189,6 +233,94 @@ async fn tcp_stream(config: &SharedServerSettings) -> Result<(TcpIncoming, Socke
     let stream = TcpIncoming::from(tcp_listener).with_nodelay(Some(true));
 
     Ok((stream, socket_addr))
+}
+
+#[cfg(unix)]
+mod uds {
+    use std::{
+        io,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use anyhow::{Context as _, Result};
+    use termusiclib::config::SharedServerSettings;
+    use tokio::net::{UnixListener, UnixStream};
+    use tokio_stream::Stream;
+
+    /// Create the UDS Stream for UDS requests.
+    pub async fn uds_stream(config: &SharedServerSettings) -> Result<(UnixListenerStream, String)> {
+        let path = &config.read().settings.com.socket_path;
+
+        // if the file already exists, tokio will error with "Address already in use"
+        // not using async here because of MutexGuard and being before anything important
+        if path.exists() {
+            warn!("Socket Path {} already exists, unlinking!", path.display());
+            let _ = std::fs::remove_file(path);
+        }
+
+        let path_str = path.display().to_string();
+        let uds = UnixListener::bind(path).with_context(|| path_str.clone())?;
+
+        let stream = UnixListenerStream::new(uds);
+
+        Ok((stream, path_str))
+    }
+
+    /// A wrapper around [`UnixListener`] that implements [`Stream`].
+    ///
+    /// Copied from [`tokio_stream::wrappers::UnixListenerStream`], which is licensed MIT.
+    ///
+    /// Modified because the normal implementation does not remove the socket on drop.
+    #[derive(Debug)]
+    #[cfg_attr(docsrs, doc(cfg(all(unix, feature = "net"))))]
+    pub struct UnixListenerStream {
+        inner: UnixListener,
+    }
+
+    impl UnixListenerStream {
+        /// Create a new `UnixListenerStream`.
+        pub fn new(listener: UnixListener) -> Self {
+            Self { inner: listener }
+        }
+    }
+
+    impl Stream for UnixListenerStream {
+        type Item = io::Result<UnixStream>;
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<io::Result<UnixStream>>> {
+            match self.inner.poll_accept(cx) {
+                Poll::Ready(Ok((stream, _))) => Poll::Ready(Some(Ok(stream))),
+                Poll::Ready(Err(err)) => Poll::Ready(Some(Err(err))),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl AsRef<UnixListener> for UnixListenerStream {
+        fn as_ref(&self) -> &UnixListener {
+            &self.inner
+        }
+    }
+
+    impl AsMut<UnixListener> for UnixListenerStream {
+        fn as_mut(&mut self) -> &mut UnixListener {
+            &mut self.inner
+        }
+    }
+
+    impl Drop for UnixListenerStream {
+        fn drop(&mut self) {
+            // unlink socket file as it is not done so by default
+            let tmp = self.inner.local_addr().ok();
+            if let Some(val) = tmp.as_ref().and_then(|v| v.as_pathname()) {
+                let _ = std::fs::remove_file(val);
+            }
+        }
+    }
 }
 
 /// The main player loop where we handle all events

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -285,7 +285,7 @@ async fn wait_till_connected_uds(
                         continue;
                     }
                     if os_err.kind() == std::io::ErrorKind::NotFound {
-                        debug!("File not found!");
+                        debug!("Socket File not found!");
                         tokio::time::sleep(WAIT_INTERVAL).await;
                         continue;
                     }


### PR DESCRIPTION
This PR mainly adds Unix Domain Socket (or also referred as UDS) support. It is also chosen as the default for `unix` targets. Some notes:
- UDS is currently only available for `unix` targets in tokio & tonic, but windows (since some 10 version) also supports UDS, so it might come to there too
- UDS will be able to be parsed from the config regardless of target
- when migrating from v1 config, `HTTP` is chosen as the default
- if UDS is not available, `HTTP` is chosen as the default
- if UDS is not available, but set in the config, a runtime error will occur

Additionally this PR does, as it somewhat impacted the implementation:
- better gracefully exit instead of calling `::exit(0)` in a `Quit` message (allows tasks to exit gracefully)
- pause & stop the player before exiting. As without the `::exit()` call, the process would be kept around until the last audio source had been consumed


PS: this is a DRAFT as i wanted to know if it builds on other targets than `unix` or if i forgot some place