### PR TITLE
fix(playback::mpris): set mpris volume on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog
 
+### next
+- Unreleased
+- Fix(server): on linux+mpris, set volume on start instead of only on change.
+
 ### [V0.11.0]
 - Released on: July 1, 2025.
 - Change: updated MSRV to 1.82.

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -182,7 +182,13 @@ impl GeneralPlayer {
         let db = DataBase::new(&config_read)?;
 
         let mpris = if config.read().settings.player.use_mediacontrols {
-            Some(mpris::Mpris::new(cmd_tx.clone()))
+            let mut mpris = mpris::Mpris::new(cmd_tx.clone());
+
+            // set volume on start, as souvlaki (0.8.2) defaults to 1.0 until set by us
+            // also otherwise we only set this once the volume actually changes or mpris is re-started via config reload
+            mpris.update_volume(backend.as_player().volume());
+
+            Some(mpris)
         } else {
             None
         };


### PR DESCRIPTION
Before we only set the volume on volume change and when the config gets re-loaded and souvlaki defaults to `1.0` volume.

fixes #528