### PR TITLE
style: fix lints for rust 1.87.0

### DIFF
--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -754,6 +754,7 @@ impl Playlist {
     }
 
     /// Create a Track from a given Path
+    #[allow(clippy::unnecessary_debug_formatting)] // we want debug information about a path (especially have it escaped)
     fn track_from_path(path_str: &str) -> Result<Track, PlaylistAddError> {
         let path = Path::new(path_str);
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -53,6 +53,7 @@ impl MusicPlayerService {
         }
     }
 
+    #[expect(clippy::result_large_err)] // for now we dont care about that here, also see https://github.com/hyperium/tonic/issues/2253
     fn command_cb(&self, cmd: PlayerCmd) -> Result<PlayerCmdCallback, Status> {
         let rx = self.cmd_tx.send_cb(cmd.clone()).map_err(|err| {
             error!("error {cmd:?}: {err}");


### PR DESCRIPTION
Once again a new rust version with new pedantic lints has released.
This time though, we will ignore those new lints for now as its either the wanted behavior or not much we can do about it (at least conveniently).