### PR TITLE
Less `block_in_place` and `block_on`

### DIFF
--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use crate::utils::display_with;
 
 /// The struct to hold all the metadata and the lyric frames
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Lyric {
     /// Offset in milliseconds
     ///
@@ -32,7 +32,7 @@ pub struct Lyric {
 }
 
 /// A caption for a specific time
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Caption {
     /// Timestamp in milliseconds
     timestamp: i64,

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -194,11 +194,11 @@ impl Component<Msg, UserEvent> for YSTablePopup {
             Event::Keyboard(KeyEvent {
                 code: Key::Tab,
                 modifiers: KeyModifiers::NONE,
-            }) => return Some(Msg::YoutubeSearch(YSMsg::TablePopupNext)),
+            }) => return Some(Msg::YoutubeSearch(YSMsg::ReqNextPage)),
             Event::Keyboard(KeyEvent {
                 code: Key::BackTab,
                 modifiers: KeyModifiers::SHIFT,
-            }) => return Some(Msg::YoutubeSearch(YSMsg::TablePopupPrevious)),
+            }) => return Some(Msg::YoutubeSearch(YSMsg::ReqPreviousPage)),
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..
             }) => {

--- a/tui/src/ui/components/tag_editor/te_track.rs
+++ b/tui/src/ui/components/tag_editor/te_track.rs
@@ -22,7 +22,7 @@ use termusiclib::{
 use crate::ui::model::ExtraLyricData;
 
 /// Track data for the Tag-Editor with helper functions
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TETrack {
     path: PathBuf,
 

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -42,6 +42,12 @@ impl Model {
                     self.mount_error_popup(e.context("log lyric and photo"));
                 }
             }
+            TEMsg::EmbedDone(song) => {
+                self.te_load_lyric_and_photo_done(song);
+            }
+            TEMsg::EmbedErr(err) => {
+                self.mount_error_popup(anyhow!(err));
+            }
             TEMsg::Save => {
                 if let Err(e) = self.te_rename_song_by_tag() {
                     self.mount_error_popup(e.context("rename song by tag"));

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -51,6 +51,9 @@ impl Model {
 
             TEMsg::SearchLyricResult(msg) => self.te_update_lyric_results(msg),
             TEMsg::TrackDownloadResult(msg) => self.te_update_download_msg(msg),
+            TEMsg::TrackDownloadPreError(err) => {
+                self.mount_error_popup(anyhow!(err));
+            }
         }
     }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -37,7 +37,7 @@ impl UI {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let stream_updates = playback.subscribe_to_stream_updates().await?;
 
-        let mut model = Model::new(config, cmd_tx, stream_updates.boxed()).await;
+        let mut model = Model::new(config, cmd_tx, stream_updates.boxed());
         model.init_config();
 
         ServerRequestActor::start_actor(playback, cmd_rx, model.tx_to_main.clone());

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -357,7 +357,7 @@ fn get_viuer_support() -> ViuerSupported {
 
 impl Model {
     #[allow(clippy::too_many_lines)]
-    pub async fn new(
+    pub fn new(
         config: CombinedSettings,
         cmd_to_server_tx: UnboundedSender<TuiCmd>,
         stream_updates: WrappedStreamEvents,
@@ -442,11 +442,7 @@ impl Model {
                 tree,
                 yanked_node_id: None,
             },
-            // TODO: Consider making YoutubeOptions async and use async reqwest in YoutubeOptions
-            // and avoid this `spawn_blocking` call.
-            youtube_options: tokio::task::spawn_blocking(YoutubeOptions::default)
-                .await
-                .expect("Failed to initialize YoutubeOptions in a blocking task due to a panic"),
+            youtube_options: YoutubeOptions::default(),
             #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
             ueberzug_instance,
             songtag_options: vec![],

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -699,12 +699,20 @@ impl Model {
             YSMsg::TablePopupCloseCancel => {
                 self.umount_youtube_search_table_popup();
             }
-            YSMsg::TablePopupNext => {
+            YSMsg::ReqNextPage => {
                 self.youtube_options_next_page();
             }
-            YSMsg::TablePopupPrevious => {
+            YSMsg::ReqPreviousPage => {
                 self.youtube_options_prev_page();
             }
+            YSMsg::PageLoaded(data) => {
+                self.youtube_options.data = data;
+                self.sync_youtube_options();
+            }
+            YSMsg::PageLoadError(err) => {
+                self.mount_error_popup(anyhow!(err));
+            }
+
             YSMsg::TablePopupCloseOk(index) => {
                 if let Err(e) = self.youtube_options_download(index) {
                     self.library_reload_with_node_focus(None);

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -9,7 +9,7 @@ use termusiclib::podcast::{PodcastDLResult, PodcastFeed, PodcastSyncResult};
 use termusiclib::songtag::{SongtagSearchResult, TrackDLMsg};
 
 use crate::ui::ids::{IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
-use crate::ui::model::youtube_options::{YTDLMsg, YoutubeOptions};
+use crate::ui::model::youtube_options::{YTDLMsg, YoutubeData, YoutubeOptions};
 
 /// Main message type that encapsulates everything else.
 // Note that the style is for each thing to have a sub-type, unless it is top-level like "ForceRedraw".
@@ -459,8 +459,15 @@ pub enum YSMsg {
     InputPopupShow,
     InputPopupCloseCancel,
     InputPopupCloseOk(String),
-    TablePopupNext,
-    TablePopupPrevious,
+
+    ReqNextPage,
+    ReqPreviousPage,
+    PageLoaded(YoutubeData),
+    /// Indicates that the youtube search page load has failed, with error message.
+    ///
+    /// `(ErrorAsString)`
+    PageLoadError(String),
+
     TablePopupCloseCancel,
     TablePopupCloseOk(usize),
 

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -488,6 +488,10 @@ pub enum TEMsg {
 
     SearchLyricResult(SongtagSearchResult),
     TrackDownloadResult(TrackDLMsg),
+    /// Indicates that the preparation for the track download have failed
+    ///
+    /// `(ErrorAsString)`
+    TrackDownloadPreError(String),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -8,6 +8,7 @@ use termusiclib::player::{GetProgressResponse, PlaylistTracks, UpdateEvents};
 use termusiclib::podcast::{PodcastDLResult, PodcastFeed, PodcastSyncResult};
 use termusiclib::songtag::{SongtagSearchResult, TrackDLMsg};
 
+use crate::ui::components::TETrack;
 use crate::ui::ids::{IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::youtube_options::{YTDLMsg, YoutubeData, YoutubeOptions};
 
@@ -487,7 +488,16 @@ pub enum TEMsg {
     Close,
     CounterDeleteOk,
     Download(usize),
+    /// Request to embed the data from `param1` into the current track.
     Embed(usize),
+    /// Embedding has finished.
+    // Box to not increase the size of this enum when not necessary.
+    EmbedDone(Box<TETrack>),
+    /// Indicates that the embedding has failed.
+    ///
+    /// `(ErrorAsString)`
+    EmbedErr(String),
+
     Focus(TFMsg),
     Save,
     Search,


### PR DESCRIPTION
This PR refactors a couple of places to make use of events instead of blocking in-place.
Also removes the spawn_blocking-await in `Model::new` for `YoutubeOptions` as this is no longer required since fffa4e32c694a7b6dc5a5f6b9ff807282e169446.
(This was added in #154 when `YoutubeOptions`/`Invidious` still made use of reqwest-blocking client, which tries to create a runtime within a runtime, which panics in debug mode)