### PR TITLE
perf: enable "parking_lot" feature for tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,6 +5123,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ symphonia = { version = "0.5.1", features = [
 rodio = { version = "0.21", default-features = false, features = ["playback"]}
 sysinfo = { version = "^0.35", default-features = false, features = ["system"] }
 textwrap = "0.16.2"
-tokio = { version = "1.45", features = ["sync", "macros", "rt","rt-multi-thread"] }
+tokio = { version = "1.45", features = ["sync", "macros", "rt", "rt-multi-thread", "parking_lot"] }
 tokio-util = "0.7.15"
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 toml = "0.8.22"


### PR DESCRIPTION
This does not improve much, but `parking_lot` *is* known to use less bytes and be slightly faster than std, we also use it directly, so why not enable it for tokio as well?