### PR TITLE
feat(playback::backends::rusty): allow configuring output sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Feat(tui): make the Config editor dynamically size elements.
 - Feat(tui): make the Config editor (at least rudementally) scrollable.
 - Feat(server): add extra config section for metadata scanning and parsing.
+- Feat(server): on rusty backend, allow configuring output sample rate, now defaulting to 48_000Hz (instead of rodio default 44_100Hz).
 - Feat: re-implement the Track database to allow for more search options. (Note that the old database is NOT automatically deleted)
 - Fix(tui): allow usage of key `Home`/`Pos1` in search lists.
 - Fix(tui): allow usage of key `Home`/`Pos1` and `End` in youtube search list.

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -44,6 +44,11 @@ pub struct RustyBackendSettings {
     ///
     /// If the given value is less than the default, the default will be used instead.
     pub decoded_buffer_size: ByteSize,
+    /// Set the preferred output sample rate.
+    ///
+    /// Default `48_000`
+    /// Recommeded Values: `44_100`, `48_000`, `96_000` `192_000`.
+    pub output_sample_rate: u32,
 }
 
 impl Default for RustyBackendSettings {
@@ -52,6 +57,7 @@ impl Default for RustyBackendSettings {
             soundtouch: true,
             file_buffer_size: ByteSize::b(FILEBUF_SIZE_DEFAULT),
             decoded_buffer_size: ByteSize::b(DECODEDBUF_SIZE_DEFAULT),
+            output_sample_rate: 48_000,
         }
     }
 }


### PR DESCRIPTION
Add a new config option under `backends.rusty` to configure the preferred output sample rate.
Now the default output sample rate is set to 48kHz, instead of rodio's previous 44.1kHz.

Note that this is only "preferred" as we will fall-back to other outputs if needed.
Finally, note that there are no limits set for the new config option, but documenting some common sample rates that should be used.