### PR TITLE
feat(server): save playlist in intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.
 - Fix(server): on mpv backend, fix possible race condition that could cause a panic by having `time-pos` event before `duration` event.
+- Fix(server): periodically save the playlist to disk, if modified. (Instead of only on exit)
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]


### PR DESCRIPTION
This PR saves the playlist in intervals of 30 seconds, only if modified. Instead of previously on on exit / quit.

This should prevent losing too much on unexpected circumstances like crash, panic or system lockup.

fixes #513