### PR TITLE
Allow keys `add single / add all` on Database `Result` view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change(tui): dont depend on `termusicplayback` anymore.
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
 - Feat(tui): add native theme support. Useful for example for `pywal`.
+- Feat(tui): allow using "add single / add all" keys on Database `Result` view.
 - Feat(server): for rusty backend, add feature `rusty-simd` to enable SIMD instructions for decoding.
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
 - Fix(tui): set `ueberzug` command to `--silent`.

--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -28,6 +28,7 @@ use crate::utils::{filetype_supported, get_app_config_path, get_pin_yin};
 use anyhow::Context;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection, Error, Result};
+use std::fmt::Debug;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
@@ -41,6 +42,15 @@ pub use track_db::{const_unknown, Indexable, TrackDB};
 pub struct DataBase {
     conn: Arc<Mutex<Connection>>,
     max_depth: ScanDepth,
+}
+
+impl Debug for DataBase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataBase")
+            .field("conn", &"<unavailable>")
+            .field("max_depth", &self.max_depth)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -39,6 +39,11 @@ mod track_db;
 
 pub use track_db::{const_unknown, Indexable, TrackDB};
 
+#[allow(clippy::doc_markdown)]
+/// The SQLite Database interface.
+///
+/// This *can* be shared between threads via `clone`, **but** only one operation may occur at a time.
+#[derive(Clone)]
 pub struct DataBase {
     conn: Arc<Mutex<Connection>>,
     max_depth: ScanDepth,

--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -54,6 +54,19 @@ pub enum SearchCriteria {
     Playlist,
 }
 
+impl SearchCriteria {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SearchCriteria::Artist => "artist",
+            SearchCriteria::Album => "album",
+            SearchCriteria::Genre => "genre",
+            SearchCriteria::Directory => "directory",
+            SearchCriteria::Playlist => "playlist",
+        }
+    }
+}
+
 impl From<usize> for SearchCriteria {
     fn from(u_index: usize) -> Self {
         match u_index {
@@ -68,13 +81,7 @@ impl From<usize> for SearchCriteria {
 
 impl std::fmt::Display for SearchCriteria {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Artist => write!(f, "artist"),
-            Self::Album => write!(f, "album"),
-            Self::Genre => write!(f, "genre"),
-            Self::Directory => write!(f, "directory"),
-            Self::Playlist => write!(f, "playlist"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -5,7 +5,7 @@ use rusqlite::{named_params, Connection, Row};
 use crate::track::Track;
 
 /// A struct representing a [`Track`](Track) in the database
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TrackDB {
     pub id: u64,
     pub artist: String,

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -375,16 +375,27 @@ pub enum LIMsg {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DBMsg {
+    /// Add all Track Results (from view `Tracks`) to the playlist
     AddAllToPlaylist,
+    /// Add a single Track Result (from view `Tracks`) to the playlist
     AddPlaylist(usize),
+    /// Add all Results (from view `Result`) to the playlist
+    AddAllResultsToPlaylist,
+    /// Add a single result (from view `Result`) to the playlist
+    AddResultToPlaylist(usize),
     CriteriaBlurDown,
     CriteriaBlurUp,
+    /// Search Results (for view `Result`) from a `Database`(view) index
     SearchResult(usize),
     SearchResultBlurDown,
     SearchResultBlurUp,
+    /// Serarch Tracks (for view `Tracks`) from a `Result`(view) index
     SearchTrack(usize),
     SearchTracksBlurDown,
     SearchTracksBlurUp,
+
+    AddAllResultsConfirmShow,
+    AddAllResultsConfirmCancel,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -566,6 +577,7 @@ pub enum Id {
     TagEditor(IdTagEditor),
     YoutubeSearchInputPopup,
     YoutubeSearchTablePopup,
+    DatabaseAddConfirmPopup,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -650,7 +650,6 @@ impl Model {
 
     /// Add all Results (from view `Result`) to the playlist.
     pub fn database_add_all_results(&mut self) {
-        // TODO: refactor this code the be on a separate thread to not block the TUI
         self.umount_results_add_confirm_database();
         if !self.dw.search_results.is_empty() {
             let mut tracks = Vec::new();

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -1,8 +1,8 @@
-use crate::ui::Model;
 use std::path::Path;
+
 use termusiclib::config::SharedTuiSettings;
 use termusiclib::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_FILE, UNKNOWN_TITLE};
-use termusiclib::library_db::{Indexable, SearchCriteria};
+use termusiclib::library_db::{Indexable, SearchCriteria, TrackDB};
 use termusiclib::types::{DBMsg, Id, Msg};
 use termusiclib::utils::{is_playlist, playlist_get_vec};
 use tui_realm_stdlib::List;
@@ -13,6 +13,9 @@ use tuirealm::{
     event::{Key, KeyEvent, KeyModifiers, NoUserEvent},
     AttrValue, Attribute, Component, Event, MockComponent, State, StateValue,
 };
+
+use super::popups::{YNConfirm, YNConfirmStyle};
+use crate::ui::Model;
 
 #[derive(MockComponent)]
 pub struct DBListCriteria {
@@ -153,6 +156,39 @@ impl Component<Msg, NoUserEvent> for DBListCriteria {
     }
 }
 
+/// Component for a "Are you sure you want to add ALL found albums? Y/N" popup
+#[derive(MockComponent)]
+pub struct AddAlbumConfirm {
+    component: YNConfirm,
+}
+
+impl AddAlbumConfirm {
+    pub fn new(config: SharedTuiSettings, criteria: &str) -> Self {
+        let component = YNConfirm::new_with_cb(
+            config,
+            format!(" Are you sure you want to add EVERYTHING from {criteria}? ",),
+            |config| YNConfirmStyle {
+                foreground_color: config.settings.theme.important_popup_foreground(),
+                background_color: config.settings.theme.important_popup_background(),
+                border_color: config.settings.theme.important_popup_border(),
+                title_alignment: Alignment::Left,
+            },
+        );
+
+        Self { component }
+    }
+}
+
+impl Component<Msg, NoUserEvent> for AddAlbumConfirm {
+    fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
+        self.component.on(
+            ev,
+            Msg::DataBase(DBMsg::AddAllResultsToPlaylist),
+            Msg::DataBase(DBMsg::AddAllResultsConfirmCancel),
+        )
+    }
+}
+
 #[derive(MockComponent)]
 pub struct DBListSearchResult {
     component: List,
@@ -197,6 +233,7 @@ impl DBListSearchResult {
 }
 
 impl Component<Msg, NoUserEvent> for DBListSearchResult {
+    #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<NoUserEvent>) -> Option<Msg> {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
@@ -286,6 +323,18 @@ impl Component<Msg, NoUserEvent> for DBListSearchResult {
 
             Event::Keyboard(keyevent) if keyevent == keys.library_keys.search.get() => {
                 return Some(Msg::GeneralSearch(crate::ui::GSMsg::PopupShowDatabase))
+            }
+
+            Event::Keyboard(keyevent) if keyevent == keys.database_keys.add_selected.get() => {
+                if let State::One(StateValue::Usize(index)) = self.state() {
+                    // Maybe we should also have a popup if it is anything other that "Album"?
+                    // Because things like "Genre" could be *very* big
+                    return Some(Msg::DataBase(DBMsg::AddResultToPlaylist(index)));
+                }
+                CmdResult::None
+            }
+            Event::Keyboard(keyevent) if keyevent == keys.database_keys.add_all.get() => {
+                return Some(Msg::DataBase(DBMsg::AddAllResultsConfirmShow))
             }
 
             _ => CmdResult::None,
@@ -554,33 +603,69 @@ impl Model {
         vec
     }
 
-    pub fn database_update_search_tracks(&mut self, index: usize) {
-        match self.dw.criteria {
+    /// Find all tracks for the given [`criteria`](SearchCriteria) which matches `val`.
+    ///
+    /// Or for the [`Playlist`](SearchCriteria::Playlist) case, `val` is the path of the playlist.
+    pub fn database_get_tracks_by_criteria(
+        &mut self,
+        criteria: SearchCriteria,
+        val: &str,
+    ) -> Option<Vec<TrackDB>> {
+        match criteria {
             SearchCriteria::Playlist => {
-                if let Some(result) = self.dw.search_results.get(index) {
-                    if let Ok(vec) = playlist_get_vec(result) {
-                        let mut vec_db = Vec::new();
-                        for item in vec {
-                            if let Ok(i) = self.db.get_record_by_path(&item) {
-                                vec_db.push(i);
-                            }
+                if let Ok(vec) = playlist_get_vec(val) {
+                    let mut vec_db = Vec::with_capacity(vec.len());
+                    for item in vec {
+                        if let Ok(i) = self.db.get_record_by_path(&item) {
+                            vec_db.push(i);
                         }
-                        self.dw.search_tracks = vec_db;
                     }
+                    return Some(vec_db);
                 }
             }
             _ => {
-                if let Ok(vec) = self
-                    .db
-                    .get_record_by_criteria(&self.dw.search_results[index], &self.dw.criteria)
-                {
-                    self.dw.search_tracks = vec;
-                }
+                return self.db.get_record_by_criteria(val, &criteria).ok();
             }
         }
 
+        None
+    }
+
+    /// Update view `Tracks` by populating it with items from the selected `Result`(view) index.
+    pub fn database_update_search_tracks(&mut self, index: usize) {
+        self.dw.search_tracks.clear();
+        let Some(at_index) = self.dw.search_results.get(index).cloned() else {
+            return;
+        };
+
+        let Some(result) = self.database_get_tracks_by_criteria(self.dw.criteria, &at_index) else {
+            return;
+        };
+
+        self.dw.search_tracks = result;
+
         self.database_sync_tracks();
         self.app.active(&Id::DBListSearchTracks).ok();
+    }
+
+    /// Add all Results (from view `Result`) to the playlist.
+    pub fn database_add_all_results(&mut self) {
+        // TODO: refactor this code the be on a separate thread to not block the TUI
+        self.umount_results_add_confirm_database();
+        if !self.dw.search_results.is_empty() {
+            let mut tracks = Vec::new();
+            // clone once instead every value in every iteration
+            let search_results = self.dw.search_results.clone();
+            for result in search_results {
+                if let Some(mut res) =
+                    self.database_get_tracks_by_criteria(self.dw.criteria, &result)
+                {
+                    tracks.append(&mut res);
+                }
+            }
+
+            self.playlist_add_all_from_db(&tracks);
+        }
     }
 
     pub fn database_reload(&mut self) {
@@ -695,5 +780,26 @@ impl Model {
 
         let filtered_music = Model::update_search(&db_tracks, input);
         self.general_search_update_show(Model::build_table(filtered_music));
+    }
+
+    /// Mount the [`AddAlbumConfirm`] popup
+    pub fn mount_results_add_confirm_database(&mut self, criteria: SearchCriteria) {
+        self.app
+            .remount(
+                Id::DatabaseAddConfirmPopup,
+                Box::new(AddAlbumConfirm::new(
+                    self.config_tui.clone(),
+                    criteria.as_str(),
+                )),
+                Vec::new(),
+            )
+            .unwrap();
+
+        self.app.active(&Id::DatabaseAddConfirmPopup).unwrap();
+    }
+
+    /// Unmount the [`AddAlbumConfirm`] popup
+    pub fn umount_results_add_confirm_database(&mut self) {
+        let _ = self.app.umount(&Id::DatabaseAddConfirmPopup);
     }
 }

--- a/tui/src/ui/components/popups/mock_yn_confirm.rs
+++ b/tui/src/ui/components/popups/mock_yn_confirm.rs
@@ -26,9 +26,9 @@ pub struct YNConfirm {
 
 impl YNConfirm {
     /// Create a new instance with custom colors
-    pub fn new_with_cb<F: FnOnce(&TuiOverlay) -> YNConfirmStyle>(
+    pub fn new_with_cb<F: FnOnce(&TuiOverlay) -> YNConfirmStyle, T: Into<String>>(
         config: SharedTuiSettings,
-        title: &'static str,
+        title: T,
         cb: F,
     ) -> Self {
         let component = {
@@ -59,6 +59,7 @@ impl YNConfirm {
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
         let cmd_result = match ev {
+            Event::Keyboard(KeyEvent { code: Key::Esc, .. }) => return Some(on_n),
             Event::Keyboard(KeyEvent {
                 code: Key::Left, ..
             }) => self.perform(Cmd::Move(Direction::Left)),

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -311,6 +311,8 @@ impl UI {
     ///
     /// Less nesting.
     async fn run_playback_playlist(&mut self, ev: PlaylistCmd) -> Result<()> {
+        // TODO: consider refactoring at least some parts of this code to not block the TUI
+        // because currently a massive "PlaylistCmd::AddTrack" will block TUI until the server responds with done.
         match ev {
             PlaylistCmd::AddTrack(tracks) => {
                 self.playback.add_to_playlist(tracks).await?;

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -589,6 +589,29 @@ impl Model {
                 let db_search_tracks = self.dw.search_tracks.clone();
                 self.playlist_add_all_from_db(&db_search_tracks);
             }
+
+            DBMsg::AddResultToPlaylist(index) => {
+                if let Some(result) = self.dw.search_results.get(*index).cloned() {
+                    if let Some(result) =
+                        self.database_get_tracks_by_criteria(self.dw.criteria, &result)
+                    {
+                        self.playlist_add_all_from_db(&result);
+                    }
+                }
+            }
+            DBMsg::AddAllResultsToPlaylist => {
+                self.database_add_all_results();
+            }
+
+            DBMsg::AddAllResultsConfirmShow => {
+                // dont try showing the popup if there is nothing to add
+                if !self.dw.search_results.is_empty() {
+                    self.mount_results_add_confirm_database(self.dw.criteria);
+                }
+            }
+            DBMsg::AddAllResultsConfirmCancel => {
+                self.umount_results_add_confirm_database();
+            }
         }
         None
     }

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -428,6 +428,10 @@ impl Model {
             let popup = draw_area_in_absolute(f.area(), 65, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::PodcastAddPopup, f, popup);
+        } else if app.mounted(&Id::DatabaseAddConfirmPopup) {
+            let popup = draw_area_in_absolute(f.area(), 60, 3);
+            f.render_widget(Clear, popup);
+            app.view(&Id::DatabaseAddConfirmPopup, f, popup);
         }
         if app.mounted(&Id::MessagePopup) {
             let popup = draw_area_top_right_absolute(f.area(), 25, 4);


### PR DESCRIPTION
This PR adds support for the `add single` and `add all` keys to work in the `Result` view / section of the Database layout.

Behavior:
- using `add single`(default `L`) will load that selected thing without question (maybe we should ask for anything other than `Album` or `Artist`?)
- using `add all`(default `shift+L`) will first ask via popup if it is actually wanted, if confirmed, will collect all results and send it to the server, which currently can be massively blocking the TUI as the server is kinda slow resolving the tracks and then responding with done.

fixes #483 

@Sporarum could you review if this is what you wanted?