### PR TITLE
Send Progress updates as stream events

### DIFF
--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -89,7 +89,7 @@ message Duration {
 }
 
 // all updates that can happen from the server side, without the client to have to ask explicitly
-// naming convention for the stream update specific messages is to add the "Update" prefix, even if it already exists
+// naming convention for the stream update specific messages is to add the "Update" prefix, even if a similar non-prefix message already exists
 message StreamUpdates {
   oneof type {
     UpdateMissedEvents missed_events = 1;
@@ -98,8 +98,8 @@ message StreamUpdates {
     UpdatePlayStateChanged play_state_changed = 4;
     UpdateTrackChanged track_changed = 5;
     UpdateGaplessChanged gapless_changed = 6;
-
     UpdatePlaylist playlist_changed = 7;
+    UpdateProgress progress_changed = 8;
   }
 }
 
@@ -153,6 +153,11 @@ message UpdateTrackChanged {
     string title = 3;
   }
   PlayerTime progress = 4;
+}
+
+// There is a progress update to the currently playing track, may not be fired if paused or stopped
+message UpdateProgress {
+  PlayerTime progress = 1;
 }
 
 // Play a specific track in the playlist

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -64,8 +64,6 @@ message GetProgressResponse {
   uint32 volume = 5;
   int32 speed = 6;
   bool gapless = 7;
-  // TODO: this is not necessary anymore, because of "UpdateTrackChanged"
-  bool current_track_updated = 8;
   string radio_title = 9;
 }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -611,10 +611,6 @@ impl PlayerTrait for GeneralPlayer {
         if let Some(ref discord) = self.discord {
             discord.pause();
         }
-
-        self.send_stream_ev(UpdateEvents::PlayStateChanged {
-            playing: RunningStatus::Paused.as_u32(),
-        });
     }
     /// This function should not be used directly, use GeneralPlayer::play
     fn resume(&mut self) {
@@ -627,10 +623,6 @@ impl PlayerTrait for GeneralPlayer {
         if let Some(ref discord) = self.discord {
             discord.resume(time_pos);
         }
-
-        self.send_stream_ev(UpdateEvents::PlayStateChanged {
-            playing: RunningStatus::Running.as_u32(),
-        });
     }
     fn is_paused(&self) -> bool {
         self.get_player().is_paused()

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -576,7 +576,7 @@ impl GeneralPlayer {
     pub fn update_progress(&mut self, progress: &PlayerProgress) {
         self.mpris_update_progress(progress);
 
-        self.send_stream_ev(UpdateEvents::Progress(*progress));
+        self.send_stream_ev_no_err(UpdateEvents::Progress(*progress));
     }
 
     /// Send stream events with consistent error handling
@@ -585,6 +585,13 @@ impl GeneralPlayer {
         if self.stream_tx.send(ev).is_err() {
             debug!("Stream Event not send: No Receivers");
         }
+    }
+
+    /// Send stream events with no error handling.
+    ///
+    /// Useful for events which would otherwise spam the logs but we dont care about (like progress updates).
+    fn send_stream_ev_no_err(&self, ev: UpdateEvents) {
+        let _ = self.stream_tx.send(ev);
     }
 }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -572,6 +572,13 @@ impl GeneralPlayer {
         }
     }
 
+    /// Update all the places that should be updated on a new Progress report.
+    pub fn update_progress(&mut self, progress: &PlayerProgress) {
+        self.mpris_update_progress(progress);
+
+        self.send_stream_ev(UpdateEvents::Progress(*progress));
+    }
+
     /// Send stream events with consistent error handling
     fn send_stream_ev(&self, ev: UpdateEvents) {
         // there is only one error case: no receivers

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -34,7 +34,14 @@ impl MusicPlayerService {
         config: SharedServerSettings,
         playlist: SharedPlaylist,
     ) -> Self {
-        let player_stats = Arc::new(Mutex::new(PlayerStats::new()));
+        let mut player_stats = PlayerStats::new();
+        let config_read = config.read();
+        player_stats.volume = config_read.settings.player.volume;
+        player_stats.gapless = config_read.settings.player.gapless;
+        player_stats.speed = config_read.settings.player.speed;
+        drop(config_read);
+
+        let player_stats = Arc::new(Mutex::new(player_stats));
 
         Self {
             cmd_tx,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -518,7 +518,7 @@ fn player_loop(
                     // the following function is "mut", which does not like having the immutable borrow to "playlist"
                     // so we have to unlock first then later re-acquire the handle for later parts
                     drop(playlist);
-                    player.mpris_update_progress(&p_tick.progress);
+                    player.update_progress(&p_tick.progress);
 
                     // only reset errors if position is either above 0 or total duration is available and is above 0
                     if pl_status == RunningStatus::Running

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -47,11 +47,9 @@ const BACKEND_ERROR_LIMIT: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 struct PlayerStats {
     pub progress: PlayerProgress,
     pub current_track_index: u64,
-    pub status: u32,
     pub volume: u16,
     pub speed: i32,
     pub gapless: bool,
-    pub current_track_updated: bool,
     pub radio_title: String,
 }
 
@@ -63,24 +61,21 @@ impl PlayerStats {
                 total_duration: None,
             },
             current_track_index: 0,
-            status: 1,
             volume: 0,
             speed: 10,
             gapless: true,
-            current_track_updated: false,
             radio_title: String::new(),
         }
     }
 
-    pub fn as_getprogress_response(&self) -> GetProgressResponse {
+    pub fn as_getprogress_response(&self, status: RunningStatus) -> GetProgressResponse {
         GetProgressResponse {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
-            status: self.status,
+            status: status.as_u32(),
             volume: u32::from(self.volume),
             speed: self.speed,
             gapless: self.gapless,
-            current_track_updated: self.current_track_updated,
             radio_title: self.radio_title.clone(),
         }
     }
@@ -499,7 +494,6 @@ fn player_loop(
                 player.mpris_handle_events();
                 let mut p_tick = playerstats.lock();
                 let mut playlist = player.playlist.read();
-                p_tick.status = playlist.status().as_u32();
                 // branch to auto-start playing if status is "stopped"(not paused) and playlist is not empty anymore
                 if playlist.status() == RunningStatus::Stopped {
                     if playlist.is_empty() {
@@ -539,7 +533,6 @@ fn player_loop(
                 if player.current_track_updated {
                     p_tick.current_track_index =
                         u64::try_from(playlist.get_current_track_index()).unwrap();
-                    p_tick.current_track_updated = player.current_track_updated;
                     player.current_track_updated = false;
                 }
                 if let Some(track) = playlist.current_track() {
@@ -579,8 +572,6 @@ fn player_loop(
             PlayerCmd::TogglePause => {
                 info!("player toggled pause");
                 player.toggle_pause();
-                let mut p_tick = playerstats.lock();
-                p_tick.status = player.playlist.read().status().as_u32();
             }
             PlayerCmd::VolumeDown => {
                 info!("before volumedown: {}", player.volume());

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::Path;
+use std::time::Duration;
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use rand::seq::IndexedRandom;
@@ -530,6 +531,7 @@ impl Model {
         }
 
         self.update_layout_for_current_track();
+        self.playback.set_current_track_pos(Duration::ZERO);
         self.player_update_current_track_after();
 
         self.lyric_update_for_podcast_by_current_track();

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -226,12 +226,6 @@ impl UI {
                         pprogress.position,
                         pprogress.total_duration.unwrap_or_default(),
                     );
-                    if response.current_track_updated {
-                        self.model.handle_current_track_index(
-                            usize::try_from(response.current_track_index).unwrap(),
-                            false,
-                        );
-                    }
 
                     self.model.lyric_update_for_radio(response.radio_title);
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -92,7 +92,7 @@ impl UI {
                 self.model.mount_error_popup(err);
             }
             if progress_interval == 0 {
-                self.model.run();
+                self.model.request_progress();
             }
             self.run_playback().await?;
             progress_interval += 1;

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -199,7 +199,9 @@ impl UI {
                     self.model.player_update_current_track_after();
                 }
             }
-            RunningStatus::Paused => {}
+            RunningStatus::Paused => {
+                self.model.player_update_current_track_after();
+            }
         }
     }
 

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -556,10 +556,9 @@ impl Model {
     }
 
     /// Send a command to request the Track Progress and set the titles to the current state.
-    pub fn run(&mut self) {
+    #[inline]
+    pub fn request_progress(&mut self) {
         self.command(TuiCmd::GetProgress);
-        self.progress_update_title();
-        self.lyric_update_title();
     }
 
     pub fn player_update_current_track_after(&mut self) {

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -561,8 +561,8 @@ impl Model {
         self.command(TuiCmd::GetProgress);
     }
 
+    /// Update all the places that need to be updated after a current track change or running status change.
     pub fn player_update_current_track_after(&mut self) {
-        self.playback.set_current_track_pos(Duration::ZERO);
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -42,7 +42,7 @@ impl Playback {
         let request = tonic::Request::new(Empty {});
         let response = self.client.get_progress(request).await?;
         let response = response.into_inner();
-        // info!("Got response from server: {:?}", response);
+        info!("Got response from server: {response:?}");
         Ok(response)
     }
 


### PR DESCRIPTION
This PR quite some little things, with the main point being that Progress updates are send as a stream event now (push) instead of fetched from the server (pull).

Additional changes:
- dont run progress & lyric title update functions when not necessary
- properly reflect "Paused" status when the tui is reconnecting to a existing server
- only send `UpdateEvents::PlayStateChanged` events from one single place, otherwise it leads to being forgotten to be send (like previously in `GeneralPlayer::start_play` switching from `Stopped`)
- dont keep "RunningStatus" in `PlayerStats`, instead fetch directly from playlist; avoids de-syncs of those values
- properly initialize `PlayerStats` starting values from config (previously some would only get set on change)
- move "server quit / kill" code to own function