### PR TITLE
Rename `ytdlp.extra_ytdlp_args` to `ytdlp.extra_args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Feat(tui): add new cli option `--disable-cover` which actually disables all cover probing and behaves as if no cover features are enabled.
 - Feat(tui): add native theme support. Useful for example for `pywal`.
 - Feat(tui): allow using "add single / add all" keys on Database `Result` view.
+- Feat(tui): add option to add extra arguments to the yt-dl command.
 - Feat(server): for rusty backend, add feature `rusty-simd` to enable SIMD instructions for decoding.
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
 - Feat(server): on rusty backend, allow choosing which speed modifier to use in the config.

--- a/lib/src/config/v2/tui/mod.rs
+++ b/lib/src/config/v2/tui/mod.rs
@@ -115,18 +115,10 @@ pub enum Alignment {
     BottomLeft,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 pub struct Ytdlp {
     /// Extra args for yt-dlp
-    pub extra_ytdlp_args: String,
-}
-
-impl Default for Ytdlp {
-    fn default() -> Self {
-        Self {
-            extra_ytdlp_args: String::new(),
-        }
-    }
+    pub extra_args: String,
 }
 
 mod v1_interop {

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -896,7 +896,7 @@ impl ExtraYtdlpArgs {
                     Style::default().fg(Color::Rgb(128, 128, 128)),
                 )
                 .title(" Extra Args for yt-dlp: ", Alignment::Left)
-                .value(&config_tui.settings.ytdlp.extra_ytdlp_args)
+                .value(&config_tui.settings.ytdlp.extra_args)
         };
 
         Self {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -2002,7 +2002,7 @@ impl Model {
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs))
         {
-            config_tui.settings.ytdlp.extra_ytdlp_args = extra_ytdlp_args;
+            config_tui.settings.ytdlp.extra_args = extra_ytdlp_args;
         }
         Ok(())
     }

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -174,7 +174,7 @@ impl Model {
             Arg::new_with_arg("--convert-subs", "lrc"),
             Arg::new_with_arg("--output", "%(title).90s.%(ext)s"),
         ];
-        let extra_args = parse_args(&config_tui.settings.ytdlp.extra_ytdlp_args)
+        let extra_args = parse_args(&config_tui.settings.ytdlp.extra_args)
             .context("Parsing config `extra_ytdlp_args`")?;
         let mut extra_args_parsed = convert_to_args(extra_args);
         if !extra_args_parsed.is_empty() {


### PR DESCRIPTION
This PR renames the property from `extra_ytdlp_args` to `extra_args` to remove redundancy in the name.
Also add this change to the CHANGELOG.

re #486