### PR TITLE
Add Backend Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Feat(tui): allow using "add single / add all" keys on Database `Result` view.
 - Feat(server): for rusty backend, add feature `rusty-simd` to enable SIMD instructions for decoding.
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
+- Feat(server): on rusty backend, allow choosing which speed modifier to use in the config.
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change: change default transport protocol to be UDS on `unix` systems.
 - Change(tui): rename cli option `--disable-cover`  to `--hide-cover`.
 - Change(tui): dont depend on `termusicplayback` anymore.
+- Feat: allow setting the backend in the `server.toml` config.
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
 - Feat(tui): add native theme support. Useful for example for `pywal`.
 - Feat(tui): allow using "add single / add all" keys on Database `Result` view.

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// Settings specific to a backend
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
+pub struct BackendSettings {
+    #[serde(skip)] // skip as long as there are no values
+    pub rusty: RustyBackendSettings,
+    #[serde(skip)] // skip as long as there are no values
+    pub mpv: MpvBackendSettings,
+    #[serde(skip)] // skip as long as there are no values
+    pub gst: GstBackendSettings,
+}
+
+/// Settings specific to the `rusty` backend
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
+pub struct RustyBackendSettings {
+    // None for now
+}
+
+/// Settings specific to the `mpv` backend
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
+pub struct MpvBackendSettings {
+    // None for now
+}
+
+/// Settings specific to the `gst` backend
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
+pub struct GstBackendSettings {
+    // None for now
+}

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct BackendSettings {
-    #[serde(skip)] // skip as long as there are no values
     pub rusty: RustyBackendSettings,
     #[serde(skip)] // skip as long as there are no values
     pub mpv: MpvBackendSettings,
@@ -13,10 +12,17 @@ pub struct BackendSettings {
 }
 
 /// Settings specific to the `rusty` backend
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct RustyBackendSettings {
-    // None for now
+    /// Enable or disable `soundtouch`; only has a effect if `rusty-soundtouch` is compiled-in
+    pub soundtouch: bool,
+}
+
+impl Default for RustyBackendSettings {
+    fn default() -> Self {
+        Self { soundtouch: true }
+    }
 }
 
 /// Settings specific to the `mpv` backend

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -8,7 +8,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::track::MediaType;
+use backends::BackendSettings;
 
+pub mod backends;
 /// Extra things necessary for a config file, like wrappers for versioning
 pub mod config_extra;
 
@@ -21,6 +23,8 @@ pub struct ServerSettings {
     pub com: ComSettings,
     pub player: PlayerSettings,
     pub podcast: PodcastSettings,
+    #[serde(skip)] // skip as long as there are no values
+    pub backends: BackendSettings,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -479,9 +483,9 @@ mod v1_interop {
     use std::num::TryFromIntError;
 
     use super::{
-        Backend, ComSettings, LoopMode, NonZeroU32, NonZeroU8, PlayerSettings, PodcastSettings,
-        PositionYesNo, PositionYesNoLower, RememberLastPosition, ScanDepth, SeekStep,
-        ServerSettings,
+        backends::BackendSettings, Backend, ComSettings, LoopMode, NonZeroU32, NonZeroU8,
+        PlayerSettings, PodcastSettings, PositionYesNo, PositionYesNoLower, RememberLastPosition,
+        ScanDepth, SeekStep, ServerSettings,
     };
     use crate::config::v1;
 
@@ -602,6 +606,7 @@ mod v1_interop {
                 com: com_settings,
                 player: player_settings,
                 podcast: podcast_settings,
+                backends: BackendSettings::default(),
             })
         }
     }

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -23,7 +23,6 @@ pub struct ServerSettings {
     pub com: ComSettings,
     pub player: PlayerSettings,
     pub podcast: PodcastSettings,
-    #[serde(skip)] // skip as long as there are no values
     pub backends: BackendSettings,
 }
 

--- a/playback/src/backends/mod.rs
+++ b/playback/src/backends/mod.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt::Display};
 
