### PR TITLE
Workaround flexi logger file issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix(server): periodically save the playlist to disk, if modified. (Instead of only on exit)
 - Fix(server): on mpv backend, when seeking while paused, it now stays paused.
 - Fix: dont consider non-path Urls (podcasts, radio) for removal after a delete.
+- Fix: allow `--log-file` arguments that dont have a directory component without error.
 
 ### [V0.10.0]
 - Released on: March 8, 2025.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd71620581c99445892ad71e2c2e0d6f62edf2e22822556f0d2ee9f8508af29"
+checksum = "ab9765cc4ba26211f932a7a37649ec88752f7abcbd8822617572562ce31234df"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ libmpv-sirno = "2.0.2-fork.1"
 # lofty 0.22.3 updates to MSRV 1.85
 lofty = "0.22.2"
 log = "0.4.27"
-flexi_logger = "0.30.1"
+flexi_logger = "0.31.0"
 colored = "3.0"
 md5 = "0.7"
 num-bigint = "0.4"

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -1,6 +1,6 @@
 //! Module for all Logger related things
 
-use std::backtrace::Backtrace;
+use std::{backtrace::Backtrace, path::PathBuf};
 
 use colored::{Color, Colorize};
 use flexi_logger::{style, DeferredNow, FileSpec, Logger, LoggerHandle, Record};
@@ -28,8 +28,23 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 logger = logger.format_for_files(log_format);
             }
 
-            let filespec = FileSpec::try_from(&args.log_options.log_file)
-                .expect("Expected logging file to be parsed correctly");
+            // workaround for https://github.com/emabee/flexi_logger/issues/194
+            let path = if args
+                .log_options
+                .log_file
+                .parent()
+                .is_some_and(|v| !v.to_string_lossy().is_empty())
+            {
+                args.log_options.log_file.clone()
+            } else {
+                let mut path = PathBuf::from(".");
+                path.push(&args.log_options.log_file);
+
+                path
+            };
+
+            let filespec =
+                FileSpec::try_from(&path).expect("Expected logging file to be parsed correctly");
             logger = logger
                 .log_to_file(filespec)
                 .append()

--- a/tui/src/logger.rs
+++ b/tui/src/logger.rs
@@ -1,6 +1,6 @@
 //! Module for all Logger related things
 
-use std::backtrace::Backtrace;
+use std::{backtrace::Backtrace, path::PathBuf};
 
 use colored::{Color, Colorize};
 use flexi_logger::{style, DeferredNow, FileSpec, Logger, LoggerHandle, Record};
@@ -28,8 +28,24 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 logger = logger.format_for_files(log_format);
             }
 
-            let filespec = FileSpec::try_from(&args.log_options.log_file)
-                .expect("Expected logging file to be parsed correctly");
+            // workaround for https://github.com/emabee/flexi_logger/issues/194
+            let path = if args
+                .log_options
+                .log_file
+                .parent()
+                .is_some_and(|v| !v.to_string_lossy().is_empty())
+            {
+                eprintln!("what {:#?}", args.log_options.log_file.parent());
+                args.log_options.log_file.clone()
+            } else {
+                let mut path = PathBuf::from(".");
+                path.push(&args.log_options.log_file);
+
+                path
+            };
+
+            let filespec =
+                FileSpec::try_from(&path).expect("Expected logging file to be parsed correctly");
             logger = logger
                 .log_to_file(filespec)
                 .append()


### PR DESCRIPTION
This PR adds a workaround for the https://github.com/emabee/flexi_logger/issues/194 issue as first noticed in #508.
Also updates `flexi_logger` to the latest version.