### PR TITLE
Track Backend Errors and skip files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix(server): periodically save the playlist to disk, if modified. (Instead of only on exit)
 - Fix(server): on mpv backend, when seeking while paused, it now stays paused.
 - Fix(server): on mpv backend, skip to next track on error (Like "File Not Found").
+- Fix(server): on gst backend, skip to next track if the current one has a error (Like "File Not Found"). Note that this has a limitation about not working with enqueuement.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix(server): on mpv backend, fix possible race condition that could cause a panic by having `time-pos` event before `duration` event.
 - Fix(server): periodically save the playlist to disk, if modified. (Instead of only on exit)
 - Fix(server): on mpv backend, when seeking while paused, it now stays paused.
+- Fix(server): on mpv backend, skip to next track on error (Like "File Not Found").
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix(server): on mpv backend, when seeking while paused, it now stays paused.
 - Fix(server): on mpv backend, skip to next track on error (Like "File Not Found").
 - Fix(server): on gst backend, skip to next track if the current one has a error (Like "File Not Found"). Note that this has a limitation about not working with enqueuement.
+- Fix(server): on rusty backend, skip to next track on error (Like "File Not Found").
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Fix(server): on mpv backend, when seeking while paused, it now stays paused.
 - Fix(server): on mpv backend, skip to next track on error (Like "File Not Found").
 - Fix(server): on gst backend, skip to next track if the current one has a error (Like "File Not Found"). Note that this has a limitation about not working with enqueuement.
-- Fix(server): on rusty backend, skip to next track on error (Like "File Not Found").
+- Fix(server): on rusty backend, skip to next track on error (Like "File Not Found" or "Unknown Codec").
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
 
 ### [V0.10.0]

--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -150,7 +150,8 @@ impl MpvBackend {
                             // -17 = Unknown format
                             if matches!(raw_i32, -13 | -14 | -16 | -17) {
                                 // Note that mpv only errors for the current file and does not pre-evaluate / pre-emit errors for enqueuement
-                                let _ = cmd_tx.send(PlayerCmd::Error);
+                                let _ =
+                                    cmd_tx.send(PlayerCmd::Error(crate::PlayerErrorType::Current));
                             }
                         }
 

--- a/playback/src/backends/rusty/mod.rs
+++ b/playback/src/backends/rusty/mod.rs
@@ -610,6 +610,16 @@ async fn player_thread(mut args: PlayerThreadArgs) {
                 .await
                 {
                     error!("Failed to enqueue track: {err:#?}");
+
+                    if options.enqueue {
+                        let _ = args
+                            .pcmd_tx
+                            .send(PlayerCmd::Error(crate::PlayerErrorType::Enqueue));
+                    } else {
+                        let _ = args
+                            .pcmd_tx
+                            .send(PlayerCmd::Error(crate::PlayerErrorType::Current));
+                    }
                 }
             }
             PlayerInternalCmd::TogglePause => {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -94,6 +94,14 @@ impl PlayerCmdSender {
     }
 }
 
