### PR TITLE
fix(playback::mpv): change seeking to not manually pause / unpause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.
 - Fix(server): on mpv backend, fix possible race condition that could cause a panic by having `time-pos` event before `duration` event.
+- Fix(server): on mpv backend, when seeking while paused, it now stays paused.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -261,23 +261,15 @@ impl MpvBackend {
                 let mut absolute_secs = secs + time_pos_seek;
                 absolute_secs = cmp::max(absolute_secs, 0);
                 absolute_secs = cmp::min(absolute_secs, duration_seek - 5);
-                let _ = mpv.pause();
                 let _ = mpv.command("seek", &[&format!("\"{absolute_secs}\""), "absolute"]);
-                let _ = mpv.unpause();
-                // let _ = message_tx
-                //     .send(PlayerMsg::Progress(time_pos_seek, duration_seek));
             }
             PlayerInternalCmd::SeekAbsolute(position) => {
-                let _ = mpv.pause();
-                while mpv
-                    .command("seek", &[&format_duration(position), "absolute"])
-                    .is_err()
+                while let Err(err) = mpv.command("seek", &[&format_duration(position), "absolute"])
                 {
+                    trace!("Error while absolutely seeking: {err:#?}");
                     // This is because we need to wait until the file is fully loaded.
                     std::thread::sleep(Duration::from_millis(100));
                 }
-                let _ = mpv.unpause();
-                // let _ = message_tx.send(PlayerMsg::Progress(secs, duration));
             }
             PlayerInternalCmd::Eos => {
                 if let Err(e) = cmd_tx.send(PlayerCmd::Eos) {


### PR DESCRIPTION
As mpv automatically handles that.
Also log the error on absolute seek problems (which i dont think actually occur).

fixes #512