### PR TITLE
Add buffer size configuration options for rusty backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Feat(server): for rusty backend, add feature `rusty-simd` to enable SIMD instructions for decoding.
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
 - Feat(server): on rusty backend, allow choosing which speed modifier to use in the config.
+- Feat(server): on rusty backend, allow configuring file buffer size.
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Feat(server): on rusty backend, do async decoding instead of JIT decoding for music and podcast files. (fixes #191)
 - Feat(server): on rusty backend, allow choosing which speed modifier to use in the config.
 - Feat(server): on rusty backend, allow configuring file buffer size.
+- Feat(server): on rusty backend, allow configuring decoded(ring) buffer size.
 - Fix(tui): set `ueberzug` command to `--silent`.
 - Fix(tui): force viuer to use the terminal image protocol that was probed at the beginning.
 - Fix(tui): add CTRL+C handler for when TUI key-reading is not active yet or not active anymore.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytesize"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4777,6 +4786,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytes",
+ "bytesize",
  "cc",
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "2.0.12"
 async-trait = "0.1.88"
 base64 = "0.22"
 bytes = "1.10"
+bytesize = { version = "2.0", features = ["serde"] }
 chrono = "0.4.41"
 clap = { version = "4.5.38", features = ["derive", "env"] }
 ctrlc = { version = "3.4.6", features = ["termination"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 base64.workspace = true
 bytes.workspace = true #   = "1"
+bytesize.workspace = true
 chrono.workspace = true #   = "^0.4.23"
 dirs.workspace = true
 escaper.workspace = true #   = "0.1.1"

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -19,6 +19,12 @@ pub struct BackendSettings {
 /// [`BufReader`]'s default size is 8 Kib
 pub const FILEBUF_SIZE_DEFAULT: u64 = 1024 * 1024 * 4;
 
+/// The minimal and default size the decode-ringbuffer should have.
+///
+/// Currently the size is based on 192kHz * 1 channel * 1 seconds, or 2 seconds of 48kHz stereo(2 channel) audio.
+// NOTE: this may desync with the actual `MIN_RING_SIZE` if the type or message size should change, and that should be consulted instead
+pub const DECODEDBUF_SIZE_DEFAULT: u64 = 192_000 * size_of::<f32>() as u64;
+
 /// Settings specific to the `rusty` backend
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
@@ -26,10 +32,18 @@ pub struct RustyBackendSettings {
     /// Enable or disable `soundtouch`; only has a effect if `rusty-soundtouch` is compiled-in
     pub soundtouch: bool,
     /// Set the buffer size for the raw file.
+    /// This value will be clamped to the actual file's size.
     /// Note this only applies to local files like music or downloaded podcasts. Does not apply to streamed podcasts or radio.
     ///
     /// If the given value is less than the default, the default will be used instead.
     pub file_buffer_size: ByteSize,
+    /// Set the decoded ring buffer size.
+    /// This controls how many decoded audio bytes are stored.
+    /// Unlike `file_buffer_size`, this buffer will always be this size, regardless if there is less data.
+    /// Note this only applies to local files like music or downloaded podcasts. Does not apply to streamed podcasts or radio.
+    ///
+    /// If the given value is less than the default, the default will be used instead.
+    pub decoded_buffer_size: ByteSize,
 }
 
 impl Default for RustyBackendSettings {
@@ -37,6 +51,7 @@ impl Default for RustyBackendSettings {
         Self {
             soundtouch: true,
             file_buffer_size: ByteSize::b(FILEBUF_SIZE_DEFAULT),
+            decoded_buffer_size: ByteSize::b(DECODEDBUF_SIZE_DEFAULT),
         }
     }
 }

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
 
 /// Settings specific to a backend
@@ -11,17 +12,32 @@ pub struct BackendSettings {
     pub gst: GstBackendSettings,
 }
 
+/// Default Buffer capacity in bytes
+///
+/// 1024 * 1024 * 4 = 4 MiB
+///
+/// [`BufReader`]'s default size is 8 Kib
+pub const FILEBUF_SIZE_DEFAULT: u64 = 1024 * 1024 * 4;
+
 /// Settings specific to the `rusty` backend
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct RustyBackendSettings {
     /// Enable or disable `soundtouch`; only has a effect if `rusty-soundtouch` is compiled-in
     pub soundtouch: bool,
+    /// Set the buffer size for the raw file.
+    /// Note this only applies to local files like music or downloaded podcasts. Does not apply to streamed podcasts or radio.
+    ///
+    /// If the given value is less than the default, the default will be used instead.
+    pub file_buffer_size: ByteSize,
 }
 
 impl Default for RustyBackendSettings {
     fn default() -> Self {
-        Self { soundtouch: true }
+        Self {
+            soundtouch: true,
+            file_buffer_size: ByteSize::b(FILEBUF_SIZE_DEFAULT),
+        }
     }
 }
 

--- a/playback/src/backends/rusty/decoder/mod.rs
+++ b/playback/src/backends/rusty/decoder/mod.rs
@@ -90,23 +90,10 @@ pub struct Symphonia {
 }
 
 impl Symphonia {
-    /// Create a new instance, which also returns a [`MediaTitleRx`]
-    #[inline]
-    pub fn new_with_media_title(
-        mss: MediaSourceStream,
-        gapless: bool,
-    ) -> Result<(Self, MediaTitleRx), SymphoniaDecoderError> {
-        // guaranteed if "media_title" is set to "true"
-        Self::common_new(mss, gapless, true).map(|v| (v.0, v.1.unwrap()))
-    }
-
-    /// Create a new instance, without a [`MediaTitleRx`]
-    #[inline]
-    pub fn new(mss: MediaSourceStream, gapless: bool) -> Result<Self, SymphoniaDecoderError> {
-        Self::common_new(mss, gapless, false).map(|v| v.0)
-    }
-
-    fn common_new(
+    /// Create a new symphonia decoder.
+    ///
+    /// The returned `Option<MediaTitleRx>` is always `Some` if parameter `media_title` is `true`.
+    pub fn new(
         mss: MediaSourceStream,
         gapless: bool,
         media_title: bool,

--- a/playback/src/backends/rusty/mod.rs
+++ b/playback/src/backends/rusty/mod.rs
@@ -80,14 +80,8 @@ pub struct RustyBackend {
     config: SharedServerSettings,
 }
 
-#[allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
-)]
 impl RustyBackend {
     #[allow(clippy::similar_names)]
-    #[allow(clippy::too_many_lines)]
     pub fn new(config: SharedServerSettings, cmd_tx: crate::PlayerCmdSender) -> Self {
         let config_read = config.read();
         let (picmd_tx, picmd_rx): (Sender<PlayerInternalCmd>, Receiver<PlayerInternalCmd>) =
@@ -217,8 +211,6 @@ impl PlayerTrait for RustyBackend {
         self.command(PlayerInternalCmd::Stop);
     }
 
-    #[allow(clippy::cast_precision_loss)]
-    #[allow(clippy::cast_possible_wrap)]
     fn get_progress(&self) -> Option<PlayerProgress> {
         Some(PlayerProgress {
             position: Some(*self.position.lock()),

--- a/playback/src/backends/rusty/source/async_ring/mod.rs
+++ b/playback/src/backends/rusty/source/async_ring/mod.rs
@@ -31,6 +31,7 @@ pub type SeekData = (Duration, oneshot::Sender<usize>);
 /// The minimal size a decode-ringbuffer should have.
 ///
 /// Currently the size is based on 192kHz * 1 channel * 1 seconds, or 2 seconds of 48kHz stereo(2 channel) audio.
+// NOTE: try to keep this in-sync with the config's `RINGBUF_SIZE_DEFAULT`
 pub const MIN_RING_SIZE: usize = 192_000 * MessageDataValue::MESSAGE_SIZE;
 
 /// A ringbuffer Producer meant for wrapping [`Source`] to make decode & playback async and keep the buffer filled without having audible gaps.


### PR DESCRIPTION
This PR cleans-up the option passing between `PlayerTrait` until actually appeneded to the sink (`sink.append`). Due to this clean-up it is easy to add the configuration options for the buffer sizes or other options in the future.
This adds dependency `bytesize` to not have to re-implement string parsing / creation from scratch or having to store a large "magic" number in the config.

```diff toml
[backends.rusty]
soundtouch = true
+file_buffer_size = "4.0 MiB"
+decoded_buffer_size = "750.0 KiB"
```

PS: this cleanup also allows us to quickly change from async-decode(ringbuf) to sync-decode(no ringbuf) or vise-versa, with only the change of one option `async_decode`.