### PR TITLE
Deduplicate `database` widget code & some other things from #511

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix(tui): escape key will now no longer also act as a quit key.
 - Fix(tui): changed the music library tree loading to be async.
 - Fix(tui): in the music library tree, when stepping out now the correct node if focused instead of the root node.
+- Fix(tui): limit Database `DataBase`(criteria) widget to size of elements it contains, now it wont grow beyond that and leave unused space.
 - Fix(server): with `rusty-soundtouch` on `rusty` backend, dont take initial samples until necessary.
 - Fix(server): on rusty backend, always decode and use `f32` samples. (instead of `i16`)
 - Fix(server): on rusty backend, update `soundtouch` version to fix build issues on latest arch & gcc 15.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,6 +4798,7 @@ dependencies = [
  "id3",
  "image",
  "include_dir",
+ "indoc",
  "libaes",
  "lofty",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -4742,6 +4742,7 @@ dependencies = [
  "colored",
  "ctrlc",
  "dirs",
+ "either",
  "escaper",
  "flexi_logger",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ futures-util = "0.3.31"
 alphanumeric-sort = "1.5"
 # for less dependencies, keep in sync with the version ratatui uses
 lru = "0.12.5"
+either = "1.15"
 # transistive dependency for some packages (like libsqlite), manually specified to upgrade the version, see https://github.com/rusqlite/rusqlite/issues/1543
 cc = "1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ glib = { version = "0.20.9" }
 gstreamer = { version = "0.23.5" }
 hex = "0.4"
 id3 = "1.16.2"
+indoc = "2.0.6"
 # image must be upgraded together with viuer
 image = "0.25.6"
 viuer = "0.9"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# This config file is still necessary if we want to further refine lints
+# see https://github.com/rust-lang/rust-clippy/issues/13712
+
+doc-valid-idents = ["ID3v2", "MiB"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -32,6 +32,7 @@ escaper.workspace = true #   = "0.1.1"
 figment.workspace = true # = { version="0.10", features = ["toml"]}
 hex.workspace = true # = "0.4"
 id3.workspace = true # = "1"
+indoc.workspace = true
 image.workspace = true # = "0.24"
 include_dir.workspace = true # = "0.7"
 libaes.workspace = true # = "0.6"

--- a/lib/src/library_db/mod.rs
+++ b/lib/src/library_db/mod.rs
@@ -215,7 +215,7 @@ impl DataBase {
                 .into_iter()
                 .filter_map(std::result::Result::ok)
                 .filter(|f| f.file_type().is_file())
-                .filter(|f| filetype_supported(&f.path().to_string_lossy()))
+                .filter(|f| filetype_supported(f.path()))
             {
                 match Self::need_update(&conn, record.path()) {
                     Ok(true) => {

--- a/lib/src/library_db/track_db.rs
+++ b/lib/src/library_db/track_db.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, UNIX_EPOCH},
 };
 
+use indoc::indoc;
 use rusqlite::{named_params, Connection, Row};
 
 use crate::track::{Track, TrackMetadata};
@@ -147,9 +148,10 @@ impl TrackDBInsertable<'_> {
     /// Insert the current [`TrackDBInsertable`] into the `tracks` table
     #[inline]
     pub fn insert_track(&self, con: &Connection) -> Result<usize, rusqlite::Error> {
-        con.execute(
-            "INSERT INTO tracks (artist, title, album, genre, file, duration, name, ext, directory, last_modified, last_position) 
-            values (:artist, :title, :album, :genre, :file, :duration, :name, :ext, :directory, :last_modified, :last_position)",
+        con.execute(indoc! {"
+            INSERT INTO tracks (artist, title, album, genre, file, duration, name, ext, directory, last_modified, last_position) 
+            VALUES (:artist, :title, :album, :genre, :file, :duration, :name, :ext, :directory, :last_modified, :last_position);
+            "},
             named_params![
                 ":artist": &self.artist,
                 ":title": &self.title,

--- a/lib/src/podcast/db/episode_db.rs
+++ b/lib/src/podcast/db/episode_db.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use indoc::indoc;
 use rusqlite::{named_params, params, Connection, Row};
 
 use crate::podcast::episode::EpisodeNoId;
@@ -105,11 +106,11 @@ impl<'a> EpisodeDBInsertable<'a> {
     /// Insert the current [`EpisodeDBInsertable`] into the `episodes` table
     #[inline]
     pub fn insert_episode(&self, con: &Connection) -> Result<usize, rusqlite::Error> {
-        let mut stmt = con.prepare_cached(
-            "INSERT INTO episodes (podcast_id, title, url, guid,
+        let mut stmt = con.prepare_cached(indoc! {"
+            INSERT INTO episodes (podcast_id, title, url, guid,
                 description, pubdate, duration, played, hidden, last_position, image_url)
-                VALUES (:podid, :title, :url, :guid, :description, :pubdate, :duration, :played, :hidden, :last_position, :image_url);",
-        )?;
+            VALUES (:podid, :title, :url, :guid, :description, :pubdate, :duration, :played, :hidden, :last_position, :image_url);
+        "})?;
         stmt.execute(named_params![
             ":podid": self.pod_id,
             ":title": self.title,
@@ -138,11 +139,11 @@ impl<'a> EpisodeDBInsertable<'a> {
         id: PodcastDBId,
         con: &Connection,
     ) -> Result<usize, rusqlite::Error> {
-        let mut stmt = con.prepare_cached(
-            "UPDATE episodes SET title = :title, url = :url,
-                    guid = :guid, description = :description, pubdate = :pubdate,
-                    duration = :duration, image_url = :image_url WHERE id = :epid;",
-        )?;
+        let mut stmt = con.prepare_cached(indoc! {"
+            UPDATE episodes SET title = :title, url = :url,
+                guid = :guid, description = :description, pubdate = :pubdate,
+            duration = :duration, image_url = :image_url WHERE id = :epid;
+        "})?;
         stmt.execute(named_params![
             ":title": self.title,
             ":url": self.url,

--- a/lib/src/podcast/db/file_db.rs
+++ b/lib/src/podcast/db/file_db.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use indoc::indoc;
 use rusqlite::{named_params, params, Connection, Row};
 
 use super::PodcastDBId;
@@ -57,10 +58,10 @@ impl<'a> FileDBInsertable<'a> {
     /// Insert the current [`FileDBInsertable`] into the `files` table
     #[inline]
     pub fn insert_file(&self, con: &Connection) -> Result<usize, rusqlite::Error> {
-        let mut stmt = con.prepare_cached(
-            "INSERT INTO files (episode_id, path)
-                VALUES (:epid, :path);",
-        )?;
+        let mut stmt = con.prepare_cached(indoc! {"
+            INSERT INTO files (episode_id, path)
+            VALUES (:epid, :path);
+        "})?;
         stmt.execute(named_params![
             ":epid": self.episode_id,
             ":path": self.path.to_string_lossy()

--- a/lib/src/podcast/db/migration.rs
+++ b/lib/src/podcast/db/migration.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use indoc::indoc;
 use rusqlite::{params, Connection};
 use semver::Version;
 
@@ -98,14 +99,18 @@ fn update_version_col(conn: &Connection) -> Result<()> {
 fn update_version_exec(conn: &Connection, current_version: &Version, update: bool) -> Result<()> {
     if update {
         conn.execute(
-            "UPDATE version SET version = ?
-            WHERE id = ?;",
+            indoc! {"
+            UPDATE version SET version = ?
+            WHERE id = ?;
+            "},
             params![current_version.to_string(), 1],
         )?;
     } else {
         conn.execute(
-            "INSERT INTO version (id, version)
-            VALUES (?, ?)",
+            indoc! {"
+            INSERT INTO version (id, version)
+            VALUES (?, ?);
+            "},
             params![1, current_version.to_string()],
         )?;
     }

--- a/lib/src/podcast/db/mod.rs
+++ b/lib/src/podcast/db/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use episode_db::{EpisodeDB, EpisodeDBInsertable};
 use file_db::{FileDB, FileDBInsertable};
+use indoc::indoc;
 use rusqlite::{params, Connection};
 
 use super::{Episode, EpisodeNoId, Podcast, PodcastNoId, RE_ARTICLES};
@@ -313,20 +314,20 @@ impl Database {
     /// Generates list of episodes for a given podcast.
     pub fn get_episodes(&self, pod_id: PodcastDBId, include_hidden: bool) -> Result<Vec<Episode>> {
         let mut stmt = if include_hidden {
-            self.conn.prepare_cached(
+            self.conn.prepare_cached(indoc! {
                 "SELECT episodes.id as epid, files.id as fileid, * FROM episodes
-                        LEFT JOIN files ON episodes.id = files.episode_id
-                        WHERE episodes.podcast_id = ?
-                        ORDER BY pubdate DESC;",
-            )?
+                LEFT JOIN files ON episodes.id = files.episode_id
+                WHERE episodes.podcast_id = ?
+                ORDER BY pubdate DESC;
+            "})?
         } else {
-            self.conn.prepare_cached(
-                "SELECT episodes.id as epid, files.id as fileid, * FROM episodes
-                        LEFT JOIN files ON episodes.id = files.episode_id
-                        WHERE episodes.podcast_id = ?
-                        AND episodes.hidden = 0
-                        ORDER BY pubdate DESC;",
-            )?
+            self.conn.prepare_cached(indoc! {"
+                SELECT episodes.id as epid, files.id as fileid, * FROM episodes
+                LEFT JOIN files ON episodes.id = files.episode_id
+                WHERE episodes.podcast_id = ?
+                AND episodes.hidden = 0
+                ORDER BY pubdate DESC;
+            "})?
         };
 
         let episodes = stmt
@@ -357,12 +358,12 @@ impl Database {
 
     /// Find a single Episode by its Url.
     pub fn get_episode_by_url(&self, ep_uri: &str) -> Result<Episode> {
-        let mut stmt = self.conn.prepare_cached(
-            "SELECT episodes.id as epid, files.id as fileid, * FROM episodes
-                    LEFT JOIN files ON episodes.id = files.episode_id
-                    WHERE episodes.url = ?
-                    ORDER BY pubdate DESC;",
-        )?;
+        let mut stmt = self.conn.prepare_cached(indoc! {"
+            SELECT episodes.id as epid, files.id as fileid, * FROM episodes
+            LEFT JOIN files ON episodes.id = files.episode_id
+            WHERE episodes.url = ?
+            ORDER BY pubdate DESC;
+        "})?;
 
         let episode = stmt
             .query_map(params![ep_uri], |row| {

--- a/lib/src/podcast/db/podcast_db.rs
+++ b/lib/src/podcast/db/podcast_db.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use indoc::indoc;
 use rusqlite::{named_params, params, Connection, Row};
 
 use super::{convert_date, PodcastDBId};
@@ -70,10 +71,10 @@ impl PodcastDBInsertable<'_> {
     /// Insert the current [`PodcastDBInsertable`] into the `podcasts` table
     #[inline]
     pub fn insert_podcast(&self, con: &Connection) -> Result<usize, rusqlite::Error> {
-        let mut stmt = con.prepare_cached(
-            "INSERT INTO podcasts (title, url, description, author, explicit, last_checked, image_url)
-            VALUES (:title, :url, :description, :author, :explicit, :last_checked, :image_url);",
-        )?;
+        let mut stmt = con.prepare_cached(indoc! {"
+            INSERT INTO podcasts (title, url, description, author, explicit, last_checked, image_url)
+            VALUES (:title, :url, :description, :author, :explicit, :last_checked, :image_url);
+        "})?;
         stmt.execute(named_params![
             ":title": self.title,
             ":url": self.url,
@@ -92,11 +93,11 @@ impl PodcastDBInsertable<'_> {
         id: PodcastDBId,
         con: &Connection,
     ) -> Result<usize, rusqlite::Error> {
-        let mut stmt = con.prepare_cached(
-            "UPDATE podcasts SET title = :title, url = :url, description = :description,
-            author = :author, explicit = :explicit, last_checked = :last_checked
-            WHERE id = :id;",
-        )?;
+        let mut stmt = con.prepare_cached(indoc! {"
+            UPDATE podcasts SET title = :title, url = :url, description = :description,
+                author = :author, explicit = :explicit, last_checked = :last_checked
+            WHERE id = :id;
+        "})?;
         stmt.execute(named_params![
             ":title": self.title,
             ":url": self.url,

--- a/lib/src/songtag/mod.rs
+++ b/lib/src/songtag/mod.rs
@@ -1,11 +1,5 @@
 //! SPDX-License-Identifier: MIT
 
-mod kugou;
-pub mod lrc;
-mod migu;
-mod netease_v2;
-mod service;
-
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::{self, sleep};
@@ -17,13 +11,19 @@ use lofty::id3::v2::{Frame, Id3v2Tag, UnsynchronizedTextFrame};
 use lofty::picture::Picture;
 use lofty::prelude::{Accessor, TagExt};
 use lofty::TextEncoding;
+use service::SongTagService;
 use tokio::sync::mpsc::UnboundedSender;
 use ytd_rs::{Arg, YoutubeDL};
 
 use crate::library_db::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use crate::types::{DLMsg, Msg, SongTagRecordingResult, TEMsg};
 use crate::utils::get_parent_folder;
-use service::SongTagService;
+
+mod kugou;
+pub mod lrc;
+mod migu;
+mod netease_v2;
+mod service;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SongTag {

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -763,9 +763,7 @@ fn handle_tag(tag: &LoftyTag, options: MetadataOptions<'_>, res: &mut TrackMetad
 
         if artists.is_empty() && !options.artist_separators.is_empty() {
             if let Some(artist) = tag.artist() {
-                let artists_iter = SplitArrayIter::new(&artist, options.artist_separators)
-                    .map(str::trim)
-                    .map(ToString::to_string);
+                let artists_iter = split_artists(&artist, options);
                 artists.extend(artists_iter);
             }
         }
@@ -796,9 +794,7 @@ fn handle_tag(tag: &LoftyTag, options: MetadataOptions<'_>, res: &mut TrackMetad
                 .get(&ItemKey::AlbumArtist)
                 .and_then(|v| v.value().text())
             {
-                let artists_iter = SplitArrayIter::new(album_artist, options.artist_separators)
-                    .map(str::trim)
-                    .map(ToString::to_string);
+                let artists_iter = split_artists(album_artist, options);
                 album_artists.extend(artists_iter);
             }
         }
@@ -826,6 +822,18 @@ fn handle_tag(tag: &LoftyTag, options: MetadataOptions<'_>, res: &mut TrackMetad
         get_lyrics_from_tags(tag, &mut lyric_frames);
         res.lyric_frames = Some(lyric_frames);
     }
+}
+
+/// Create a iterator which separates `artist` with options from `options`
+#[inline]
+fn split_artists<'a>(
+    artist: &'a str,
+    options: MetadataOptions<'a>,
+) -> impl Iterator<Item = String> + 'a {
+    SplitArrayIter::new(artist, options.artist_separators)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToString::to_string)
 }
 
 /// Fetch all lyrics from the given Lofty tag into the given array.

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -618,7 +618,7 @@ impl Display for DurationFmtShort {
 
 /// The default and most common separators used for artists.
 pub const DEFAULT_ARTIST_SEPARATORS: &[&str] =
-    &[",", ";", "&", "ft.", "feat.", "/", "|", "×", "・", "、"];
+    &[",", ";", "&", "ft.", "feat.", "/", "|", "×", "、", " x "];
 
 /// See [`TrackMetadata`] for explanation of values.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -24,6 +24,7 @@ use lru::LruCache;
 
 use crate::{
     player::playlist_helpers::PlaylistTrackSource, podcast::episode::Episode, songtag::lrc::Lyric,
+    utils::SplitArrayIter,
 };
 
 /// A simple no-value representation of [`MediaTypes`].
@@ -615,15 +616,23 @@ impl Display for DurationFmtShort {
     }
 }
 
+/// The default and most common separators used for artists.
+pub const DEFAULT_ARTIST_SEPARATORS: &[&str] =
+    &[",", ";", "&", "ft.", "feat.", "/", "|", "×", "・", "、"];
+
 /// See [`TrackMetadata`] for explanation of values.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[allow(clippy::struct_excessive_bools)] // configuration, this is not a state machine
-pub struct MetadataOptions {
+pub struct MetadataOptions<'a> {
     pub album: bool,
     pub album_artist: bool,
     pub album_artists: bool,
     pub artist: bool,
     pub artists: bool,
+    /// Separators for fallback parsing of a single `artist` value into multiple `artists`.
+    ///
+    /// See [`DEFAULT_ARTIST_SEPARATORS`].
+    pub artist_separators: &'a [&'a str],
     pub title: bool,
     pub duration: bool,
     pub genre: bool,
@@ -632,7 +641,7 @@ pub struct MetadataOptions {
     pub file_times: bool,
 }
 
-impl MetadataOptions {
+impl MetadataOptions<'_> {
     /// Enable all options
     #[must_use]
     pub fn all() -> Self {
@@ -642,6 +651,7 @@ impl MetadataOptions {
             album_artists: true,
             artist: true,
             artists: true,
+            artist_separators: &[],
             title: true,
             duration: true,
             genre: true,
@@ -690,7 +700,10 @@ pub struct FileTimes {
 }
 
 /// Try to parse all specified metadata in the given `options`.
-pub fn parse_metadata_from_file(path: &Path, options: MetadataOptions) -> Result<TrackMetadata> {
+pub fn parse_metadata_from_file(
+    path: &Path,
+    options: MetadataOptions<'_>,
+) -> Result<TrackMetadata> {
     let mut parse_options = ParseOptions::new();
 
     parse_options = parse_options.read_cover_art(options.cover);
@@ -729,7 +742,7 @@ pub fn parse_metadata_from_file(path: &Path, options: MetadataOptions) -> Result
 }
 
 /// The inner working to actually copy data from the given [`LoftyTag`] into the `res`ult
-fn handle_tag(tag: &LoftyTag, options: MetadataOptions, res: &mut TrackMetadata) {
+fn handle_tag(tag: &LoftyTag, options: MetadataOptions<'_>, res: &mut TrackMetadata) {
     if let Some(len_tag) = tag.get_string(&ItemKey::Length) {
         match len_tag.parse::<u64>() {
             Ok(v) => res.duration = Some(Duration::from_millis(v)),
@@ -743,11 +756,21 @@ fn handle_tag(tag: &LoftyTag, options: MetadataOptions, res: &mut TrackMetadata)
         res.artist = tag.artist().map(Cow::into_owned);
     }
     if options.artists {
-        res.artists = Some(
-            tag.get_strings(&ItemKey::TrackArtists)
-                .map(ToString::to_string)
-                .collect(),
-        );
+        let mut artists: Vec<String> = tag
+            .get_strings(&ItemKey::TrackArtists)
+            .map(ToString::to_string)
+            .collect();
+
+        if artists.is_empty() && !options.artist_separators.is_empty() {
+            if let Some(artist) = tag.artist() {
+                let artists_iter = SplitArrayIter::new(&artist, options.artist_separators)
+                    .map(str::trim)
+                    .map(ToString::to_string);
+                artists.extend(artists_iter);
+            }
+        }
+
+        res.artists = Some(artists);
     }
     if options.album {
         res.album = tag.album().map(Cow::into_owned);
@@ -763,11 +786,24 @@ fn handle_tag(tag: &LoftyTag, options: MetadataOptions, res: &mut TrackMetadata)
         // see https://github.com/Serial-ATA/lofty-rs/issues/522
         // res.album_artists = Some(tag.get_strings(&ItemKey::AlbumArtists).map(ToString::to_string).collect());
         // lofty already separates them from a "; "
-        res.album_artists = Some(
-            tag.get_strings(&ItemKey::Unknown("ALBUMARTISTS".to_string()))
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-        );
+        let mut album_artists: Vec<String> = tag
+            .get_strings(&ItemKey::Unknown("ALBUMARTISTS".to_string()))
+            .map(ToString::to_string)
+            .collect();
+
+        if album_artists.is_empty() && !options.artist_separators.is_empty() {
+            if let Some(album_artist) = tag
+                .get(&ItemKey::AlbumArtist)
+                .and_then(|v| v.value().text())
+            {
+                let artists_iter = SplitArrayIter::new(album_artist, options.artist_separators)
+                    .map(str::trim)
+                    .map(ToString::to_string);
+                album_artists.extend(artists_iter);
+            }
+        }
+
+        res.album_artists = Some(album_artists);
     }
     if options.title {
         res.title = tag.title().map(Cow::into_owned);

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use crate::config::v2::tui::{keys::KeyBinding, theme::styles::ColorTermusic};
 use crate::ids::{IdConfigEditor, IdKey};
 use crate::invidious::{Instance, YoutubeVideo};
+use crate::library_db::SearchCriteria;
 use crate::podcast::{EpData, PodcastFeed, PodcastNoId};
 use crate::songtag::SongTag;
 use anyhow::{anyhow, Result};
@@ -425,7 +426,7 @@ pub enum DBMsg {
     CriteriaBlurDown,
     CriteriaBlurUp,
     /// Search Results (for view `Result`) from a `Database`(view) index
-    SearchResult(usize),
+    SearchResult(SearchCriteria),
     SearchResultBlurDown,
     SearchResultBlurUp,
     /// Serarch Tracks (for view `Tracks`) from a `Result`(view) index

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -487,7 +487,7 @@ pub enum PLMsg {
     /// Change focus to the previous view
     PlaylistTableBlurUp,
     /// Add a directory / file to the playlist
-    Add(String),
+    Add(PathBuf),
     /// Remove INDEX from playlist
     Delete(usize),
     /// Clear the Playlist

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -39,32 +39,24 @@ pub fn filetype_supported(path: &Path) -> bool {
         return true;
     }
 
-    match path.extension() {
-        Some(ext) if ext == "mkv" || ext == "mka" => true,
-        Some(ext) if ext == "mp3" => true,
-        Some(ext) if ext == "aiff" => true,
-        Some(ext) if ext == "flac" => true,
-        Some(ext) if ext == "m4a" => true,
-        Some(ext) if ext == "aac" => true,
-        Some(ext) if ext == "opus" => true,
-        Some(ext) if ext == "ogg" => true,
-        Some(ext) if ext == "wav" => true,
-        Some(ext) if ext == "webm" => true,
-        Some(_) | None => false,
-    }
+    let Some(ext) = path.extension().and_then(OsStr::to_str) else {
+        return false;
+    };
+
+    matches!(
+        ext,
+        "mkv" | "mka" | "mp3" | "aiff" | "flac" | "m4a" | "aac" | "opus" | "ogg" | "wav" | "webm"
+    )
 }
 
 /// Check if the given path has a extension that matches well-known playlists that are supported by us.
 #[must_use]
 pub fn is_playlist(path: &Path) -> bool {
-    match path.extension() {
-        Some(ext) if ext == "m3u" => true,
-        Some(ext) if ext == "m3u8" => true,
-        Some(ext) if ext == "pls" => true,
-        Some(ext) if ext == "asx" => true,
-        Some(ext) if ext == "xspf" => true,
-        Some(_) | None => false,
-    }
+    let Some(ext) = path.extension().and_then(OsStr::to_str) else {
+        return false;
+    };
+
+    matches!(ext, "m3u" | "m3u8" | "pls" | "asx" | "xspf")
 }
 
 /// Get the parent path of the given `path`, if there is none use the tempdir

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -54,11 +54,10 @@ pub fn filetype_supported(path: &Path) -> bool {
     }
 }
 
+/// Check if the given path has a extension that matches well-known playlists that are supported by us.
 #[must_use]
-pub fn is_playlist(current_node: &str) -> bool {
-    let p = Path::new(current_node);
-
-    match p.extension() {
+pub fn is_playlist(path: &Path) -> bool {
+    match path.extension() {
         Some(ext) if ext == "m3u" => true,
         Some(ext) if ext == "m3u8" => true,
         Some(ext) if ext == "pls" => true,
@@ -109,8 +108,7 @@ pub fn create_podcast_dir(config: &ServerOverlay, pod_title: String) -> Result<P
 }
 
 /// Parse the playlist at `current_node`(from the tui tree) and return the media paths
-pub fn playlist_get_vec(current_node: &str) -> Result<Vec<String>> {
-    let playlist_path = Path::new(current_node);
+pub fn playlist_get_vec(playlist_path: &Path) -> Result<Vec<String>> {
     // get the directory the playlist is in
     let playlist_directory = absolute_path(
         playlist_path

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -34,14 +34,12 @@ pub fn get_pin_yin(input: &str) -> String {
 
 // TODO: decide filetype supported by backend instead of in library
 #[must_use]
-pub fn filetype_supported(current_node: &str) -> bool {
-    let p = Path::new(current_node);
-
-    if p.starts_with("http") {
+pub fn filetype_supported(path: &Path) -> bool {
+    if path.starts_with("http") {
         return true;
     }
 
-    match p.extension() {
+    match path.extension() {
         Some(ext) if ext == "mkv" || ext == "mka" => true,
         Some(ext) if ext == "mp3" => true,
         Some(ext) if ext == "aiff" => true,

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -830,7 +830,7 @@ impl Playlist {
     fn track_from_path(path_str: &str) -> Result<Track, PlaylistAddError> {
         let path = Path::new(path_str);
 
-        if !filetype_supported(path_str) {
+        if !filetype_supported(path) {
             error!("unsupported filetype: {path:#?}");
             let p = path.to_path_buf();
             let ext = path.extension().map(|v| v.to_string_lossy().to_string());

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -60,6 +60,7 @@ reqwest.workspace = true
 parking_lot.workspace = true
 alphanumeric-sort.workspace = true
 pathdiff.workspace = true
+either.workspace = true
 
 
 [features]

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -493,7 +493,7 @@ impl KeyCombo {
         let chunks = Layout::default()
             .direction(LayoutDirection::Vertical)
             .margin(0)
-            .constraints([Constraint::Length(2), Constraint::Min(1)].as_ref())
+            .constraints([Constraint::Length(2), Constraint::Min(1)])
             .split(area);
         // Render like "closed" tab in chunk 0
         let selected_text = match self.states.choices.get(self.states.selected) {
@@ -682,7 +682,7 @@ impl KeyCombo {
         let chunks = Layout::default()
             .direction(LayoutDirection::Horizontal)
             .margin(0)
-            .constraints([Constraint::Ratio(2, 3), Constraint::Ratio(1, 3)].as_ref())
+            .constraints([Constraint::Ratio(2, 3), Constraint::Ratio(1, 3)])
             .split(area);
 
         let mut foreground = self

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -41,7 +41,7 @@ use tuirealm::props::{
     PropValue, Props, Style, TextModifiers,
 };
 use tuirealm::ratatui::{
-    layout::{Constraint, Direction as LayoutDirection, Layout, Rect},
+    layout::{Constraint, Layout, Rect},
     text::Span,
     widgets::{Block, List, ListItem, ListState, Paragraph},
 };
@@ -490,11 +490,7 @@ impl KeyCombo {
             .and_then(AttrValue::as_color)
             .unwrap_or(foreground);
         // Prepare layout
-        let chunks = Layout::default()
-            .direction(LayoutDirection::Vertical)
-            .margin(0)
-            .constraints([Constraint::Length(2), Constraint::Min(1)])
-            .split(area);
+        let chunks = Layout::vertical([Constraint::Length(2), Constraint::Min(1)]).split(area);
         // Render like "closed" tab in chunk 0
         let selected_text = match self.states.choices.get(self.states.selected) {
             None => "",
@@ -679,11 +675,8 @@ impl KeyCombo {
     }
 
     fn render_input(&self, render: &mut Frame<'_>, area: Rect) {
-        let chunks = Layout::default()
-            .direction(LayoutDirection::Horizontal)
-            .margin(0)
-            .constraints([Constraint::Ratio(2, 3), Constraint::Ratio(1, 3)])
-            .split(area);
+        let chunks =
+            Layout::horizontal([Constraint::Ratio(2, 3), Constraint::Ratio(1, 3)]).split(area);
 
         let mut foreground = self
             .props

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -50,60 +50,51 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3),
-                            Constraint::Min(3),
-                            Constraint::Length(1),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3),
+                        Constraint::Min(3),
+                        Constraint::Length(1),
+                    ])
                     .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)].as_ref())
+                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
                     .split(chunks_main[1]);
 
                 let chunks_middle_left = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[0]);
 
                 let chunks_middle_right = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[1]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
@@ -379,20 +370,17 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3), // config header
-                            Constraint::Min(3),
-                            Constraint::Length(1), // config footer
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3), // config header
+                        Constraint::Min(3),
+                        Constraint::Length(1), // config footer
+                    ])
                     .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)].as_ref())
+                    .constraints([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
                     .split(chunks_main[1]);
 
                 let chunks_style = Layout::default()
@@ -404,125 +392,101 @@ impl Model {
                 let chunks_style_top = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Ratio(1, 4), // library
-                            Constraint::Ratio(1, 4), // playlist
-                            Constraint::Ratio(1, 4), // progress
-                            Constraint::Ratio(1, 4), // lyric
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Ratio(1, 4), // library
+                        Constraint::Ratio(1, 4), // playlist
+                        Constraint::Ratio(1, 4), // progress
+                        Constraint::Ratio(1, 4), // lyric
+                    ])
                     .split(chunks_style[0]);
 
                 let chunks_style_bottom = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Ratio(1, 4), // important popup
-                            Constraint::Ratio(1, 4), // unused...
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Ratio(1, 4), // important popup
+                        Constraint::Ratio(1, 4), // unused...
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                    ])
                     .split(chunks_style[1]);
 
                 let chunks_library = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_library_foreground_len),
-                            Constraint::Length(select_library_background_len),
-                            Constraint::Length(select_library_border_len),
-                            Constraint::Length(select_library_highlight_len),
-                            Constraint::Length(3),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_library_foreground_len),
+                        Constraint::Length(select_library_background_len),
+                        Constraint::Length(select_library_border_len),
+                        Constraint::Length(select_library_highlight_len),
+                        Constraint::Length(3),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_top[0]);
 
                 let chunks_playlist = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_playlist_foreground_len),
-                            Constraint::Length(select_playlist_background_len),
-                            Constraint::Length(select_playlist_border_len),
-                            Constraint::Length(select_playlist_highlight_len),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_playlist_foreground_len),
+                        Constraint::Length(select_playlist_background_len),
+                        Constraint::Length(select_playlist_border_len),
+                        Constraint::Length(select_playlist_highlight_len),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_top[1]);
 
                 let chunks_progress = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_progress_foreground_len),
-                            Constraint::Length(select_progress_background_len),
-                            Constraint::Length(select_progress_border_len),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_progress_foreground_len),
+                        Constraint::Length(select_progress_background_len),
+                        Constraint::Length(select_progress_border_len),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_top[2]);
 
                 let chunks_lyric = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_lyric_foreground_len),
-                            Constraint::Length(select_lyric_background_len),
-                            Constraint::Length(select_lyric_border_len),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_lyric_foreground_len),
+                        Constraint::Length(select_lyric_background_len),
+                        Constraint::Length(select_lyric_border_len),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_top[3]);
 
                 let chunks_important_popup = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_important_popup_foreground_len),
-                            Constraint::Length(select_important_popup_background_len),
-                            Constraint::Length(select_important_popup_border_len),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_important_popup_foreground_len),
+                        Constraint::Length(select_important_popup_background_len),
+                        Constraint::Length(select_important_popup_border_len),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_bottom[0]);
 
                 let chunks_fallback = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(1),
-                            Constraint::Length(select_fallback_foreground_len),
-                            Constraint::Length(select_fallback_background_len),
-                            Constraint::Length(select_fallback_border_len),
-                            Constraint::Length(select_fallback_highlight_len),
-                            Constraint::Min(3),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(select_fallback_foreground_len),
+                        Constraint::Length(select_fallback_background_len),
+                        Constraint::Length(select_fallback_border_len),
+                        Constraint::Length(select_fallback_highlight_len),
+                        Constraint::Min(3),
+                    ])
                     .split(chunks_style_bottom[1]);
 
                 self.app
@@ -929,107 +893,89 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3),
-                            Constraint::Min(3),
-                            Constraint::Length(1),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3),
+                        Constraint::Min(3),
+                        Constraint::Length(1),
+                    ])
                     .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                    ])
                     .split(chunks_main[1]);
 
                 let chunks_middle_column1 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_global_quit_len),
-                            Constraint::Length(select_global_left_len),
-                            Constraint::Length(select_global_down_len),
-                            Constraint::Length(select_global_up_len),
-                            Constraint::Length(select_global_right_len),
-                            Constraint::Length(select_global_goto_top_len),
-                            Constraint::Length(select_global_goto_bottom_len),
-                            Constraint::Length(select_global_player_toggle_pause_len),
-                            Constraint::Length(select_global_player_next_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_global_quit_len),
+                        Constraint::Length(select_global_left_len),
+                        Constraint::Length(select_global_down_len),
+                        Constraint::Length(select_global_up_len),
+                        Constraint::Length(select_global_right_len),
+                        Constraint::Length(select_global_goto_top_len),
+                        Constraint::Length(select_global_goto_bottom_len),
+                        Constraint::Length(select_global_player_toggle_pause_len),
+                        Constraint::Length(select_global_player_next_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[0]);
 
                 let chunks_middle_column2 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_global_player_previous_len),
-                            Constraint::Length(select_global_help_len),
-                            Constraint::Length(select_global_volume_up_len),
-                            Constraint::Length(select_global_volume_down_len),
-                            Constraint::Length(select_global_player_seek_forward_len),
-                            Constraint::Length(select_global_player_seek_backward_len),
-                            Constraint::Length(select_global_player_speed_up_len),
-                            Constraint::Length(select_global_player_speed_down_len),
-                            Constraint::Length(select_global_lyric_adjust_forward_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_global_player_previous_len),
+                        Constraint::Length(select_global_help_len),
+                        Constraint::Length(select_global_volume_up_len),
+                        Constraint::Length(select_global_volume_down_len),
+                        Constraint::Length(select_global_player_seek_forward_len),
+                        Constraint::Length(select_global_player_seek_backward_len),
+                        Constraint::Length(select_global_player_speed_up_len),
+                        Constraint::Length(select_global_player_speed_down_len),
+                        Constraint::Length(select_global_lyric_adjust_forward_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[1]);
                 let chunks_middle_column3 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_global_lyric_adjust_backward_len),
-                            Constraint::Length(select_global_lyric_cycle_len),
-                            Constraint::Length(select_global_layout_treeview_len),
-                            Constraint::Length(select_global_layout_database_len),
-                            Constraint::Length(select_global_player_toggle_gapless_len),
-                            Constraint::Length(select_global_config_len),
-                            Constraint::Length(select_global_save_playlist),
-                            Constraint::Length(select_global_layout_podcast),
-                            Constraint::Length(select_global_xywh_move_left),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_global_lyric_adjust_backward_len),
+                        Constraint::Length(select_global_lyric_cycle_len),
+                        Constraint::Length(select_global_layout_treeview_len),
+                        Constraint::Length(select_global_layout_database_len),
+                        Constraint::Length(select_global_player_toggle_gapless_len),
+                        Constraint::Length(select_global_config_len),
+                        Constraint::Length(select_global_save_playlist),
+                        Constraint::Length(select_global_layout_podcast),
+                        Constraint::Length(select_global_xywh_move_left),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[2]);
 
                 let chunks_middle_column4 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_global_xywh_move_right),
-                            Constraint::Length(select_global_xywh_move_up),
-                            Constraint::Length(select_global_xywh_move_down),
-                            Constraint::Length(select_global_xywh_zoom_in),
-                            Constraint::Length(select_global_xywh_zoom_out),
-                            Constraint::Length(select_global_xywh_hide),
-                            // Constraint::Length(select_global_xywh_hide),
-                            // Constraint::Length(select_global_xywh_hide),
-                            // Constraint::Length(select_global_xywh_hide),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_global_xywh_move_right),
+                        Constraint::Length(select_global_xywh_move_up),
+                        Constraint::Length(select_global_xywh_move_down),
+                        Constraint::Length(select_global_xywh_zoom_in),
+                        Constraint::Length(select_global_xywh_zoom_out),
+                        Constraint::Length(select_global_xywh_hide),
+                        // Constraint::Length(select_global_xywh_hide),
+                        // Constraint::Length(select_global_xywh_hide),
+                        // Constraint::Length(select_global_xywh_hide),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[3]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
@@ -1430,107 +1376,89 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(3),
-                            Constraint::Min(3),
-                            Constraint::Length(1),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(3),
+                        Constraint::Min(3),
+                        Constraint::Length(1),
+                    ])
                     .split(f.area());
 
                 let chunks_middle = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                    ])
                     .split(chunks_main[1]);
 
                 let chunks_middle_column1 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_library_tag_editor_len),
-                            Constraint::Length(select_library_delete_len),
-                            Constraint::Length(select_library_load_dir_len),
-                            Constraint::Length(select_library_yank_len),
-                            Constraint::Length(select_library_paste_len),
-                            Constraint::Length(select_library_search_len),
-                            Constraint::Length(select_library_search_youtube_len),
-                            Constraint::Length(select_playlist_delete_len),
-                            Constraint::Length(select_playlist_delete_all_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_library_tag_editor_len),
+                        Constraint::Length(select_library_delete_len),
+                        Constraint::Length(select_library_load_dir_len),
+                        Constraint::Length(select_library_yank_len),
+                        Constraint::Length(select_library_paste_len),
+                        Constraint::Length(select_library_search_len),
+                        Constraint::Length(select_library_search_youtube_len),
+                        Constraint::Length(select_playlist_delete_len),
+                        Constraint::Length(select_playlist_delete_all_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[0]);
                 let chunks_middle_column2 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_playlist_search_len),
-                            Constraint::Length(select_playlist_shuffle_len),
-                            Constraint::Length(select_playlist_mode_cycle_len),
-                            Constraint::Length(select_playlist_play_selected_len),
-                            Constraint::Length(select_playlist_swap_down_len),
-                            Constraint::Length(select_playlist_swap_up_len),
-                            Constraint::Length(select_database_add_all_len),
-                            Constraint::Length(select_database_add_selected_len),
-                            Constraint::Length(select_playlist_random_album_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_playlist_search_len),
+                        Constraint::Length(select_playlist_shuffle_len),
+                        Constraint::Length(select_playlist_mode_cycle_len),
+                        Constraint::Length(select_playlist_play_selected_len),
+                        Constraint::Length(select_playlist_swap_down_len),
+                        Constraint::Length(select_playlist_swap_up_len),
+                        Constraint::Length(select_database_add_all_len),
+                        Constraint::Length(select_database_add_selected_len),
+                        Constraint::Length(select_playlist_random_album_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[1]);
 
                 let chunks_middle_column3 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(select_playlist_random_tracks_len),
-                            Constraint::Length(library_switch_root_len),
-                            Constraint::Length(library_add_root_len),
-                            Constraint::Length(library_remove_root_len),
-                            Constraint::Length(podcast_mark_played_len),
-                            Constraint::Length(podcast_mark_all_played_len),
-                            Constraint::Length(podcast_ep_download_len),
-                            Constraint::Length(podcast_ep_delete_file_len),
-                            Constraint::Length(podcast_delete_feed_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(select_playlist_random_tracks_len),
+                        Constraint::Length(library_switch_root_len),
+                        Constraint::Length(library_add_root_len),
+                        Constraint::Length(library_remove_root_len),
+                        Constraint::Length(podcast_mark_played_len),
+                        Constraint::Length(podcast_mark_all_played_len),
+                        Constraint::Length(podcast_ep_download_len),
+                        Constraint::Length(podcast_ep_delete_file_len),
+                        Constraint::Length(podcast_delete_feed_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[2]);
 
                 let chunks_middle_column4 = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(podcast_delete_all_feeds_len),
-                            Constraint::Length(podcast_refresh_feed_len),
-                            Constraint::Length(podcast_refresh_all_feeds_len),
-                            Constraint::Length(podcast_search_add_feed_len),
-                            // Constraint::Length(podcast_mark_played_len),
-                            // Constraint::Length(podcast_mark_all_played_len),
-                            // Constraint::Length(podcast_ep_download_len),
-                            // Constraint::Length(podcast_ep_delete_file_len),
-                            // Constraint::Length(podcast_delete_feed_len),
-                            Constraint::Min(0),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(podcast_delete_all_feeds_len),
+                        Constraint::Length(podcast_refresh_feed_len),
+                        Constraint::Length(podcast_refresh_all_feeds_len),
+                        Constraint::Length(podcast_search_add_feed_len),
+                        // Constraint::Length(podcast_mark_played_len),
+                        // Constraint::Length(podcast_mark_all_played_len),
+                        // Constraint::Length(podcast_ep_download_len),
+                        // Constraint::Length(podcast_ep_delete_file_len),
+                        // Constraint::Length(podcast_delete_feed_len),
+                        Constraint::Min(0),
+                    ])
                     .split(chunks_middle[3]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -37,7 +37,7 @@ use termusiclib::types::Msg;
 use termusiclib::utils::{get_app_config_path, get_pin_yin};
 use termusiclib::THEME_DIR;
 use tuirealm::props::{PropPayload, PropValue, TableBuilder, TextSpan};
-use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::layout::{Constraint, Layout};
 use tuirealm::ratatui::widgets::Clear;
 use tuirealm::{AttrValue, Attribute, Frame, State, StateValue};
 
@@ -47,55 +47,44 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3),
-                        Constraint::Min(3),
-                        Constraint::Length(1),
-                    ])
-                    .split(f.area());
+                let chunks_main = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                    Constraint::Length(1),
+                ])
+                .split(f.area());
 
-                let chunks_middle = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                    .split(chunks_main[1]);
+                let chunks_middle =
+                    Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+                        .split(chunks_main[1]);
 
-                let chunks_middle_left = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[0]);
+                let chunks_middle_left = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[0]);
 
-                let chunks_middle_right = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[1]);
+                let chunks_middle_right = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[1]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
                 self.app.view(
@@ -367,127 +356,96 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3), // config header
-                        Constraint::Min(3),
-                        Constraint::Length(1), // config footer
-                    ])
-                    .split(f.area());
+                let chunks_main = Layout::vertical([
+                    Constraint::Length(3), // config header
+                    Constraint::Min(3),
+                    Constraint::Length(1), // config footer
+                ])
+                .split(f.area());
 
-                let chunks_middle = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
-                    .split(chunks_main[1]);
+                let chunks_middle =
+                    Layout::horizontal([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
+                        .split(chunks_main[1]);
 
-                let chunks_style = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .split(chunks_middle[1]);
+                let chunks_style =
+                    Layout::vertical([Constraint::Percentage(50), Constraint::Percentage(50)])
+                        .split(chunks_middle[1]);
 
-                let chunks_style_top = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Ratio(1, 4), // library
-                        Constraint::Ratio(1, 4), // playlist
-                        Constraint::Ratio(1, 4), // progress
-                        Constraint::Ratio(1, 4), // lyric
-                    ])
-                    .split(chunks_style[0]);
+                let chunks_style_top = Layout::horizontal([
+                    Constraint::Ratio(1, 4), // library
+                    Constraint::Ratio(1, 4), // playlist
+                    Constraint::Ratio(1, 4), // progress
+                    Constraint::Ratio(1, 4), // lyric
+                ])
+                .split(chunks_style[0]);
 
-                let chunks_style_bottom = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Ratio(1, 4), // important popup
-                        Constraint::Ratio(1, 4), // unused...
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                    ])
-                    .split(chunks_style[1]);
+                let chunks_style_bottom = Layout::horizontal([
+                    Constraint::Ratio(1, 4), // important popup
+                    Constraint::Ratio(1, 4), // unused...
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                ])
+                .split(chunks_style[1]);
 
-                let chunks_library = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_library_foreground_len),
-                        Constraint::Length(select_library_background_len),
-                        Constraint::Length(select_library_border_len),
-                        Constraint::Length(select_library_highlight_len),
-                        Constraint::Length(3),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_top[0]);
+                let chunks_library = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_library_foreground_len),
+                    Constraint::Length(select_library_background_len),
+                    Constraint::Length(select_library_border_len),
+                    Constraint::Length(select_library_highlight_len),
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_top[0]);
 
-                let chunks_playlist = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_playlist_foreground_len),
-                        Constraint::Length(select_playlist_background_len),
-                        Constraint::Length(select_playlist_border_len),
-                        Constraint::Length(select_playlist_highlight_len),
-                        Constraint::Length(3),
-                        Constraint::Length(3),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_top[1]);
+                let chunks_playlist = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_playlist_foreground_len),
+                    Constraint::Length(select_playlist_background_len),
+                    Constraint::Length(select_playlist_border_len),
+                    Constraint::Length(select_playlist_highlight_len),
+                    Constraint::Length(3),
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_top[1]);
 
-                let chunks_progress = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_progress_foreground_len),
-                        Constraint::Length(select_progress_background_len),
-                        Constraint::Length(select_progress_border_len),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_top[2]);
+                let chunks_progress = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_progress_foreground_len),
+                    Constraint::Length(select_progress_background_len),
+                    Constraint::Length(select_progress_border_len),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_top[2]);
 
-                let chunks_lyric = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_lyric_foreground_len),
-                        Constraint::Length(select_lyric_background_len),
-                        Constraint::Length(select_lyric_border_len),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_top[3]);
+                let chunks_lyric = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_lyric_foreground_len),
+                    Constraint::Length(select_lyric_background_len),
+                    Constraint::Length(select_lyric_border_len),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_top[3]);
 
-                let chunks_important_popup = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_important_popup_foreground_len),
-                        Constraint::Length(select_important_popup_background_len),
-                        Constraint::Length(select_important_popup_border_len),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_bottom[0]);
+                let chunks_important_popup = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_important_popup_foreground_len),
+                    Constraint::Length(select_important_popup_background_len),
+                    Constraint::Length(select_important_popup_border_len),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_bottom[0]);
 
