### PR TITLE
Fix mpv race condition panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.
+- Fix(server): on mpv backend, fix possible race condition that could cause a panic by having `time-pos` event before `duration` event.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -239,7 +239,12 @@ impl Track {
 
     /// Create a new Track from a local file, populated with the most important tags
     pub fn read_track_from_path<P: Into<PathBuf>>(path: P) -> Result<Self> {
-        let path = path.into();
+        let path: PathBuf = path.into();
+
+        // for the case that we somehow get a path that is just ""(empty)
+        if path.as_os_str().is_empty() {
+            bail!("Given path is empty!");
+        }
 
         let metadata = match parse_metadata_from_file(
             &path,

--- a/playback/src/backends/gstreamer/mod.rs
+++ b/playback/src/backends/gstreamer/mod.rs
@@ -518,8 +518,6 @@ impl PlayerTrait for GStreamerBackend {
         let _ = self.playbin.set_state(gst::State::Null);
     }
 
-    #[allow(clippy::cast_precision_loss)]
-    #[allow(clippy::cast_possible_wrap)]
     fn get_progress(&self) -> Option<PlayerProgress> {
         let position = Some(self.playbin.get_position()?.into());
         let total_duration = Some(self.playbin.get_duration()?.into());

--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -18,6 +18,8 @@ use termusiclib::track::{MediaTypes, Track};
 
 use crate::{MediaInfo, PlayerCmd, PlayerProgress, PlayerTrait, Speed, Volume};
 
+pub type ArcTotalDuration = Arc<Mutex<Option<Duration>>>;
+
 pub struct MpvBackend {
     // player: Mpv,
     volume: u16,
@@ -25,8 +27,7 @@ pub struct MpvBackend {
     gapless: bool,
     command_tx: Sender<PlayerInternalCmd>,
     position: Arc<Mutex<Duration>>,
-    // TODO: this should likely be a Option
-    duration: Arc<Mutex<Duration>>,
+    total_duration: ArcTotalDuration,
     media_title: Arc<Mutex<String>>,
     // cmd_tx: crate::PlayerCmdSender,
 }
@@ -53,10 +54,10 @@ impl MpvBackend {
         let speed = config.settings.player.speed;
         let gapless = config.settings.player.gapless;
         let position = Arc::new(Mutex::new(Duration::default()));
-        let duration = Arc::new(Mutex::new(Duration::default()));
+        let total_duration = Arc::new(Mutex::new(None));
         let media_title = Arc::new(Mutex::new(String::new()));
         let position_inside = position.clone();
-        let duration_inside = duration.clone();
+        let total_duration_inside = total_duration.clone();
         let media_title_inside = media_title.clone();
 
         let mpv = Mpv::new().expect("Couldn't initialize MpvHandlerBuilder");
@@ -85,7 +86,7 @@ impl MpvBackend {
                     &cmd_tx,
                     &media_title_inside,
                     &position_inside,
-                    &duration_inside,
+                    &total_duration_inside,
                 );
             })
             .expect("failed to start mpv event loop thread");
@@ -96,7 +97,7 @@ impl MpvBackend {
             gapless,
             command_tx,
             position,
-            duration,
+            total_duration,
             media_title,
         }
     }
@@ -109,7 +110,7 @@ impl MpvBackend {
         cmd_tx: &crate::PlayerCmdSender,
         media_title: &Arc<Mutex<String>>,
         position: &Arc<Mutex<Duration>>,
-        duration: &Arc<Mutex<Duration>>,
+        total_duration: &ArcTotalDuration,
     ) {
         let mut ev_ctx = mpv.create_event_context();
         ev_ctx
@@ -134,7 +135,7 @@ impl MpvBackend {
                             cmd_tx,
                             media_title,
                             position,
-                            duration,
+                            total_duration,
                         );
                     }
                     Err(err) => {
@@ -145,7 +146,7 @@ impl MpvBackend {
             }
 
             if let Ok(cmd) = icmd_rx.try_recv() {
-                Self::handle_internal_cmd(cmd, mpv, duration, cmd_tx);
+                Self::handle_internal_cmd(cmd, mpv, total_duration, cmd_tx);
             }
 
             // This is important to keep the mpv running, otherwise it cannot play.
@@ -160,7 +161,7 @@ impl MpvBackend {
         cmd_tx: &crate::PlayerCmdSender,
         media_title: &Arc<Mutex<String>>,
         position: &Arc<Mutex<Duration>>,
-        duration: &Arc<Mutex<Duration>>,
+        total_duration: &ArcTotalDuration,
     ) {
         match ev {
             Event::EndFile(e) => {
@@ -180,7 +181,7 @@ impl MpvBackend {
                 "duration" => {
                     if let PropertyData::Double(dur) = change {
                         // using "dur.max" because mpv *may* return a negative number
-                        *duration.lock() = Duration::from_secs_f64(dur.max(0.0));
+                        *total_duration.lock() = Some(Duration::from_secs_f64(dur.max(0.0)));
                     }
                 }
                 "time-pos" => {
@@ -190,11 +191,14 @@ impl MpvBackend {
                         *position.lock() = time_pos;
 
                         // About to finish signal is a simulation of gstreamer, and used for gapless
-                        let dur = duration.lock();
-                        let progress = time_pos.as_secs_f64() / dur.as_secs_f64();
-                        if progress >= 0.5 && (*dur - time_pos) < Duration::from_secs(2) {
-                            if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
-                                error!("command AboutToFinish sent failed: {e}");
+                        if let Some(total_duration) = *total_duration.lock() {
+                            let progress = time_pos.as_secs_f64() / total_duration.as_secs_f64();
+                            if progress >= 0.5
+                                && total_duration.saturating_sub(time_pos) < Duration::from_secs(2)
+                            {
+                                if let Err(e) = cmd_tx.send(PlayerCmd::AboutToFinish) {
+                                    error!("command AboutToFinish sent failed: {e}");
+                                }
                             }
                         }
                     }
@@ -226,15 +230,14 @@ impl MpvBackend {
     fn handle_internal_cmd(
         cmd: PlayerInternalCmd,
         mpv: &Mpv,
-        duration: &Arc<Mutex<Duration>>,
+        total_duration: &ArcTotalDuration,
         cmd_tx: &crate::PlayerCmdSender,
     ) {
         match cmd {
-            // PlayerCmd::Eos => message_tx.send(PlayerMsg::Eos).unwrap(),
             PlayerInternalCmd::Play(new) => {
-                *duration.lock() = Duration::default();
+                // reset total duration for new track
+                let _ = total_duration.lock().take();
                 let _ = mpv.command("loadfile", &[&format!("\"{new}\""), "replace"]);
-                // error!("add and play {} ok", new);
             }
             PlayerInternalCmd::QueueNext(next) => {
                 let _ = mpv.command("loadfile", &[&format!("\"{next}\""), "append"]);
@@ -367,7 +370,7 @@ impl PlayerTrait for MpvBackend {
     fn get_progress(&self) -> Option<PlayerProgress> {
         Some(PlayerProgress {
             position: Some(*self.position.lock()),
-            total_duration: Some(*self.duration.lock()),
+            total_duration: *self.total_duration.lock(),
         })
     }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -143,6 +143,15 @@ impl Playlist {
             .with_context(|| "failed to get podcasts from db.")?;
         for line in lines {
             let line = line?;
+
+            let trimmed_line = line.trim();
+
+            // skip empty lines without trying to process them
+            // skip lines that are comments (m3u-like)
+            if trimmed_line.is_empty() || trimmed_line.starts_with('#') {
+                continue;
+            }
+
             if line.starts_with("http") {
                 let mut is_podcast = false;
                 'outer: for pod in &podcasts {

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -166,6 +166,10 @@ impl Playlist {
             }
         }
 
+        // protect against the listed index in the playlist file not matching the elements in the playlist
+        // for example lets say it has "100", but there are only 2 elements in the playlist
+        let current_track_index = current_track_index.min(playlist_items.len().saturating_sub(1));
+
         Ok((current_track_index, playlist_items))
     }
 


### PR DESCRIPTION
This PR fixes the race condition panic as reported in #506, and also some other things that i encountered while trying to debug this, which includes:
- protect against tracks having empty paths
- the playlist should clamp the `current_track_index` on parse to the actual playlist items
- the playlist should skip empty lines and comment lines on parse
- refactor the mpv time resetting to be consistent on `Event::StartFile`

fixes #506 