### PR TITLE
Fix accidental inclusion of debug prints & revert flexi_logger workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9765cc4ba26211f932a7a37649ec88752f7abcbd8822617572562ce31234df"
+checksum = "759bfa52db036a2db54f0b5f0ff164efa249b3014720459c5ea4198380c529bc"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ libmpv-sirno = "2.0.2-fork.1"
 # lofty 0.22.3 updates to MSRV 1.85
 lofty = "0.22.2"
 log = "0.4.27"
-flexi_logger = "0.31.0"
+flexi_logger = "0.31.2"
 colored = "3.0"
 md5 = "0.7"
 num-bigint = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![crates.io](https://img.shields.io/crates/v/termusic.svg)](https://crates.io/crates/termusic)
 [![dependency status](https://deps.rs/repo/github/tramhao/termusic/status.svg)](https://deps.rs/repo/github/tramhao/termusic)
 [![MSRV](https://img.shields.io/badge/MSRV-1.82.0-blue)](https://blog.rust-lang.org/2023/12/28/Rust-1.82.0.html)
-# Terminal Music and Podcast Player written in Rust
 
 Listen to music and podcasts freely as both in freedom and free of charge!
 

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -1,6 +1,6 @@
 //! Module for all Logger related things
 
-use std::{backtrace::Backtrace, path::PathBuf};
+use std::backtrace::Backtrace;
 
 use colored::{Color, Colorize};
 use flexi_logger::{style, DeferredNow, FileSpec, Logger, LoggerHandle, Record};
@@ -28,23 +28,8 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 logger = logger.format_for_files(log_format);
             }
 
-            // workaround for https://github.com/emabee/flexi_logger/issues/194
-            let path = if args
-                .log_options
-                .log_file
-                .parent()
-                .is_some_and(|v| !v.to_string_lossy().is_empty())
-            {
-                args.log_options.log_file.clone()
-            } else {
-                let mut path = PathBuf::from(".");
-                path.push(&args.log_options.log_file);
-
-                path
-            };
-
-            let filespec =
-                FileSpec::try_from(&path).expect("Expected logging file to be parsed correctly");
+            let filespec = FileSpec::try_from(&args.log_options.log_file)
+                .expect("Expected logging file to be parsed correctly");
             logger = logger
                 .log_to_file(filespec)
                 .append()

--- a/tui/src/logger.rs
+++ b/tui/src/logger.rs
@@ -1,6 +1,6 @@
 //! Module for all Logger related things
 
-use std::{backtrace::Backtrace, path::PathBuf};
+use std::backtrace::Backtrace;
 
 use colored::{Color, Colorize};
 use flexi_logger::{style, DeferredNow, FileSpec, Logger, LoggerHandle, Record};
@@ -28,23 +28,8 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 logger = logger.format_for_files(log_format);
             }
 
-            // workaround for https://github.com/emabee/flexi_logger/issues/194
-            let path = if args
-                .log_options
-                .log_file
-                .parent()
-                .is_some_and(|v| !v.to_string_lossy().is_empty())
-            {
-                args.log_options.log_file.clone()
-            } else {
-                let mut path = PathBuf::from(".");
-                path.push(&args.log_options.log_file);
-
-                path
-            };
-
-            let filespec =
-                FileSpec::try_from(&path).expect("Expected logging file to be parsed correctly");
+            let filespec = FileSpec::try_from(&args.log_options.log_file)
+                .expect("Expected logging file to be parsed correctly");
             logger = logger
                 .log_to_file(filespec)
                 .append()

--- a/tui/src/logger.rs
+++ b/tui/src/logger.rs
@@ -35,7 +35,6 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 .parent()
                 .is_some_and(|v| !v.to_string_lossy().is_empty())
             {
-                eprintln!("what {:#?}", args.log_options.log_file.parent());
                 args.log_options.log_file.clone()
             } else {
                 let mut path = PathBuf::from(".");


### PR DESCRIPTION
This PR upgrades to `flexi_logger` `0.31.2` and reverts the flexi-logger workaround added in #521 due to flexi_logger handling this case properly now.
This also removes a accidental inclusion of a left-over debug print.

I think after this PR a new version is definitely ready (#517).