### PR TITLE
Faster TUI MusicLibrary node open/close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Feat: re-implement the Track database to allow for more search options. (Note that the old database is NOT automatically deleted)
 - Fix(tui): allow usage of key `Home`/`Pos1` in search lists.
 - Fix(tui): allow usage of key `Home`/`Pos1` and `End` in youtube search list.
+- Fix(tui): faster music library node open/close (right/left).
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -21,7 +21,6 @@ use crate::utils::get_pin_yin;
 pub struct MusicLibrary {
     component: TreeView<String>,
     config: SharedTuiSettings,
-    pub init: bool,
 }
 
 impl MusicLibrary {
@@ -57,11 +56,11 @@ impl MusicLibrary {
                 .initial_node(initial_node)
         };
 
-        Self {
-            component,
-            config,
-            init: true,
-        }
+        let mut ret = Self { component, config };
+
+        ret.open_root_node();
+
+        ret
     }
 
     /// Also known as going up in the tree
@@ -100,19 +99,19 @@ impl MusicLibrary {
             )
         }
     }
+
+    /// [`TreeView`] does not start with the root node opened, this function does that.
+    fn open_root_node(&mut self) {
+        let root = self.component.tree().root();
+        if self.component.tree_state().is_closed(root) {
+            self.perform(Cmd::Custom(TREE_CMD_OPEN));
+        }
+    }
 }
 
 impl Component<Msg, UserEvent> for MusicLibrary {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: Event<UserEvent>) -> Option<Msg> {
-        // When init, open root
-        if self.init {
-            let root = self.component.tree().root();
-            if self.component.tree_state().is_closed(root) {
-                self.perform(Cmd::Custom(TREE_CMD_OPEN));
-                self.init = false;
-            }
-        }
         let config = self.config.clone();
         let keys = &config.read().settings.keys;
         let result = match ev {


### PR DESCRIPTION
This PR decreases the time a node takes to open / close in the TUI, this is because `TreeView` component does not report a change on `.perform(TREE_CMD_OPEN|TREE_CMD_CLOSE)`.
Also apply the initial `.perform(TREE_CMD_OPEN)` without requiring a random event first.