### PR TITLE
fix(playback::backends::mpv): allow configuring audio-device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 - Feat(tui): make the Config editor (at least rudementally) scrollable.
 - Feat(server): add extra config section for metadata scanning and parsing.
 - Feat(server): on rusty backend, allow configuring output sample rate, now defaulting to 48_000Hz (instead of rodio default 44_100Hz).
+- Feat(server): on mpv backend, add option to configure `audio-device` property.
 - Feat: re-implement the Track database to allow for more search options. (Note that the old database is NOT automatically deleted)
 - Fix(tui): allow usage of key `Home`/`Pos1` in search lists.
 - Fix(tui): allow usage of key `Home`/`Pos1` and `End` in youtube search list.
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
+- Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.
 - Fix: due to the Track database re-implementation, a bug where the database could grow with duplicated paths is fixed.
 
 ### [V0.11.0]

--- a/lib/src/config/v2/server/backends.rs
+++ b/lib/src/config/v2/server/backends.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct BackendSettings {
     pub rusty: RustyBackendSettings,
-    #[serde(skip)] // skip as long as there are no values
     pub mpv: MpvBackendSettings,
     #[serde(skip)] // skip as long as there are no values
     pub gst: GstBackendSettings,
@@ -63,10 +62,23 @@ impl Default for RustyBackendSettings {
 }
 
 /// Settings specific to the `mpv` backend
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)] // allow missing fields and fill them with the `..Self::default()` in this struct
 pub struct MpvBackendSettings {
-    // None for now
+    /// Select the audio device mpv should be using, analog to mpv's `--audio-device=` option.
+    ///
+    /// See all available options for mpv by running `mpv --audio-device=help`
+    ///
+    /// Default: `auto`
+    pub audio_device: String,
+}
+
+impl Default for MpvBackendSettings {
+    fn default() -> Self {
+        Self {
+            audio_device: "auto".to_string(),
+        }
+    }
 }
 
 /// Settings specific to the `gst` backend

--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -62,9 +62,11 @@ impl MpvBackend {
         mpv.set_property("vo", "null")
             .expect("Couldn't set vo=null in libmpv");
 
-        #[cfg(target_os = "linux")]
-        mpv.set_property("ao", "pulse")
-            .expect("Couldn't set ao=pulse in libmpv");
+        mpv.set_property(
+            "audio-device",
+            config.settings.backends.mpv.audio_device.as_str(),
+        )
+        .expect("Couldnt set \"audio-device\" property");
 
         mpv.set_property("volume", i64::from(volume))
             .expect("Error setting volume");


### PR DESCRIPTION
and dont force "ao=pulse" in linux.

This PR is DRAFT until @foxyseta could try it.

re #452