+#[derive(Clone, Debug, Copy, PartialEq)]
+pub enum PlayerErrorType {
+    /// The error happened for the currently playing track.
+    Current,
+    /// The error happened for the track that was tried to be enqueued.
+    Enqueue,
+}
+
 #[derive(Clone, Debug)]
 pub enum PlayerCmd {
     AboutToFinish,
@@ -120,7 +128,7 @@ pub enum PlayerCmd {
     /// This will basically be treated as a [`Eos`](PlayerCmd::Eos), with some extra handling.
     ///
     /// This should **not** be used if the whole backend is unrecoverable.
-    Error,
+    Error(PlayerErrorType),
 
     PlaylistPlaySpecific(PlaylistPlaySpecific),
     PlaylistAddTrack(PlaylistAddTrack),

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -116,6 +116,11 @@ pub enum PlayerCmd {
     TogglePause,
     VolumeDown,
     VolumeUp,
+    /// A Error happened in the backend (for example `NotFound`) that makes it unrecoverable to continue to play the current track.
+    /// This will basically be treated as a [`Eos`](PlayerCmd::Eos), with some extra handling.
+    ///
+    /// This should **not** be used if the whole backend is unrecoverable.
+    Error,
 
     PlaylistPlaySpecific(PlaylistPlaySpecific),
     PlaylistAddTrack(PlaylistAddTrack),
@@ -141,6 +146,9 @@ pub struct GeneralPlayer {
     pub db_podcast: DBPod,
     pub cmd_tx: PlayerCmdSender,
     pub stream_tx: StreamTX,
+
+    /// Keep track of continues backend errors (like `NotFound`) to not keep trying infinitely.
+    pub errors_since_last_progress: usize,
 }
 
 impl GeneralPlayer {
@@ -189,7 +197,19 @@ impl GeneralPlayer {
             cmd_tx,
             stream_tx,
             current_track_updated: false,
+
+            errors_since_last_progress: 0,
         })
+    }
+
+    /// Increment the errors that happened by one.
+    pub fn increment_errors(&mut self) {
+        self.errors_since_last_progress += 1;
+    }
+
+    /// Reset errors that happened back to 0
+    pub fn reset_errors(&mut self) {
+        self.errors_since_last_progress = 0;
     }
 
     /// Create a new [`GeneralPlayer`], with the default Backend ([`BackendSelect::Rusty`])

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -3,6 +3,7 @@ mod logger;
 mod music_player_service;
 
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,6 +38,10 @@ extern crate log;
 pub const MAX_DEPTH: usize = 4;
 pub const VOLUME_STEP: VolumeSigned = 5;
 pub const SPEED_STEP: SpeedSigned = 1;
+
+/// The Limit of continues errors before stopping playback and awaiting user input to start something specific again.
+// SAFETY: using "unsafe" here as "const unwrap" is MSRV 1.83, we are currently on 1.82
+const BACKEND_ERROR_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(5) };
 
 /// Stats for the music player responses
 #[derive(Debug, Clone, PartialEq)]
@@ -385,6 +390,7 @@ fn player_loop(
     playlist: SharedPlaylist,
 ) -> Result<()> {
     let mut player = GeneralPlayer::new_backend(backend, config, cmd_tx, stream_tx, playlist)?;
+
     while let Some((cmd, cb)) = cmd_rx.blocking_recv() {
         #[allow(unreachable_patterns)]
         match cmd {
@@ -423,26 +429,16 @@ fn player_loop(
             }
             PlayerCmd::Eos => {
                 info!("Eos received");
-                let mut playlist = player.playlist.write();
-                if playlist.is_empty() {
-                    drop(playlist);
-                    player.stop();
-                    continue;
-                }
-                debug!(
-                    "current track index: {:?}",
-                    playlist.get_current_track_index()
-                );
-                playlist.clear_current_track();
-                drop(playlist);
-                player.start_play();
-                debug!(
-                    "playing index is: {}",
-                    player.playlist.read().get_current_track_index()
-                );
+                player_eos(&mut player);
+            }
+            PlayerCmd::Error => {
+                info!("Error received");
+                player.increment_errors();
+                player_eos(&mut player);
             }
             PlayerCmd::GetProgress => {}
             PlayerCmd::SkipPrevious => {
+                player.reset_errors();
                 info!("skip to previous track");
                 player.player_save_last_position();
                 player.previous();
@@ -470,6 +466,7 @@ fn player_loop(
                 }
             }
             PlayerCmd::SkipNext => {
+                player.reset_errors();
                 info!("skip to next track.");
                 player.player_save_last_position();
                 player.next();
@@ -513,11 +510,22 @@ fn player_loop(
                     continue;
                 }
                 if let Some(progress) = player.get_progress() {
+                    let pl_status = playlist.status();
                     p_tick.progress = progress;
+
                     // the following function is "mut", which does not like having the immutable borrow to "playlist"
                     // so we have to unlock first then later re-acquire the handle for later parts
                     drop(playlist);
                     player.mpris_update_progress(&p_tick.progress);
+
+                    // only reset errors if position is either above 0 or total duration is available and is above 0
+                    if pl_status == RunningStatus::Running
+                        && (progress.total_duration.is_some_and(|v| v > Duration::ZERO)
+                            || progress.position.is_some_and(|v| v > Duration::ZERO))
+                    {
+                        player.reset_errors();
+                    }
+
                     playlist = player.playlist.read();
                 }
                 if player.current_track_updated {
@@ -592,6 +600,7 @@ fn player_loop(
             }
 
             PlayerCmd::PlaylistPlaySpecific(info) => {
+                player.reset_errors();
                 info!(
                     "play specific track, idx: {} id: {:#?}",
                     info.track_index, info.id
@@ -613,6 +622,7 @@ fn player_loop(
                 }
             }
             PlayerCmd::PlaylistClear => {
+                player.reset_errors();
                 player.playlist.write().clear();
             }
             PlayerCmd::PlaylistSwapTrack(info) => {
@@ -632,6 +642,37 @@ fn player_loop(
     }
 
     Ok(())
+}
+
+/// Common [`PlayerCmd::Eos`] handler.
+fn player_eos(player: &mut GeneralPlayer) {
+    let mut playlist = player.playlist.write();
+    if playlist.is_empty() {
+        drop(playlist);
+        player.stop();
+        return;
+    }
+    if player.errors_since_last_progress >= BACKEND_ERROR_LIMIT.get() {
+        error!(
+            "Stopping playback because too many errors happened in succession; Limit: {}",
+            BACKEND_ERROR_LIMIT.get()
+        );
+        drop(playlist);
+        // this path should also call stop, but currently stop on a non-empty playlist basically resets playback on tick
+        // player.stop();
+        return;
+    }
+    debug!(
+        "current track index: {:?}",
+        playlist.get_current_track_index()
+    );
+    playlist.clear_current_track();
+    drop(playlist);
+    player.start_play();
+    debug!(
+        "playing index is: {}",
+        player.playlist.read().get_current_track_index()
+    );
 }
 
 /// Spawn the thread that periodically sends [`PlayerCmd::Tick`]


### PR DESCRIPTION
This PR tries to add a mechanism to track errors in the backend (file not found, unknown codec) and then skips those files.
This works properly on mpv and rusty, but i could not figure out a good way to make it work on gstreamer with enqueuement (currently it only works if it is a error via non-enqueuement), for the reasons why, read the big comment in `gstreamer/mod.rs`.

When a Error event is recieved, the corresponding track will be skipped. If there are 5 continues error-ing tracks, then playback is stopped (similar to as before this PR) to not try infinitely or having to implement a costly "what tracks have already been visited and did the playlist change since?" thingy.

fixes #519

@tramhao Before merging, could you try this and report if you find any errors related to this PR?