### PR TITLE
fix(tui): increase connect timeout and add message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## ChangeLog
 
+### next
+- Unreleased
+- Change(tui): increase connection timeout from 5s to 30s, but print a message on original time.
+
 ### [V0.11.0]
 - Released on: July 1, 2025.
 - Change: updated MSRV to 1.82.


### PR DESCRIPTION
This changes the connection timeout from 5 seconds to 30 seconds, but print a message on 5 seconds (regardless if connecting is somehow blocking) that it is taking longer than expected.