-use termusiclib::config::{v2::server::Backend as ConfigBackend, ServerOverlay};
+use termusiclib::config::{v2::server::Backend as ConfigBackend, SharedServerSettings};
 
 use crate::{PlayerCmdSender, PlayerTrait};
 
@@ -73,14 +73,14 @@ impl Backend {
     /// Create a new Backend based on `backend`([`BackendSelect`])
     pub(crate) fn new_select(
         backend: BackendSelect,
-        config: &ServerOverlay,
+        config: SharedServerSettings,
         cmd_tx: PlayerCmdSender,
     ) -> Self {
         match backend {
             #[cfg(feature = "mpv")]
-            BackendSelect::Mpv => Self::new_mpv(config, cmd_tx),
+            BackendSelect::Mpv => Self::new_mpv(&config, cmd_tx),
             #[cfg(feature = "gst")]
-            BackendSelect::GStreamer => Self::new_gstreamer(config, cmd_tx),
+            BackendSelect::GStreamer => Self::new_gstreamer(&config, cmd_tx),
             BackendSelect::Rusty => Self::new_rusty(config, cmd_tx),
         }
     }
@@ -89,7 +89,7 @@ impl Backend {
     // ///
     // /// For the order see [`BackendSelect::Default`]
     // #[allow(unreachable_code)]
-    // fn new_default(config: &ServerOverlay, cmd_tx: PlayerCmdSender) -> Self {
+    // fn new_default(config: SharedServerSettings, cmd_tx: PlayerCmdSender) -> Self {
     //     #[cfg(feature = "gst")]
     //     return Self::new_gstreamer(config, cmd_tx);
     //     #[cfg(feature = "mpv")]
@@ -98,23 +98,25 @@ impl Backend {
     // }
 
     /// Explicitly choose Backend [`RustyBackend`](rusty::RustyBackend)
-    fn new_rusty(config: &ServerOverlay, cmd_tx: PlayerCmdSender) -> Self {
+    fn new_rusty(config: SharedServerSettings, cmd_tx: PlayerCmdSender) -> Self {
         info!("Using Backend \"rusty\"");
         Self::Rusty(rusty::RustyBackend::new(config, cmd_tx))
     }
 
     /// Explicitly choose Backend [`GstreamerBackend`](gstreamer::GStreamerBackend)
     #[cfg(feature = "gst")]
-    fn new_gstreamer(config: &ServerOverlay, cmd_tx: PlayerCmdSender) -> Self {
+    fn new_gstreamer(config: &SharedServerSettings, cmd_tx: PlayerCmdSender) -> Self {
         info!("Using Backend \"GStreamer\"");
-        Self::GStreamer(gstreamer::GStreamerBackend::new(config, cmd_tx))
+        let config_read = config.read();
+        Self::GStreamer(gstreamer::GStreamerBackend::new(&config_read, cmd_tx))
     }
 
     /// Explicitly choose Backend [`MpvBackend`](mpv::MpvBackend)
     #[cfg(feature = "mpv")]
-    fn new_mpv(config: &ServerOverlay, cmd_tx: PlayerCmdSender) -> Self {
+    fn new_mpv(config: &SharedServerSettings, cmd_tx: PlayerCmdSender) -> Self {
         info!("Using Backend \"mpv\"");
-        Self::Mpv(mpv::MpvBackend::new(config, cmd_tx))
+        let config_read = config.read();
+        Self::Mpv(mpv::MpvBackend::new(&config_read, cmd_tx))
     }
 
     #[must_use]

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -55,6 +55,18 @@ struct Controls {
     position: RwLock<Duration>,
 }
 
+/// Options to apply to a specific source
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceOptions {
+    pub soundtouch: bool,
+}
+
+impl Default for SourceOptions {
+    fn default() -> Self {
+        Self { soundtouch: true }
+    }
+}
+
 #[allow(dead_code)]
 impl Sink {
     /// Builds a new `Sink`, beginning playback on a stream.
@@ -100,7 +112,7 @@ impl Sink {
     /// Appends a sound to the queue of sounds to play.
     #[inline]
     #[allow(clippy::cast_possible_wrap)]
-    pub fn append<S>(&self, source: S)
+    pub fn append<S>(&self, source: S, options: &SourceOptions)
     where
         S: Source<Item = SampleType> + Send + 'static,
     {
@@ -117,7 +129,7 @@ impl Sink {
         let progress_tx = self.picmd_tx.clone();
         let source = source
             .track_position()
-            .custom_speed(1.0, SpecificType::soundtouch(true))
+            .custom_speed(1.0, SpecificType::soundtouch(options.soundtouch))
             .amplify(1.0)
             .pausable(false)
             .skippable()

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -9,9 +9,8 @@ use parking_lot::{Mutex, RwLock};
 use rodio::{queue, source::Done, Source};
 use rodio::{OutputStreamHandle, PlayError};
 
-use super::source::SampleType;
-#[allow(unused_imports)] // used for "rusty-soundtouch"
 use super::source::SourceExt as _;
+use super::source::{SampleType, SpecificType};
 use super::PlayerInternalCmd;
 use crate::PlayerCmd;
 
@@ -118,7 +117,7 @@ impl Sink {
         let progress_tx = self.picmd_tx.clone();
         let source = source
             .track_position()
-            .custom_speed(1.0)
+            .custom_speed(1.0, SpecificType::soundtouch(true))
             .amplify(1.0)
             .pausable(false)
             .skippable()

--- a/playback/src/backends/rusty/sink.rs
+++ b/playback/src/backends/rusty/sink.rs
@@ -176,6 +176,7 @@ impl Sink {
         self.sound_count.fetch_add(1, Ordering::Relaxed);
         let source = Done::new(source, self.sound_count.clone());
         *self.sleep_until_end.lock() = Some(self.queue_tx.append_with_signal(source));
+        self.message_on_end();
     }
 
     /// Gets the volume of the sound.
@@ -317,9 +318,9 @@ impl Sink {
         *self.controls.position.read()
     }
 
-    // Spawns a new thread to sleep until the sound ends, and then sends the SoundEnded
-    // message through the given Sender.
-    pub fn message_on_end(&self) {
+    // Spawns a new thread to sleep until the sound ends, and then sends the `Eos`
+    // message through the given Senders.
+    fn message_on_end(&self) {
         // TODO: we should not expose this function to be called outside of rusty-mod and always just have it active as we always need it
         // NOTE: (in addition to the todo), we always use "message_on_end" to rely on EOS, so it is basically always set, so it should not be necessary
         // to be set by commands every time, and worst, forget to call it or have race conditions that enqueue multiple things and wait on the wrong thing.

--- a/playback/src/backends/rusty/source/custom_speed.rs
+++ b/playback/src/backends/rusty/source/custom_speed.rs
@@ -34,6 +34,7 @@ where
         SpecificType::Rodio => CustomSpeed::Rodio(input.speed(initial_speed)),
         #[cfg(feature = "rusty-soundtouch")]
         SpecificType::Soundtouch => {
+            trace!("Using soundtouch");
             CustomSpeed::SoundTouch(super::soundtouch::soundtouch(input, initial_speed))
         }
     }

--- a/playback/src/backends/rusty/source/mod.rs
+++ b/playback/src/backends/rusty/source/mod.rs
@@ -1,5 +1,6 @@
 //! Custom rodio sources and extension trait
 
+pub use custom_speed::SpecificType;
 use rodio::{Sample, Source};
 
 #[cfg(feature = "rusty-soundtouch")]
@@ -19,12 +20,16 @@ where
     Self::Item: Sample,
 {
     /// A custom [`Source`] implementation to abstract away which speed module gets chosen.
-    fn custom_speed(self, initial_speed: f32) -> custom_speed::CustomSpeed<Self>
+    fn custom_speed(
+        self,
+        initial_speed: f32,
+        specific: SpecificType,
+    ) -> custom_speed::CustomSpeed<Self>
     where
         Self: Sized,
         Self: Source<Item = f32>,
     {
-        custom_speed::custom_speed(self, initial_speed)
+        custom_speed::custom_speed(self, initial_speed, specific)
     }
 }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -295,10 +295,6 @@ impl GeneralPlayer {
                 drop(playlist);
                 self.current_track_updated = true;
                 info!("gapless next track played");
-                #[allow(irrefutable_let_patterns)]
-                if let Backend::Rusty(ref mut backend) = self.backend {
-                    backend.message_on_end();
-                }
                 self.add_and_play_mpris_discord();
                 return;
             }
@@ -312,10 +308,6 @@ impl GeneralPlayer {
 
             self.add_and_play_mpris_discord();
             self.player_restore_last_position();
-            #[allow(irrefutable_let_patterns)]
-            if let Backend::Rusty(ref mut backend) = self.backend {
-                backend.message_on_end();
-            }
 
             self.send_stream_ev(UpdateEvents::TrackChanged(TrackChangedInfo {
                 current_track_index: u64::try_from(self.playlist.read().get_current_track_index())

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -157,12 +157,12 @@ impl GeneralPlayer {
         stream_tx: StreamTX,
         playlist: SharedPlaylist,
     ) -> Result<Self> {
-        let config_read = config.read();
-        let backend = Backend::new_select(backend, &config_read, cmd_tx.clone());
+        let backend = Backend::new_select(backend, config.clone(), cmd_tx.clone());
 
         let db_path = get_app_config_path().with_context(|| "failed to get podcast db path.")?;
 
         let db_podcast = DBPod::new(&db_path).with_context(|| "error connecting to podcast db.")?;
+        let config_read = config.read();
         let db = DataBase::new(&config_read)?;
 
         let mpris = if config.read().settings.player.use_mediacontrols {

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -44,8 +44,9 @@ pub struct Args {
     /// Max depth(NUMBER) of folder, default is 4.
     #[arg(short, long)]
     pub max_depth: Option<u32>,
-    #[arg(short, long, default_value_t = Backend::Rusty, env = "TMS_BACKEND")]
-    pub backend: Backend,
+    /// Select the backend, default is `rusty`
+    #[arg(short, long, env = "TMS_BACKEND")]
+    pub backend: Option<Backend>,
     #[clap(flatten)]
     pub log_options: LogOptions,
 }
@@ -57,12 +58,6 @@ pub enum Backend {
     #[cfg(feature = "gst")]
     #[value(alias = "gst", name = "gstreamer")]
     GStreamer,
-    /// Create a new Backend with default backend ordering
-    ///
-    /// Order:
-    /// - [`Rusty`](Backend::Rusty) (default)
-    /// - [`GStreamer`](Backend::GStreamer) (feature `gst`)
-    /// - [`Mpv`](Backend::Mpv) (feature `mpv`)
     Rusty,
 }
 

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -130,9 +130,10 @@ async fn actual_main() -> Result<()> {
             server_args.push("--log-filecolor");
         }
 
-        let backend = args.backend.to_string();
-        server_args.push("--backend");
-        server_args.push(&backend);
+        if let Some(backend) = args.backend {
+            server_args.push("--backend");
+            server_args.push(backend.as_str());
+        }
 
         // server can stay around after client exits (if supported by the system)
         #[allow(clippy::zombie_processes)]


### PR DESCRIPTION
This PR mainly focuses on adding backend related options, in more details:
- add config option to select the backend; previously this was only available as a cli option / environment variable
- add config option to enable / disable soundtouch, if compiled in (otherwise it will have no effect)
- add config options for the other backends (which are skipped until there actual options)

Some slight related refactors:
- move rusty `player_thread` arguments into a struct to reduce confusion and resolve `clippy::too_many_arguments`
- always call `message_on_end` on the sink instead of having to do it outside

I am not quite satisfied with the way i am passing around options from the player_thread to the sink, but without further refactors (which i intend to maybe do) it is ugly, but it will do for now.