### PR TITLE
Change the TUI Music library tree loading to be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix(tui): re-select the (approximately) same playlist item after a shuffle.
 - Fix(tui): escape key will now no longer also act as a quit key.
 - Fix(tui): changed the music library tree loading to be async.
+- Fix(tui): in the music library tree, when stepping out now the correct node if focused instead of the root node.
 - Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix(tui): on track change, dont select "current track" playlist item if the old "current track" was not selected.
 - Fix(tui): re-select the (approximately) same playlist item after a shuffle.
 - Fix(tui): escape key will now no longer also act as a quit key.
+- Fix(tui): changed the music library tree loading to be async.
 - Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::v2::tui::{keys::KeyBinding, theme::styles::ColorTermusic};
@@ -387,6 +388,14 @@ pub enum KFMsg {
     PodcastRefreshAllFeedsBlurUp,
 }
 
+/// Basically a Tree Node, but without having to include `tui-realm-treeview` as another dependency for lib
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecVec<T, V> {
+    pub id: T,
+    pub value: V,
+    pub children: Vec<RecVec<T, V>>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LIMsg {
     TreeStepInto(String),
@@ -397,6 +406,10 @@ pub enum LIMsg {
     SwitchRoot,
     AddRoot,
     RemoveRoot,
+
+    /// A requested node is ready from loading.
+    /// `(Tree, FocusNode)`
+    TreeNodeReady(RecVec<PathBuf, String>, Option<String>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1732,7 +1732,7 @@ impl Model {
     }
 
     pub fn umount_config_editor(&mut self) {
-        self.library_reload_tree();
+        self.library_scan_dir(&self.library.tree_path, None);
         self.playlist_reload();
         self.database_reload();
         self.progress_reload();

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -397,13 +397,16 @@ impl Model {
         }
     }
 
+    /// Handle stepping into a node on the tree
     pub fn library_stepinto(&mut self, node_id: &str) {
         self.library_scan_dir(PathBuf::from(node_id), None);
     }
 
+    /// Handle stepping out of the current root node on the tree
     pub fn library_stepout(&mut self) {
         if let Some(p) = self.library_upper_dir() {
-            self.library_scan_dir(p, None);
+            let focus_node = Some(self.library.tree_path.to_string_lossy().to_string());
+            self.library_scan_dir(p, focus_node);
         }
     }
 

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -90,6 +90,7 @@ impl MusicLibrary {
         let current_node = self.component.tree_state().selected().unwrap();
         let p: &Path = Path::new(current_node);
         if p.is_dir() {
+            // TODO: try to load the directory if it is not loaded yet.
             (self.perform(Cmd::Custom(TREE_CMD_OPEN)), None)
         } else {
             (

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -888,7 +888,7 @@ impl Model {
         // TODO: move this to server?
         self.playback.playlist.save_m3u(filename)?;
 
-        self.library_reload_with_node_focus(Some(&filename.to_string_lossy()));
+        self.library_reload_with_node_focus(Some(filename.to_string_lossy().to_string()));
 
         Ok(())
     }

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -34,7 +34,7 @@ impl Model {
             TEMsg::TagEditorClose => {
                 if let Some(s) = self.tageditor_song.clone() {
                     // TODO: this should be re-done and take actual track ids themself, or at least verified to use the same functions to result in the same id
-                    self.library_reload_with_node_focus(Some(&s.path_as_id_str()));
+                    self.library_reload_with_node_focus(Some(s.path_as_id_str().to_string()));
                 }
                 self.umount_tageditor();
             }


### PR DESCRIPTION
This PR changes the TUI music library tree loading to be non-blocking and feel responsive by not being locked-up.
Also fixes a bug that the root node is always selected when stepping out of the current directory instead of focusing the stepped-out of node.

Important notes:
- because it is now loading async and the component itself was not touched, means that while something is loading, the user can still navigate and execute things on the tree, like for example starting another load
- the initial `Loading...` text is currently handled via a tree with such a node and a dummy path, but because of this, it can still be navigated. (at least on linux, didnt test this dummy path on windows)
- this pr did not change anything regarding pre-loading a directory, so when encountering a directory that is not pre-loaded (due to for example having `library_scan_depth` set to `1`), the node cannot be expanded (via `ARROW RIGHT`), but can still be stepped into.

@emenel Could you try this PR on your big music library with a higher `library_scan_depth` again and see if it is responsive now?

fixes #481
re #159; this PR coves the main case described there, but does not entirely fix it as, to my knowledge, there are still some sync things that could block processing command.

PS: the previous implementation re-loaded the tree from disk quite often, now it does not anymore.