### PR TITLE
Some lyric related changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Feat: re-implement the Track database to allow for more search options. (Note that the old database is NOT automatically deleted)
 - Fix(tui): allow usage of key `Home`/`Pos1` in search lists.
 - Fix(tui): allow usage of key `Home`/`Pos1` and `End` in youtube search list.
+- Fix(tui): when in podcast layout, always show the currently selected episode's description (instead of only when moving to it).
+- Fix(tui): properly reset lyric text once leaving podcast layout.
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -103,6 +103,9 @@ impl Model {
         self.force_redraw();
     }
 
+    /// Handle progress updates.
+    ///
+    /// Updates all places where progress updates need to be populated to.
     // TODO: refactor to have "total_duration" optional
     #[allow(clippy::cast_precision_loss, clippy::cast_possible_wrap)]
     pub fn progress_update(&mut self, time_pos: Option<Duration>, total_duration: Duration) {
@@ -125,6 +128,7 @@ impl Model {
         let new_prog = Self::progress_safeguard(progress);
 
         self.progress_set(new_prog, total_duration);
+        self.lyric_update();
     }
 
     fn progress_safeguard(progress: f64) -> f64 {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -9,7 +9,7 @@ pub mod utils;
 use anyhow::Context;
 use anyhow::Result;
 use futures_util::FutureExt;
-use model::{Model, TermusicLayout};
+use model::Model;
 use music_player_client::Playback;
 use std::time::Duration;
 use sysinfo::Pid;
@@ -88,9 +88,6 @@ impl UI {
         // Main loop
         while !self.model.quit {
             self.model.update_outside_msg();
-            if self.model.layout != TermusicLayout::Podcast {
-                self.model.lyric_update();
-            }
             if let Err(err) = self.handle_stream_events(&mut stream_updates) {
                 self.model.mount_error_popup(err);
             }

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -569,6 +569,7 @@ impl Model {
         }
         self.progress_update_title();
         self.lyric_update_title();
+        self.lyric_update();
         self.update_playing_song();
     }
 

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -500,6 +500,8 @@ impl Model {
 
                 self.layout = TermusicLayout::DataBase;
                 self.playlist_switch_layout();
+                self.lyric_update_title();
+                self.lyric_update();
             }
             MainLayoutMsg::TreeView => {
                 let mut need_to_set_focus = true;
@@ -521,6 +523,8 @@ impl Model {
 
                 self.layout = TermusicLayout::TreeView;
                 self.playlist_switch_layout();
+                self.lyric_update_title();
+                self.lyric_update();
             }
             MainLayoutMsg::Podcast => {
                 let mut need_to_set_focus = true;
@@ -554,6 +558,8 @@ impl Model {
                 self.layout = TermusicLayout::Podcast;
                 self.podcast_sync_feeds_and_episodes();
                 self.playlist_switch_layout();
+                self.lyric_update_title();
+                self.lyric_update();
             }
         }
 


### PR DESCRIPTION
This PR fixes:
- that switching TO podcast layout did not change the lyric's title (even when going to select a episode)
- that switching TO podcast layout will now always show the selected episode's details (instead of having to first manually select a episode in the list)
- that switching FROM podcast layout to any other to not properly reset lyric contents to their actual non-podcast content
- only run `lyric_update` when actually necessary instead of in every loop

Also add a little more documentation.