### PR TITLE
Continue adding tracks to playlist on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix(tui): faster music library node open/close (right/left).
 - Fix(tui): when in podcast layout, always show the currently selected episode's description (instead of only when moving to it).
 - Fix(tui): properly reset lyric text once leaving podcast layout.
+- Fix(server): when adding multipl tracks to the playlist, dont exit on first error and add remaining possible tracks.
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -612,7 +612,7 @@ fn player_loop(
             }
             PlayerCmd::PlaylistAddTrack(info) => {
                 if let Err(err) = player.playlist.write().add_tracks(info, &player.db_podcast) {
-                    error!("Error adding tracks: {err}");
+                    error!("Error adding tracks: {err:?}");
                 }
             }
             PlayerCmd::PlaylistRemoveTrack(info) => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -612,7 +612,7 @@ fn player_loop(
             }
             PlayerCmd::PlaylistAddTrack(info) => {
                 if let Err(err) = player.playlist.write().add_tracks(info, &player.db_podcast) {
-                    error!("Error adding tracks: {err:?}");
+                    error!("Error adding tracks: {err}");
                 }
             }
             PlayerCmd::PlaylistRemoveTrack(info) => {


### PR DESCRIPTION
This PR changes the `playback::Playlist::add_tracks` method to collect (and report) errors, but continue adding the remaining tracks.

fixes #565