### PR TITLE
style: fix clippy 1.88 warnings

### DIFF
--- a/playback/src/backends/rusty/mod.rs
+++ b/playback/src/backends/rusty/mod.rs
@@ -447,10 +447,7 @@ fn append_to_sink<MT: Fn(MediaTitleType) + Send + 'static, TD: Display>(
         |decoder, media_title_rx| {
             // ensured to always exist if `specific_options.media_title = true`
             let mut media_title_rx = media_title_rx.unwrap();
-            std::mem::swap(
-                &mut *total_duration_local.lock(),
-                &mut decoder.total_duration(),
-            );
+            *total_duration_local.lock() = decoder.total_duration();
 
             let handle = Handle::current();
 
@@ -509,7 +506,7 @@ fn append_to_sink_queue<MT: Fn(MediaTitleType) + Send + 'static, TD: Display>(
             // ensured to always exist if `specific_options.media_title = true`
             let mut media_title_rx = media_title_rx.unwrap();
 
-            std::mem::swap(next_duration_opt, &mut decoder.total_duration());
+            *next_duration_opt = decoder.total_duration();
 
             let handle = Handle::current();
 

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -55,7 +55,7 @@ pub fn setup(args: &Args) -> LoggerHandle {
     std::panic::set_hook(Box::new(move |panic| {
         // this works because rust will execute the panic hook before unwinding
         let backtrace = Backtrace::capture();
-        error!("Panic occured:\n{}\n{}", panic, backtrace);
+        error!("Panic occured:\n{panic}\n{backtrace}");
         original_hook(panic);
     }));
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -89,7 +89,7 @@ impl PlayerStats {
 fn main() -> Result<()> {
     // print error to the log and then throw it
     if let Err(err) = actual_main() {
-        error!("Error: {:?}", err);
+        error!("Error: {err:?}");
         return Err(err);
     }
 
@@ -276,7 +276,7 @@ async fn tcp_stream(config: &SharedServerSettings) -> Result<(TcpIncoming, Socke
     // see https://github.com/hyperium/tonic/issues/351
     let tcp_listener = tokio::net::TcpListener::bind(addr)
         .await
-        .with_context(|| format!("Error binding address: {}", addr))?;
+        .with_context(|| format!("Error binding address: {addr}"))?;
 
     // workaround as "TcpIncoming" does not provide a function to get the address
     let socket_addr = tcp_listener.local_addr()?;
@@ -449,7 +449,7 @@ fn player_loop(
             }
             PlayerCmd::ReloadConfig => {
                 if let Err(err) = player.reload_config() {
-                    error!("Reloading config failed, using old: {:#?}", err);
+                    error!("Reloading config failed, using old: {err:#?}");
                 }
             }
             PlayerCmd::ReloadPlaylist => {
@@ -476,7 +476,7 @@ fn player_loop(
             }
             PlayerCmd::SpeedDown => {
                 let new_speed = player.add_speed(-SPEED_STEP);
-                info!("after speed down: {}", new_speed);
+                info!("after speed down: {new_speed}");
                 player.config.write().settings.player.speed = new_speed;
                 let mut p_tick = playerstats.lock();
                 p_tick.speed = new_speed;
@@ -484,7 +484,7 @@ fn player_loop(
 
             PlayerCmd::SpeedUp => {
                 let new_speed = player.add_speed(SPEED_STEP);
-                info!("after speed up: {}", new_speed);
+                info!("after speed up: {new_speed}");
                 player.config.write().settings.player.speed = new_speed;
                 let mut p_tick = playerstats.lock();
                 p_tick.speed = new_speed;
@@ -570,7 +570,7 @@ fn player_loop(
                 info!("before volumedown: {}", player.volume());
                 let new_volume = player.add_volume(-VOLUME_STEP);
                 player.config.write().settings.player.volume = new_volume;
-                info!("after volumedown: {}", new_volume);
+                info!("after volumedown: {new_volume}");
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
                 player.mpris_volume_update();
@@ -579,7 +579,7 @@ fn player_loop(
                 info!("before volumeup: {}", player.volume());
                 let new_volume = player.add_volume(VOLUME_STEP);
                 player.config.write().settings.player.volume = new_volume;
-                info!("after volumeup: {}", new_volume);
+                info!("after volumeup: {new_volume}");
                 let mut p_tick = playerstats.lock();
                 p_tick.volume = new_volume;
                 player.mpris_volume_update();


### PR DESCRIPTION
This PR fixes the new clippy warnings added with rust 1.88 now being released.