-                let chunks_fallback = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(1),
-                        Constraint::Length(select_fallback_foreground_len),
-                        Constraint::Length(select_fallback_background_len),
-                        Constraint::Length(select_fallback_border_len),
-                        Constraint::Length(select_fallback_highlight_len),
-                        Constraint::Min(3),
-                    ])
-                    .split(chunks_style_bottom[1]);
+                let chunks_fallback = Layout::vertical([
+                    Constraint::Length(1),
+                    Constraint::Length(select_fallback_foreground_len),
+                    Constraint::Length(select_fallback_background_len),
+                    Constraint::Length(select_fallback_border_len),
+                    Constraint::Length(select_fallback_highlight_len),
+                    Constraint::Min(3),
+                ])
+                .split(chunks_style_bottom[1]);
 
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
@@ -890,93 +848,75 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3),
-                        Constraint::Min(3),
-                        Constraint::Length(1),
-                    ])
-                    .split(f.area());
+                let chunks_main = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                    Constraint::Length(1),
+                ])
+                .split(f.area());
 
-                let chunks_middle = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                    ])
-                    .split(chunks_main[1]);
+                let chunks_middle = Layout::horizontal([
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                ])
+                .split(chunks_main[1]);
 
-                let chunks_middle_column1 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_global_quit_len),
-                        Constraint::Length(select_global_left_len),
-                        Constraint::Length(select_global_down_len),
-                        Constraint::Length(select_global_up_len),
-                        Constraint::Length(select_global_right_len),
-                        Constraint::Length(select_global_goto_top_len),
-                        Constraint::Length(select_global_goto_bottom_len),
-                        Constraint::Length(select_global_player_toggle_pause_len),
-                        Constraint::Length(select_global_player_next_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[0]);
+                let chunks_middle_column1 = Layout::vertical([
+                    Constraint::Length(select_global_quit_len),
+                    Constraint::Length(select_global_left_len),
+                    Constraint::Length(select_global_down_len),
+                    Constraint::Length(select_global_up_len),
+                    Constraint::Length(select_global_right_len),
+                    Constraint::Length(select_global_goto_top_len),
+                    Constraint::Length(select_global_goto_bottom_len),
+                    Constraint::Length(select_global_player_toggle_pause_len),
+                    Constraint::Length(select_global_player_next_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[0]);
 
-                let chunks_middle_column2 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_global_player_previous_len),
-                        Constraint::Length(select_global_help_len),
-                        Constraint::Length(select_global_volume_up_len),
-                        Constraint::Length(select_global_volume_down_len),
-                        Constraint::Length(select_global_player_seek_forward_len),
-                        Constraint::Length(select_global_player_seek_backward_len),
-                        Constraint::Length(select_global_player_speed_up_len),
-                        Constraint::Length(select_global_player_speed_down_len),
-                        Constraint::Length(select_global_lyric_adjust_forward_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[1]);
-                let chunks_middle_column3 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_global_lyric_adjust_backward_len),
-                        Constraint::Length(select_global_lyric_cycle_len),
-                        Constraint::Length(select_global_layout_treeview_len),
-                        Constraint::Length(select_global_layout_database_len),
-                        Constraint::Length(select_global_player_toggle_gapless_len),
-                        Constraint::Length(select_global_config_len),
-                        Constraint::Length(select_global_save_playlist),
-                        Constraint::Length(select_global_layout_podcast),
-                        Constraint::Length(select_global_xywh_move_left),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[2]);
+                let chunks_middle_column2 = Layout::vertical([
+                    Constraint::Length(select_global_player_previous_len),
+                    Constraint::Length(select_global_help_len),
+                    Constraint::Length(select_global_volume_up_len),
+                    Constraint::Length(select_global_volume_down_len),
+                    Constraint::Length(select_global_player_seek_forward_len),
+                    Constraint::Length(select_global_player_seek_backward_len),
+                    Constraint::Length(select_global_player_speed_up_len),
+                    Constraint::Length(select_global_player_speed_down_len),
+                    Constraint::Length(select_global_lyric_adjust_forward_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[1]);
+                let chunks_middle_column3 = Layout::vertical([
+                    Constraint::Length(select_global_lyric_adjust_backward_len),
+                    Constraint::Length(select_global_lyric_cycle_len),
+                    Constraint::Length(select_global_layout_treeview_len),
+                    Constraint::Length(select_global_layout_database_len),
+                    Constraint::Length(select_global_player_toggle_gapless_len),
+                    Constraint::Length(select_global_config_len),
+                    Constraint::Length(select_global_save_playlist),
+                    Constraint::Length(select_global_layout_podcast),
+                    Constraint::Length(select_global_xywh_move_left),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[2]);
 
-                let chunks_middle_column4 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_global_xywh_move_right),
-                        Constraint::Length(select_global_xywh_move_up),
-                        Constraint::Length(select_global_xywh_move_down),
-                        Constraint::Length(select_global_xywh_zoom_in),
-                        Constraint::Length(select_global_xywh_zoom_out),
-                        Constraint::Length(select_global_xywh_hide),
-                        // Constraint::Length(select_global_xywh_hide),
-                        // Constraint::Length(select_global_xywh_hide),
-                        // Constraint::Length(select_global_xywh_hide),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[3]);
+                let chunks_middle_column4 = Layout::vertical([
+                    Constraint::Length(select_global_xywh_move_right),
+                    Constraint::Length(select_global_xywh_move_up),
+                    Constraint::Length(select_global_xywh_move_down),
+                    Constraint::Length(select_global_xywh_zoom_in),
+                    Constraint::Length(select_global_xywh_zoom_out),
+                    Constraint::Length(select_global_xywh_hide),
+                    // Constraint::Length(select_global_xywh_hide),
+                    // Constraint::Length(select_global_xywh_hide),
+                    // Constraint::Length(select_global_xywh_hide),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[3]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
                 self.app
@@ -1373,93 +1313,75 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(3),
-                        Constraint::Min(3),
-                        Constraint::Length(1),
-                    ])
-                    .split(f.area());
+                let chunks_main = Layout::vertical([
+                    Constraint::Length(3),
+                    Constraint::Min(3),
+                    Constraint::Length(1),
+                ])
+                .split(f.area());
 
-                let chunks_middle = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                        Constraint::Ratio(1, 4),
-                    ])
-                    .split(chunks_main[1]);
+                let chunks_middle = Layout::horizontal([
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                    Constraint::Ratio(1, 4),
+                ])
+                .split(chunks_main[1]);
 
