### PR TITLE
fix(tui::ui::model::load_from_grpc): dont call "set_current_track_index" if there are no tracks

### DIFF
--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -231,7 +231,13 @@ impl Playback {
         }
 
         self.playlist.set_tracks(playlist_items);
-        self.playlist.set_current_track_index(current_track_index)?;
+
+        // the old server playlist implementation will send `current_track_index: 0`, even if there are not tracks
+        // but the new TUI implementation function "set_current_track_index" will refuse to set anything if the index is out-of-bounds
+        if !self.playlist.is_empty() {
+            self.playlist.set_current_track_index(current_track_index)?;
+        }
+
         self.set_current_track_from_playlist();
 
         Ok(())


### PR DESCRIPTION
This fixes a error i didnt check for in #476. This happens because in the TUI Playlist `current_track_index` is `Option` and can only be set if it is within `tracks` bounds, but the current GRPC interface and the server Playlist still have it as non-optional and send `0` even if there are no tracks.