-                let chunks_middle_column1 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_library_tag_editor_len),
-                        Constraint::Length(select_library_delete_len),
-                        Constraint::Length(select_library_load_dir_len),
-                        Constraint::Length(select_library_yank_len),
-                        Constraint::Length(select_library_paste_len),
-                        Constraint::Length(select_library_search_len),
-                        Constraint::Length(select_library_search_youtube_len),
-                        Constraint::Length(select_playlist_delete_len),
-                        Constraint::Length(select_playlist_delete_all_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[0]);
-                let chunks_middle_column2 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_playlist_search_len),
-                        Constraint::Length(select_playlist_shuffle_len),
-                        Constraint::Length(select_playlist_mode_cycle_len),
-                        Constraint::Length(select_playlist_play_selected_len),
-                        Constraint::Length(select_playlist_swap_down_len),
-                        Constraint::Length(select_playlist_swap_up_len),
-                        Constraint::Length(select_database_add_all_len),
-                        Constraint::Length(select_database_add_selected_len),
-                        Constraint::Length(select_playlist_random_album_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[1]);
+                let chunks_middle_column1 = Layout::vertical([
+                    Constraint::Length(select_library_tag_editor_len),
+                    Constraint::Length(select_library_delete_len),
+                    Constraint::Length(select_library_load_dir_len),
+                    Constraint::Length(select_library_yank_len),
+                    Constraint::Length(select_library_paste_len),
+                    Constraint::Length(select_library_search_len),
+                    Constraint::Length(select_library_search_youtube_len),
+                    Constraint::Length(select_playlist_delete_len),
+                    Constraint::Length(select_playlist_delete_all_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[0]);
+                let chunks_middle_column2 = Layout::vertical([
+                    Constraint::Length(select_playlist_search_len),
+                    Constraint::Length(select_playlist_shuffle_len),
+                    Constraint::Length(select_playlist_mode_cycle_len),
+                    Constraint::Length(select_playlist_play_selected_len),
+                    Constraint::Length(select_playlist_swap_down_len),
+                    Constraint::Length(select_playlist_swap_up_len),
+                    Constraint::Length(select_database_add_all_len),
+                    Constraint::Length(select_database_add_selected_len),
+                    Constraint::Length(select_playlist_random_album_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[1]);
 
-                let chunks_middle_column3 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(select_playlist_random_tracks_len),
-                        Constraint::Length(library_switch_root_len),
-                        Constraint::Length(library_add_root_len),
-                        Constraint::Length(library_remove_root_len),
-                        Constraint::Length(podcast_mark_played_len),
-                        Constraint::Length(podcast_mark_all_played_len),
-                        Constraint::Length(podcast_ep_download_len),
-                        Constraint::Length(podcast_ep_delete_file_len),
-                        Constraint::Length(podcast_delete_feed_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[2]);
+                let chunks_middle_column3 = Layout::vertical([
+                    Constraint::Length(select_playlist_random_tracks_len),
+                    Constraint::Length(library_switch_root_len),
+                    Constraint::Length(library_add_root_len),
+                    Constraint::Length(library_remove_root_len),
+                    Constraint::Length(podcast_mark_played_len),
+                    Constraint::Length(podcast_mark_all_played_len),
+                    Constraint::Length(podcast_ep_download_len),
+                    Constraint::Length(podcast_ep_delete_file_len),
+                    Constraint::Length(podcast_delete_feed_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[2]);
 
-                let chunks_middle_column4 = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(podcast_delete_all_feeds_len),
-                        Constraint::Length(podcast_refresh_feed_len),
-                        Constraint::Length(podcast_refresh_all_feeds_len),
-                        Constraint::Length(podcast_search_add_feed_len),
-                        // Constraint::Length(podcast_mark_played_len),
-                        // Constraint::Length(podcast_mark_all_played_len),
-                        // Constraint::Length(podcast_ep_download_len),
-                        // Constraint::Length(podcast_ep_delete_file_len),
-                        // Constraint::Length(podcast_delete_feed_len),
-                        Constraint::Min(0),
-                    ])
-                    .split(chunks_middle[3]);
+                let chunks_middle_column4 = Layout::vertical([
+                    Constraint::Length(podcast_delete_all_feeds_len),
+                    Constraint::Length(podcast_refresh_feed_len),
+                    Constraint::Length(podcast_refresh_all_feeds_len),
+                    Constraint::Length(podcast_search_add_feed_len),
+                    // Constraint::Length(podcast_mark_played_len),
+                    // Constraint::Length(podcast_mark_all_played_len),
+                    // Constraint::Length(podcast_ep_download_len),
+                    // Constraint::Length(podcast_ep_delete_file_len),
+                    // Constraint::Length(podcast_delete_feed_len),
+                    Constraint::Min(0),
+                ])
+                .split(chunks_middle[3]);
                 self.app
                     .view(&Id::ConfigEditor(IdConfigEditor::Header), f, chunks_main[0]);
                 self.app

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -52,7 +52,7 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn view_config_editor_general(&mut self) {
+    fn view_config_editor_general(&mut self) {
         self.terminal
             .raw_mut()
             .draw(|f| {
@@ -208,7 +208,7 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn view_config_editor_color(&mut self) {
+    fn view_config_editor_color(&mut self) {
         let select_library_foreground_len = match self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::LibraryForeground))
@@ -634,7 +634,7 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn view_config_editor_key1(&mut self) {
+    fn view_config_editor_key1(&mut self) {
         let select_global_quit_len = match self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::Key(IdKey::GlobalQuit)))
@@ -1107,7 +1107,7 @@ impl Model {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn view_config_editor_key2(&mut self) {
+    fn view_config_editor_key2(&mut self) {
         let select_library_delete_len = match self
             .app
             .state(&Id::ConfigEditor(IdConfigEditor::Key(IdKey::LibraryDelete)))

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -42,6 +42,15 @@ use tuirealm::ratatui::widgets::Clear;
 use tuirealm::{AttrValue, Attribute, Frame, State, StateValue};
 
 impl Model {
+    pub fn view_config_editor(&mut self) {
+        match self.config_editor.layout {
+            ConfigEditorLayout::General => self.view_config_editor_general(),
+            ConfigEditorLayout::Color => self.view_config_editor_color(),
+            ConfigEditorLayout::Key1 => self.view_config_editor_key1(),
+            ConfigEditorLayout::Key2 => self.view_config_editor_key2(),
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     pub fn view_config_editor_general(&mut self) {
         self.terminal

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -118,6 +118,12 @@ enum DBCriteria {
 }
 
 impl DBCriteria {
+    /// Number of elements in the table.
+    /// This is for example used to get exact space allocation for the layout.
+    ///
+    /// Note: keep this in-sync with [`Self::build_table`]
+    const NUM_OPTIONS: u16 = 5;
+
     fn build_table() -> Table {
         TableBuilder::default()
             .add_col(TextSpan::from("Artist"))
@@ -196,6 +202,12 @@ impl DBListCriteria {
             on_key_backtab,
             config,
         }
+    }
+
+    /// Get the number of static options in the list.
+    // See `DBCriteria::num_option` for actual implementation.
+    pub const fn num_options() -> u16 {
+        DBCriteria::NUM_OPTIONS
     }
 }
 

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -587,7 +587,7 @@ impl Model {
         for record in all_items
             .into_iter()
             .filter_map(std::result::Result::ok)
-            .filter(|p| is_playlist(&p.path().to_string_lossy()))
+            .filter(|p| is_playlist(p.path()))
         {
             let full_path_name = record.path().to_string_lossy().to_string();
             vec.push(full_path_name);
@@ -605,7 +605,8 @@ impl Model {
     ) -> Option<Vec<TrackDB>> {
         match criteria {
             SearchCriteria::Playlist => {
-                if let Ok(vec) = playlist_get_vec(val) {
+                let path = Path::new(val);
+                if let Ok(vec) = playlist_get_vec(path) {
                     let mut vec_db = Vec::with_capacity(vec.len());
                     for item in vec {
                         if let Ok(i) = self.db.get_record_by_path(&item) {

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -89,14 +89,14 @@ impl MusicLibrary {
     /// Also known as going down the tree / adding file to playlist
     fn handle_right_key(&mut self) -> (CmdResult, Option<Msg>) {
         let current_node = self.component.tree_state().selected().unwrap();
-        let p: &Path = Path::new(current_node);
-        if p.is_dir() {
+        let path: &Path = Path::new(current_node);
+        if path.is_dir() {
             // TODO: try to load the directory if it is not loaded yet.
             (self.perform(Cmd::Custom(TREE_CMD_OPEN)), None)
         } else {
             (
                 CmdResult::None,
-                Some(Msg::Playlist(PLMsg::Add(current_node.to_string()))),
+                Some(Msg::Playlist(PLMsg::Add(path.to_path_buf()))),
             )
         }
     }
@@ -153,9 +153,9 @@ impl Component<Msg, UserEvent> for MusicLibrary {
 
             Event::Keyboard(keyevent) if keyevent == keys.library_keys.load_dir.get() => {
                 let current_node = self.component.tree_state().selected().unwrap();
-                let p: &Path = Path::new(current_node);
-                if p.is_dir() {
-                    return Some(Msg::Playlist(PLMsg::Add(current_node.to_string())));
+                let path: &Path = Path::new(current_node);
+                if path.is_dir() {
+                    return Some(Msg::Playlist(PLMsg::Add(path.to_path_buf())));
                 }
                 CmdResult::None
             }

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -823,7 +823,8 @@ impl Model {
                     if record.title.contains("Unknown Title") {
                         continue;
                     }
-                    if filetype_supported(&record.file) {
+                    let path = Path::new(&record.file);
+                    if filetype_supported(path) {
                         result.push(record.clone());
                         i += 1;
                         if i > quantity - 1 {

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -272,8 +272,8 @@ impl Model {
     }
 
     /// Add a playlist (like m3u) to the playlist.
-    fn playlist_add_playlist(&mut self, current_node: &str) -> Result<()> {
-        let vec = playlist_get_vec(current_node)?;
+    fn playlist_add_playlist(&mut self, playlist_path: &Path) -> Result<()> {
+        let vec = playlist_get_vec(playlist_path)?;
 
         let sources = vec
             .into_iter()
@@ -325,13 +325,12 @@ impl Model {
     /// Add the `current_node`, regardless if it is a Track, dir, playlist, etc.
     ///
     /// See [`Model::playlist_add_episode`] for podcast episode adding
-    pub fn playlist_add(&mut self, current_node: &str) -> Result<()> {
-        let p: &Path = Path::new(&current_node);
-        if !p.exists() {
+    pub fn playlist_add(&mut self, path: &Path) -> Result<()> {
+        if !path.exists() {
             return Ok(());
         }
-        if p.is_dir() {
-            let new_items_vec = Self::library_dir_children(p);
+        if path.is_dir() {
+            let new_items_vec = Self::library_dir_children(path);
 
             let sources = new_items_vec
                 .into_iter()
@@ -347,21 +346,21 @@ impl Model {
 
             return Ok(());
         }
-        self.playlist_add_item(current_node)?;
+        self.playlist_add_item(path)?;
         self.playlist_sync();
         Ok(())
     }
 
     /// Add a Track or a Playlist to the playlist
-    fn playlist_add_item(&mut self, current_node: &str) -> Result<()> {
-        if is_playlist(current_node) {
-            self.playlist_add_playlist(current_node)?;
+    fn playlist_add_item(&mut self, path: &Path) -> Result<()> {
+        if is_playlist(path) {
+            self.playlist_add_playlist(path)?;
             return Ok(());
         }
-        let source = if current_node.starts_with("http") {
-            PlaylistTrackSource::Url(current_node.to_string())
+        let source = if path.starts_with("http") {
+            PlaylistTrackSource::Url(path.to_string_lossy().to_string())
         } else {
-            PlaylistTrackSource::Path(current_node.to_string())
+            PlaylistTrackSource::Path(path.to_string_lossy().to_string())
         };
 
         self.command(TuiCmd::Playlist(PlaylistCmd::AddTrack(

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -1,28 +1,7 @@
-use crate::ui::model::UserEvent;
-/**
- * MIT License
- *
- * termusic - Copyright (c) 2021 Larry Hao
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-use crate::ui::Model;
+//! SPDX-License-Identifier: MIT
+
+use std::path::Path;
+
 use anyhow::{anyhow, bail, Result};
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use termusiclib::ids::Id;
@@ -34,6 +13,9 @@ use tuirealm::command::{Cmd, CmdResult, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers};
 use tuirealm::props::{Alignment, BorderType, Borders, InputType, TableBuilder, TextSpan};
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
+
+use crate::ui::model::UserEvent;
+use crate::ui::Model;
 
 #[derive(MockComponent)]
 pub struct GSInputPopup {
@@ -440,7 +422,8 @@ impl Model {
                 if let Some(line) = table.get(index) {
                     if let Some(text_span) = line.get(1) {
                         let text = &text_span.content;
-                        self.playlist_add(text)?;
+                        let path = Path::new(text);
+                        self.playlist_add(path)?;
                     }
                 }
             }
@@ -530,7 +513,8 @@ impl Model {
 
     pub fn general_search_after_database_add_playlist(&mut self) -> Result<()> {
         let track = self.general_search_get_info(3)?;
-        self.playlist_add(&track)?;
+        let path = Path::new(&track);
+        self.playlist_add(path)?;
         Ok(())
     }
 

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -55,55 +55,47 @@ impl Model {
                     let chunks_main = Layout::default()
                         .direction(Direction::Vertical)
                         .margin(0)
-                        .constraints(
-                            [
-                                Constraint::Length(1),
-                                Constraint::Length(3),
-                                Constraint::Length(3),
-                                // Constraint::Length(3),
-                                Constraint::Min(2),
-                                Constraint::Length(1),
-                            ]
-                            .as_ref(),
-                        )
+                        .constraints([
+                            Constraint::Length(1),
+                            Constraint::Length(3),
+                            Constraint::Length(3),
+                            // Constraint::Length(3),
+                            Constraint::Min(2),
+                            Constraint::Length(1),
+                        ])
                         .split(f.area());
 
                     let chunks_row1 = Layout::default()
                         .direction(Direction::Horizontal)
                         .margin(0)
-                        .constraints([Constraint::Ratio(2, 5), Constraint::Ratio(3, 5)].as_ref())
+                        .constraints([Constraint::Ratio(2, 5), Constraint::Ratio(3, 5)])
                         .split(chunks_main[1]);
                     let chunks_row2 = Layout::default()
                         .direction(Direction::Horizontal)
                         .margin(0)
-                        .constraints(
-                            [
-                                Constraint::Ratio(1, 4),
-                                Constraint::Ratio(1, 4),
-                                Constraint::Ratio(1, 4),
-                                Constraint::Ratio(1, 4),
-                            ]
-                            .as_ref(),
-                        )
+                        .constraints([
+                            Constraint::Ratio(1, 4),
+                            Constraint::Ratio(1, 4),
+                            Constraint::Ratio(1, 4),
+                            Constraint::Ratio(1, 4),
+                        ])
                         .split(chunks_main[2]);
                     let chunks_row4 = Layout::default()
                         .direction(Direction::Horizontal)
                         .margin(0)
-                        .constraints([Constraint::Ratio(3, 5), Constraint::Ratio(2, 5)].as_ref())
+                        .constraints([Constraint::Ratio(3, 5), Constraint::Ratio(2, 5)])
                         .split(chunks_main[3]);
 
                     let chunks_row4_right = Layout::default()
                         .direction(Direction::Vertical)
                         .margin(0)
-                        .constraints(
-                            [Constraint::Length(select_lyric_len), Constraint::Min(2)].as_ref(),
-                        )
+                        .constraints([Constraint::Length(select_lyric_len), Constraint::Min(2)])
                         .split(chunks_row4[1]);
 
                     let chunks_row4_right_top = Layout::default()
                         .direction(Direction::Horizontal)
                         .margin(0)
-                        .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)].as_ref())
+                        .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
                         .split(chunks_row4_right[0]);
 
                     // -- footer
@@ -111,14 +103,11 @@ impl Model {
                         let chunks_footer = Layout::default()
                             .direction(Direction::Horizontal)
                             .margin(0)
-                            .constraints(
-                                [
-                                    Constraint::Length(1),
-                                    Constraint::Length(1),
-                                    Constraint::Min(10),
-                                ]
-                                .as_ref(),
-                            )
+                            .constraints([
+                                Constraint::Length(1),
+                                Constraint::Length(1),
+                                Constraint::Min(10),
+                            ])
                             .split(chunks_main[4]);
 
                         self.app.view(&Id::DownloadSpinner, f, chunks_footer[1]);

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -33,7 +33,7 @@ use std::borrow::Cow;
 use std::path::Path;
 use termusiclib::ids::{Id, IdTagEditor};
 use tuirealm::props::{Alignment, AttrValue, Attribute, PropPayload, PropValue, TextSpan};
-use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::layout::{Constraint, Layout};
 use tuirealm::ratatui::widgets::Clear;
 use tuirealm::State;
 
@@ -52,63 +52,48 @@ impl Model {
                     };
                 if self.app.mounted(&Id::TagEditor(IdTagEditor::LabelHint)) {
                     f.render_widget(Clear, f.area());
-                    let chunks_main = Layout::default()
-                        .direction(Direction::Vertical)
-                        .margin(0)
-                        .constraints([
-                            Constraint::Length(1),
-                            Constraint::Length(3),
-                            Constraint::Length(3),
-                            // Constraint::Length(3),
-                            Constraint::Min(2),
-                            Constraint::Length(1),
-                        ])
-                        .split(f.area());
+                    let chunks_main = Layout::vertical([
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                        Constraint::Length(3),
+                        // Constraint::Length(3),
+                        Constraint::Min(2),
+                        Constraint::Length(1),
+                    ])
+                    .split(f.area());
 
-                    let chunks_row1 = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .margin(0)
-                        .constraints([Constraint::Ratio(2, 5), Constraint::Ratio(3, 5)])
-                        .split(chunks_main[1]);
-                    let chunks_row2 = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .margin(0)
-                        .constraints([
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                            Constraint::Ratio(1, 4),
-                        ])
-                        .split(chunks_main[2]);
-                    let chunks_row4 = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .margin(0)
-                        .constraints([Constraint::Ratio(3, 5), Constraint::Ratio(2, 5)])
-                        .split(chunks_main[3]);
+                    let chunks_row1 =
+                        Layout::horizontal([Constraint::Ratio(2, 5), Constraint::Ratio(3, 5)])
+                            .split(chunks_main[1]);
+                    let chunks_row2 = Layout::horizontal([
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                        Constraint::Ratio(1, 4),
+                    ])
+                    .split(chunks_main[2]);
+                    let chunks_row4 =
+                        Layout::horizontal([Constraint::Ratio(3, 5), Constraint::Ratio(2, 5)])
+                            .split(chunks_main[3]);
 
-                    let chunks_row4_right = Layout::default()
-                        .direction(Direction::Vertical)
-                        .margin(0)
-                        .constraints([Constraint::Length(select_lyric_len), Constraint::Min(2)])
-                        .split(chunks_row4[1]);
+                    let chunks_row4_right = Layout::vertical([
+                        Constraint::Length(select_lyric_len),
+                        Constraint::Min(2),
+                    ])
+                    .split(chunks_row4[1]);
 
-                    let chunks_row4_right_top = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .margin(0)
-                        .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                        .split(chunks_row4_right[0]);
+                    let chunks_row4_right_top =
+                        Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+                            .split(chunks_row4_right[0]);
 
                     // -- footer
                     if self.download_tracker.visible() {
-                        let chunks_footer = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .margin(0)
-                            .constraints([
-                                Constraint::Length(1),
-                                Constraint::Length(1),
-                                Constraint::Min(10),
-                            ])
-                            .split(chunks_main[4]);
+                        let chunks_footer = Layout::horizontal([
+                            Constraint::Length(1),
+                            Constraint::Length(1),
+                            Constraint::Min(10),
+                        ])
+                        .split(chunks_main[4]);
 
                         self.app.view(&Id::DownloadSpinner, f, chunks_footer[1]);
                         self.app.view(&Id::Label, f, chunks_footer[2]);

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use termusiclib::ids::{Id, IdTagEditor};
-use termusiclib::library_db::SearchCriteria;
 use termusiclib::track::MediaTypesSimple;
 use termusiclib::types::{
     DBMsg, DLMsg, GSMsg, LIMsg, LyricMsg, MainLayoutMsg, Msg, PCMsg, PLMsg, PlayerMsg,
@@ -28,7 +27,7 @@ impl Update<Msg> for Model {
         // Match message
         match msg {
             Msg::ConfigEditor(m) => self.update_config_editor(m),
-            Msg::DataBase(m) => self.update_database_list(&m),
+            Msg::DataBase(m) => self.update_database_list(m),
 
             Msg::DeleteConfirmShow | Msg::DeleteConfirmCloseCancel | Msg::DeleteConfirmCloseOk => {
                 self.update_delete_confirmation(&msg)
@@ -496,7 +495,7 @@ impl Model {
 
         None
     }
-    fn update_database_list(&mut self, msg: &DBMsg) -> Option<Msg> {
+    fn update_database_list(&mut self, msg: DBMsg) -> Option<Msg> {
         match msg {
             DBMsg::CriteriaBlurDown | DBMsg::SearchTracksBlurUp => {
                 self.app.active(&Id::DBListSearchResult).ok();
@@ -510,16 +509,16 @@ impl Model {
             DBMsg::SearchResultBlurUp => {
                 self.app.active(&Id::DBListCriteria).ok();
             }
-            DBMsg::SearchResult(index) => {
-                self.dw.criteria = SearchCriteria::from(*index);
+            DBMsg::SearchResult(criteria) => {
+                self.dw.criteria = criteria;
                 self.database_update_search_results();
             }
             DBMsg::SearchTrack(index) => {
-                self.database_update_search_tracks(*index);
+                self.database_update_search_tracks(index);
             }
             DBMsg::AddPlaylist(index) => {
                 if !self.dw.search_tracks.is_empty() {
-                    if let Some(track) = self.dw.search_tracks.get(*index) {
+                    if let Some(track) = self.dw.search_tracks.get(index) {
                         let file = track.file.clone();
                         if let Err(e) = self.playlist_add(&file) {
                             self.mount_error_popup(e.context("playlist add"));
@@ -533,7 +532,7 @@ impl Model {
             }
 
             DBMsg::AddResultToPlaylist(index) => {
-                if let Some(result) = self.dw.search_results.get(*index).cloned() {
+                if let Some(result) = self.dw.search_results.get(index).cloned() {
                     if let Some(result) =
                         self.database_get_tracks_by_criteria(self.dw.criteria, &result)
                     {

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -1,6 +1,6 @@
 //! SPDX-License-Identifier: MIT
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -519,7 +519,7 @@ impl Model {
             DBMsg::AddPlaylist(index) => {
                 if !self.dw.search_tracks.is_empty() {
                     if let Some(track) = self.dw.search_tracks.get(index) {
-                        let file = track.file.clone();
+                        let file = PathBuf::from(&track.file);
                         if let Err(e) = self.playlist_add(&file) {
                             self.mount_error_popup(e.context("playlist add"));
                         }

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -230,9 +230,10 @@ impl Model {
                     .margin(0)
                     .constraints(
                         [
-                            Constraint::Length(10),
-                            Constraint::Length(10),
-                            Constraint::Min(2),
+                            Constraint::Length(DBListCriteria::num_options() + 2), // + 2 as this area still includes the borders
+                            // maybe resize based on which one is focused?
+                            Constraint::Fill(1),
+                            Constraint::Fill(2),
                         ]
                         .as_ref(),
                     )

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -161,7 +161,7 @@ impl Model {
         }
     }
 
-    pub fn view_layout_podcast(&mut self) {
+    fn view_layout_podcast(&mut self) {
         self.terminal
             .raw_mut()
             .draw(|f| {
@@ -194,7 +194,7 @@ impl Model {
             .expect("Expected to draw without error");
     }
 
-    pub fn view_layout_database(&mut self) {
+    fn view_layout_database(&mut self) {
         self.terminal
             .raw_mut()
             .draw(|f| {
@@ -233,7 +233,7 @@ impl Model {
             .expect("Expected to draw without error");
     }
 
-    pub fn view_layout_treeview(&mut self) {
+    fn view_layout_treeview(&mut self) {
         self.terminal
             .raw_mut()
             .draw(|f| {

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -173,30 +173,27 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Min(2),
-                            Constraint::Length(3),
-                            Constraint::Length(1),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Min(2),
+                        Constraint::Length(3),
+                        Constraint::Length(1),
+                    ])
                     .split(f.area());
                 let chunks_center = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)].as_ref())
+                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
                     .split(chunks_main[0]);
 
                 let chunks_left = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)].as_ref())
+                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
                     .split(chunks_center[0]);
                 let chunks_right = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)].as_ref())
+                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
                     .split(chunks_center[1]);
 
                 self.app.view(&Id::Podcast, f, chunks_left[0]);
@@ -217,38 +214,32 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
+                    .constraints([Constraint::Min(2), Constraint::Length(1)])
                     .split(f.area());
                 let chunks_left = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)].as_ref())
+                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
                     .split(chunks_main[0]);
 
                 let chunks_left_sections = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Length(DBListCriteria::num_options() + 2), // + 2 as this area still includes the borders
-                            // maybe resize based on which one is focused?
-                            Constraint::Fill(1),
-                            Constraint::Fill(2),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Length(DBListCriteria::num_options() + 2), // + 2 as this area still includes the borders
+                        // maybe resize based on which one is focused?
+                        Constraint::Fill(1),
+                        Constraint::Fill(2),
+                    ])
                     .split(chunks_left[0]);
                 let chunks_right = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Min(2),
-                            Constraint::Length(3),
-                            Constraint::Length(4),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Min(2),
+                        Constraint::Length(3),
+                        Constraint::Length(4),
+                    ])
                     .split(chunks_left[1]);
 
                 self.app
@@ -273,24 +264,21 @@ impl Model {
                 let chunks_main = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
+                    .constraints([Constraint::Min(2), Constraint::Length(1)])
                     .split(f.area());
                 let chunks_left = Layout::default()
                     .direction(Direction::Horizontal)
                     .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)].as_ref())
+                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
                     .split(chunks_main[0]);
                 let chunks_right = Layout::default()
                     .direction(Direction::Vertical)
                     .margin(0)
-                    .constraints(
-                        [
-                            Constraint::Min(2),
-                            Constraint::Length(3),
-                            Constraint::Length(4),
-                        ]
-                        .as_ref(),
-                    )
+                    .constraints([
+                        Constraint::Min(2),
+                        Constraint::Length(3),
+                        Constraint::Length(4),
+                    ])
                     .split(chunks_left[1]);
 
                 self.app.view(&Id::Library, f, chunks_left[0]);
@@ -315,19 +303,16 @@ impl Model {
             let chunks_main = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(0)
-                .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
+                .constraints([Constraint::Min(2), Constraint::Length(1)])
                 .split(f.area());
             let chunks_footer = Layout::default()
                 .direction(Direction::Horizontal)
                 .margin(0)
-                .constraints(
-                    [
-                        Constraint::Length(1),
-                        Constraint::Length(1),
-                        Constraint::Min(10),
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Min(10),
+                ])
                 .split(chunks_main[1]);
 
             app.view(&Id::DownloadSpinner, f, chunks_footer[1]);
@@ -336,7 +321,7 @@ impl Model {
             let chunks_main = Layout::default()
                 .direction(Direction::Vertical)
                 .margin(0)
-                .constraints([Constraint::Min(2), Constraint::Length(1)].as_ref())
+                .constraints([Constraint::Min(2), Constraint::Length(1)])
                 .split(f.area());
             app.view(&Id::Label, f, chunks_main[1]);
         }
@@ -371,13 +356,10 @@ impl Model {
             f.render_widget(Clear, popup);
             let popup_chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints(
-                    [
-                        Constraint::Length(3), // Input form
-                        Constraint::Min(2),    // Yes/No
-                    ]
-                    .as_ref(),
-                )
+                .constraints([
+                    Constraint::Length(3), // Input form
+                    Constraint::Min(2),    // Yes/No
+                ])
                 .split(popup);
             app.view(&Id::GeneralSearchInput, f, popup_chunks[0]);
             app.view(&Id::GeneralSearchTable, f, popup_chunks[1]);
@@ -398,7 +380,7 @@ impl Model {
             f.render_widget(Clear, popup);
             let popup_chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Length(3), Constraint::Length(3)].as_ref())
+                .constraints([Constraint::Length(3), Constraint::Length(3)])
                 .split(popup);
             app.view(&Id::SavePlaylistPopup, f, popup_chunks[0]);
             app.view(&Id::SavePlaylistLabel, f, popup_chunks[1]);

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -20,7 +20,7 @@ use crate::ui::components::{
     FeedsList, Footer, GSInputPopup, GSTablePopup, GlobalListener, LabelSpan, Lyric, MusicLibrary,
     Playlist, Progress, Source,
 };
-use crate::ui::model::{ConfigEditorLayout, Model, TermusicLayout, UserEvent};
+use crate::ui::model::{Model, TermusicLayout, UserEvent};
 use crate::ui::utils::{
     draw_area_in_absolute, draw_area_in_relative, draw_area_top_right_absolute,
 };
@@ -149,12 +149,7 @@ impl Model {
                 self.view_tag_editor();
                 return;
             } else if self.app.mounted(&Id::ConfigEditor(IdConfigEditor::Header)) {
-                match self.config_editor.layout {
-                    ConfigEditorLayout::General => self.view_config_editor_general(),
-                    ConfigEditorLayout::Color => self.view_config_editor_color(),
-                    ConfigEditorLayout::Key1 => self.view_config_editor_key1(),
-                    ConfigEditorLayout::Key2 => self.view_config_editor_key2(),
-                }
+                self.view_config_editor();
                 return;
             }
 

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -170,34 +170,35 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::vertical([
+                let [chunks_main, progress, _bottom_help] = Layout::vertical([
                     Constraint::Min(2),
                     Constraint::Length(3),
                     Constraint::Length(1),
                 ])
-                .split(f.area());
-                let chunks_center =
+                .areas(f.area());
+                let [center_left, center_right] =
                     Layout::horizontal([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-                        .split(chunks_main[0]);
+                        .areas(chunks_main);
 
-                let chunks_left =
+                let [left_podcasts, left_episodes] =
                     Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                        .split(chunks_center[0]);
-                let chunks_right =
+                        .areas(center_left);
+                let [right_playlist, right_lyric] =
                     Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                        .split(chunks_center[1]);
+                        .areas(center_right);
 
-                self.app.view(&Id::Podcast, f, chunks_left[0]);
-                self.app.view(&Id::Episode, f, chunks_left[1]);
-                self.app.view(&Id::Playlist, f, chunks_right[0]);
-                self.app.view(&Id::Lyric, f, chunks_right[1]);
-                self.app.view(&Id::Progress, f, chunks_main[1]);
-                self.app.view(&Id::Label, f, chunks_main[2]);
+                self.app.view(&Id::Podcast, f, left_podcasts);
+                self.app.view(&Id::Episode, f, left_episodes);
+
+                self.app.view(&Id::Playlist, f, right_playlist);
+                self.app.view(&Id::Lyric, f, right_lyric);
+                self.app.view(&Id::Progress, f, progress);
 
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
             .expect("Expected to draw without error");
     }
+
     pub fn view_layout_database(&mut self) {
         self.terminal
             .raw_mut()
@@ -231,6 +232,7 @@ impl Model {
                 self.app.view(&Id::Playlist, f, right_playlist);
                 self.app.view(&Id::Progress, f, right_progress);
                 self.app.view(&Id::Lyric, f, right_lyric);
+
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
             .expect("Expected to draw without error");
@@ -240,23 +242,23 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main =
-                    Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
-                let chunks_left =
+                let [chunks_main, _bottom_help] =
+                    Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
+                let [left_library, right] =
                     Layout::horizontal([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-                        .split(chunks_main[0]);
-                let chunks_right = Layout::vertical([
+                        .areas(chunks_main);
+                let [right_playlist, right_progress, right_lyric] = Layout::vertical([
                     Constraint::Min(2),
                     Constraint::Length(3),
                     Constraint::Length(4),
                 ])
-                .split(chunks_left[1]);
+                .areas(right);
 
-                self.app.view(&Id::Library, f, chunks_left[0]);
-                self.app.view(&Id::Playlist, f, chunks_right[0]);
-                self.app.view(&Id::Progress, f, chunks_right[1]);
-                self.app.view(&Id::Lyric, f, chunks_right[2]);
-                self.app.view(&Id::Label, f, chunks_main[1]);
+                self.app.view(&Id::Library, f, left_library);
+
+                self.app.view(&Id::Playlist, f, right_playlist);
+                self.app.view(&Id::Progress, f, right_progress);
+                self.app.view(&Id::Lyric, f, right_lyric);
 
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
@@ -271,21 +273,21 @@ impl Model {
     ) {
         // -- footer
         if downloading_visible {
-            let chunks_main =
-                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
-            let chunks_footer = Layout::horizontal([
+            let [_content, bottom_label] =
+                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
+            let [_spacer, spinner, remainder] = Layout::horizontal([
                 Constraint::Length(1),
                 Constraint::Length(1),
                 Constraint::Min(10),
             ])
-            .split(chunks_main[1]);
+            .areas(bottom_label);
 
-            app.view(&Id::DownloadSpinner, f, chunks_footer[1]);
-            app.view(&Id::Label, f, chunks_footer[2]);
+            app.view(&Id::DownloadSpinner, f, spinner);
+            app.view(&Id::Label, f, remainder);
         } else {
-            let chunks_main =
-                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
-            app.view(&Id::Label, f, chunks_main[1]);
+            let [_content, bottom_label] =
+                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
+            app.view(&Id::Label, f, bottom_label);
         }
 
         // -- popups

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -211,47 +211,35 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([Constraint::Min(2), Constraint::Length(1)])
-                    .split(f.area());
-                let chunks_left = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-                    .split(chunks_main[0]);
+                let [chunks_main, _bottom_help] =
+                    Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
+                let [chunks_main_left, chunks_main_right] =
+                    Layout::horizontal([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
+                        .areas(chunks_main);
 
-                let chunks_left_sections = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Length(DBListCriteria::num_options() + 2), // + 2 as this area still includes the borders
-                        // maybe resize based on which one is focused?
-                        Constraint::Fill(1),
-                        Constraint::Fill(2),
-                    ])
-                    .split(chunks_left[0]);
-                let chunks_right = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Min(2),
-                        Constraint::Length(3),
-                        Constraint::Length(4),
-                    ])
-                    .split(chunks_left[1]);
+                let [left_criteria, left_search_result, left_search_tracks] = Layout::vertical([
+                    Constraint::Length(DBListCriteria::num_options() + 2), // + 2 as this area still includes the borders
+                    // maybe resize based on which one is focused?
+                    Constraint::Fill(1),
+                    Constraint::Fill(2),
+                ])
+                .areas(chunks_main_left);
+                let [right_playlist, right_progress, right_lyric] = Layout::vertical([
+                    Constraint::Min(2),
+                    Constraint::Length(3),
+                    Constraint::Length(4),
+                ])
+                .areas(chunks_main_right);
 
+                self.app.view(&Id::DBListCriteria, f, left_criteria);
                 self.app
-                    .view(&Id::DBListCriteria, f, chunks_left_sections[0]);
+                    .view(&Id::DBListSearchResult, f, left_search_result);
                 self.app
-                    .view(&Id::DBListSearchResult, f, chunks_left_sections[1]);
-                self.app
-                    .view(&Id::DBListSearchTracks, f, chunks_left_sections[2]);
+                    .view(&Id::DBListSearchTracks, f, left_search_tracks);
 
-                self.app.view(&Id::Playlist, f, chunks_right[0]);
-                self.app.view(&Id::Progress, f, chunks_right[1]);
-                self.app.view(&Id::Lyric, f, chunks_right[2]);
+                self.app.view(&Id::Playlist, f, right_playlist);
+                self.app.view(&Id::Progress, f, right_progress);
+                self.app.view(&Id::Lyric, f, right_lyric);
                 Self::view_layout_commons(f, &mut self.app, self.download_tracker.visible());
             })
             .expect("Expected to draw without error");

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -33,9 +33,6 @@ impl Model {
         config: &SharedTuiSettings,
     ) -> Application<Id, Msg, UserEvent> {
         // Setup application
-        // NOTE: NoUserEvent is a shorthand to tell tui-realm we're not going to use any custom user event
-        // NOTE: the event listener is configured to use the default crossterm input listener and to raise a Tick event each second
-        // which we will use to update the clock
 
         let mut app: Application<Id, Msg, UserEvent> = Application::init(
             EventListenerCfg::default()

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -265,16 +265,16 @@ impl Model {
             .expect("Expected to draw without error");
     }
 
-    #[allow(clippy::too_many_lines)]
-    fn view_layout_commons(
+    /// Draw the footer in the last line.
+    fn view_common_footer(
         f: &mut Frame<'_>,
         app: &mut Application<Id, Msg, UserEvent>,
         downloading_visible: bool,
     ) {
-        // -- footer
+        let [_content, bottom_label] =
+            Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
+
         if downloading_visible {
-            let [_content, bottom_label] =
-                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
             let [_spacer, spinner, remainder] = Layout::horizontal([
                 Constraint::Length(1),
                 Constraint::Length(1),
@@ -285,12 +285,12 @@ impl Model {
             app.view(&Id::DownloadSpinner, f, spinner);
             app.view(&Id::Label, f, remainder);
         } else {
-            let [_content, bottom_label] =
-                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).areas(f.area());
             app.view(&Id::Label, f, bottom_label);
         }
+    }
 
-        // -- popups
+    /// Draw any popup.
+    fn view_popups(f: &mut Frame<'_>, app: &mut Application<Id, Msg, UserEvent>) {
         if app.mounted(&Id::QuitPopup) {
             let popup = draw_area_in_absolute(f.area(), 30, 3);
             f.render_widget(Clear, popup);
@@ -367,6 +367,17 @@ impl Model {
             f.render_widget(Clear, popup);
             app.view(&Id::ErrorPopup, f, popup);
         }
+    }
+
+    /// Draw common things, like the bottom label and popups.
+    fn view_layout_commons(
+        f: &mut Frame<'_>,
+        app: &mut Application<Id, Msg, UserEvent>,
+        downloading_visible: bool,
+    ) {
+        Self::view_common_footer(f, app, downloading_visible);
+
+        Self::view_popups(f, app);
     }
 
     /// Mount / Remount a search popup for the provided source

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -10,7 +10,7 @@ use termusiclib::types::{DBMsg, Msg, PCMsg};
 use termusiclib::utils::get_parent_folder;
 use tui_realm_treeview::Tree;
 use tuirealm::props::{AttrValue, Attribute, Color, PropPayload, PropValue, TextSpan};
-use tuirealm::ratatui::layout::{Constraint, Direction, Layout};
+use tuirealm::ratatui::layout::{Constraint, Layout};
 use tuirealm::ratatui::widgets::Clear;
 use tuirealm::EventListenerCfg;
 use tuirealm::{Frame, State, StateValue};
@@ -170,31 +170,22 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Min(2),
-                        Constraint::Length(3),
-                        Constraint::Length(1),
-                    ])
-                    .split(f.area());
-                let chunks_center = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-                    .split(chunks_main[0]);
+                let chunks_main = Layout::vertical([
+                    Constraint::Min(2),
+                    Constraint::Length(3),
+                    Constraint::Length(1),
+                ])
+                .split(f.area());
+                let chunks_center =
+                    Layout::horizontal([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
+                        .split(chunks_main[0]);
 
-                let chunks_left = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                    .split(chunks_center[0]);
-                let chunks_right = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                    .split(chunks_center[1]);
+                let chunks_left =
+                    Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+                        .split(chunks_center[0]);
+                let chunks_right =
+                    Layout::vertical([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
+                        .split(chunks_center[1]);
 
                 self.app.view(&Id::Podcast, f, chunks_left[0]);
                 self.app.view(&Id::Episode, f, chunks_left[1]);
@@ -249,25 +240,17 @@ impl Model {
         self.terminal
             .raw_mut()
             .draw(|f| {
-                let chunks_main = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([Constraint::Min(2), Constraint::Length(1)])
-                    .split(f.area());
-                let chunks_left = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .margin(0)
-                    .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-                    .split(chunks_main[0]);
-                let chunks_right = Layout::default()
-                    .direction(Direction::Vertical)
-                    .margin(0)
-                    .constraints([
-                        Constraint::Min(2),
-                        Constraint::Length(3),
-                        Constraint::Length(4),
-                    ])
-                    .split(chunks_left[1]);
+                let chunks_main =
+                    Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
+                let chunks_left =
+                    Layout::horizontal([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
+                        .split(chunks_main[0]);
+                let chunks_right = Layout::vertical([
+                    Constraint::Min(2),
+                    Constraint::Length(3),
+                    Constraint::Length(4),
+                ])
+                .split(chunks_left[1]);
 
                 self.app.view(&Id::Library, f, chunks_left[0]);
                 self.app.view(&Id::Playlist, f, chunks_right[0]);
@@ -288,29 +271,20 @@ impl Model {
     ) {
         // -- footer
         if downloading_visible {
-            let chunks_main = Layout::default()
-                .direction(Direction::Vertical)
-                .margin(0)
-                .constraints([Constraint::Min(2), Constraint::Length(1)])
-                .split(f.area());
-            let chunks_footer = Layout::default()
-                .direction(Direction::Horizontal)
-                .margin(0)
-                .constraints([
-                    Constraint::Length(1),
-                    Constraint::Length(1),
-                    Constraint::Min(10),
-                ])
-                .split(chunks_main[1]);
+            let chunks_main =
+                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
+            let chunks_footer = Layout::horizontal([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(10),
+            ])
+            .split(chunks_main[1]);
 
             app.view(&Id::DownloadSpinner, f, chunks_footer[1]);
             app.view(&Id::Label, f, chunks_footer[2]);
         } else {
-            let chunks_main = Layout::default()
-                .direction(Direction::Vertical)
-                .margin(0)
-                .constraints([Constraint::Min(2), Constraint::Length(1)])
-                .split(f.area());
+            let chunks_main =
+                Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(f.area());
             app.view(&Id::Label, f, chunks_main[1]);
         }
 
@@ -342,13 +316,11 @@ impl Model {
         } else if app.mounted(&Id::GeneralSearchInput) {
             let popup = draw_area_in_relative(f.area(), 65, 68);
             f.render_widget(Clear, popup);
-            let popup_chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(3), // Input form
-                    Constraint::Min(2),    // Yes/No
-                ])
-                .split(popup);
+            let popup_chunks = Layout::vertical([
+                Constraint::Length(3), // Input form
+                Constraint::Min(2),    // Yes/No
+            ])
+            .split(popup);
             app.view(&Id::GeneralSearchInput, f, popup_chunks[0]);
             app.view(&Id::GeneralSearchTable, f, popup_chunks[1]);
         } else if app.mounted(&Id::YoutubeSearchInputPopup) {
@@ -366,10 +338,8 @@ impl Model {
         } else if app.mounted(&Id::SavePlaylistPopup) {
             let popup = draw_area_in_absolute(f.area(), 76, 6);
             f.render_widget(Clear, popup);
-            let popup_chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(3), Constraint::Length(3)])
-                .split(popup);
+            let popup_chunks =
+                Layout::vertical([Constraint::Length(3), Constraint::Length(3)]).split(popup);
             app.view(&Id::SavePlaylistPopup, f, popup_chunks[0]);
             app.view(&Id::SavePlaylistLabel, f, popup_chunks[1]);
         } else if app.mounted(&Id::SavePlaylistConfirm) {

--- a/tui/src/ui/utils.rs
+++ b/tui/src/ui/utils.rs
@@ -1,4 +1,4 @@
-use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
+use tuirealm::ratatui::layout::{Constraint, Layout, Rect};
 
 // /// Get block
 // pub fn get_block<'a>(props: &Borders, title: (String, Alignment), focus: bool) -> Block<'a> {
@@ -16,60 +16,48 @@ use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 
 /// Draw an area (`WxH / 3`) in the middle of the parent area
 pub fn draw_area_in_relative(parent: Rect, width: u16, height: u16) -> Rect {
-    let new_area = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - height) / 2),
-            Constraint::Percentage(height),
-            Constraint::Percentage((100 - height) / 2),
-        ])
-        .split(parent);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - width) / 2),
-            Constraint::Percentage(width),
-            Constraint::Percentage((100 - width) / 2),
-        ])
-        .split(new_area[1])[1]
+    let new_area = Layout::vertical([
+        Constraint::Percentage((100 - height) / 2),
+        Constraint::Percentage(height),
+        Constraint::Percentage((100 - height) / 2),
+    ])
+    .split(parent);
+    Layout::horizontal([
+        Constraint::Percentage((100 - width) / 2),
+        Constraint::Percentage(width),
+        Constraint::Percentage((100 - width) / 2),
+    ])
+    .split(new_area[1])[1]
 }
 
 pub fn draw_area_in_absolute(parent: Rect, width: u16, height: u16) -> Rect {
-    let new_area = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length((parent.height - height) / 2),
-            Constraint::Length(height),
-            Constraint::Length((parent.height - height) / 2),
-        ])
-        .split(parent);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length((parent.width - width) / 2),
-            Constraint::Length(width),
-            Constraint::Length((parent.width - width) / 2),
-        ])
-        .split(new_area[1])[1]
+    let new_area = Layout::vertical([
+        Constraint::Length((parent.height - height) / 2),
+        Constraint::Length(height),
+        Constraint::Length((parent.height - height) / 2),
+    ])
+    .split(parent);
+    Layout::horizontal([
+        Constraint::Length((parent.width - width) / 2),
+        Constraint::Length(width),
+        Constraint::Length((parent.width - width) / 2),
+    ])
+    .split(new_area[1])[1]
 }
 
 pub fn draw_area_top_right_absolute(parent: Rect, width: u16, height: u16) -> Rect {
-    let new_area = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(height),
-            Constraint::Length(parent.height - height - 1),
-        ])
-        .split(parent);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Length(parent.width - width - 1),
-            Constraint::Length(width),
-            Constraint::Length(1),
-        ])
-        .split(new_area[1])[1]
+    let new_area = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(height),
+        Constraint::Length(parent.height - height - 1),
+    ])
+    .split(parent);
+    Layout::horizontal([
+        Constraint::Length(parent.width - width - 1),
+        Constraint::Length(width),
+        Constraint::Length(1),
+    ])
+    .split(new_area[1])[1]
 }
 
 #[cfg(test)]

--- a/tui/src/ui/utils.rs
+++ b/tui/src/ui/utils.rs
@@ -18,75 +18,57 @@ use tuirealm::ratatui::layout::{Constraint, Direction, Layout, Rect};
 pub fn draw_area_in_relative(parent: Rect, width: u16, height: u16) -> Rect {
     let new_area = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Percentage((100 - height) / 2),
-                Constraint::Percentage(height),
-                Constraint::Percentage((100 - height) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Percentage((100 - height) / 2),
+            Constraint::Percentage(height),
+            Constraint::Percentage((100 - height) / 2),
+        ])
         .split(parent);
     Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Percentage((100 - width) / 2),
-                Constraint::Percentage(width),
-                Constraint::Percentage((100 - width) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Percentage((100 - width) / 2),
+            Constraint::Percentage(width),
+            Constraint::Percentage((100 - width) / 2),
+        ])
         .split(new_area[1])[1]
 }
 
 pub fn draw_area_in_absolute(parent: Rect, width: u16, height: u16) -> Rect {
     let new_area = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Length((parent.height - height) / 2),
-                Constraint::Length(height),
-                Constraint::Length((parent.height - height) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length((parent.height - height) / 2),
+            Constraint::Length(height),
+            Constraint::Length((parent.height - height) / 2),
+        ])
         .split(parent);
     Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Length((parent.width - width) / 2),
-                Constraint::Length(width),
-                Constraint::Length((parent.width - width) / 2),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length((parent.width - width) / 2),
+            Constraint::Length(width),
+            Constraint::Length((parent.width - width) / 2),
+        ])
         .split(new_area[1])[1]
 }
 
 pub fn draw_area_top_right_absolute(parent: Rect, width: u16, height: u16) -> Rect {
     let new_area = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Length(1),
-                Constraint::Length(height),
-                Constraint::Length(parent.height - height - 1),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(height),
+            Constraint::Length(parent.height - height - 1),
+        ])
         .split(parent);
     Layout::default()
         .direction(Direction::Horizontal)
-        .constraints(
-            [
-                Constraint::Length(parent.width - width - 1),
-                Constraint::Length(width),
-                Constraint::Length(1),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Length(parent.width - width - 1),
+            Constraint::Length(width),
+            Constraint::Length(1),
+        ])
         .split(new_area[1])[1]
 }
 


### PR DESCRIPTION
This PR moves some things i had done in #511 to a separate PR to include it for the next version and to reduce the review size of #511. In more details what this includes:
- add album artist parsing to the track metadata as a option
- add split album artists and track artists to track metadata as a option
- refactor TUI `database` file to de-duplicate common code paths
- refactor some message types to use better types instead of casting everywhere (`DBMsg::SearchResult`, `PLMsg::Add`)
- refactor some `lib::utils` functions to directly take paths and reduce "if" guards
- make use of `indoc` to have consistent multi-line strings, without having those extra spaces in the compile
- limit vertical size of `DBListCriteria` to the number of table items (now it wont grow beyond that size and leave unused space)

UPDATE:
- reduce code size / deduplicate code by using built-in functions on `Layout`