### PR TITLE
fix(tui::ui::components::progress::progress_update_title): always show status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix(tui): faster music library node open/close (right/left).
 - Fix(tui): when in podcast layout, always show the currently selected episode's description (instead of only when moving to it).
 - Fix(tui): properly reset lyric text once leaving podcast layout.
+- Fix(tui): always properly show Progress component's title (Status, Volume, Speed, etc).
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -597,33 +597,4 @@ impl Model {
         }
         false
     }
-
-    /// Handle running [`RunningStatus`] having possibly changed.
-    pub fn handle_status(&mut self, new_status: RunningStatus) {
-        let old_status = self.playback.status();
-        // nothing needs to be done as the status is the same
-        if new_status == old_status {
-            return;
-        }
-
-        self.playback.set_status(new_status);
-
-        match new_status {
-            RunningStatus::Running => {
-                // This is to show the first album photo
-                if old_status == RunningStatus::Stopped {
-                    self.player_update_current_track_after();
-                }
-            }
-            RunningStatus::Stopped => {
-                // This is to clear the photo shown when stopped
-                if self.playback.playlist.is_empty() {
-                    self.player_update_current_track_after();
-                }
-            }
-            RunningStatus::Paused => {
-                self.player_update_current_track_after();
-            }
-        }
-    }
 }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -1089,7 +1089,10 @@ impl Model {
 
                 self.lyric_update_for_radio(response.radio_title);
 
-                self.handle_status(RunningStatus::from_u32(response.status));
+                self.playback
+                    .set_status(RunningStatus::from_u32(response.status));
+                // "GetProgress" is, as of ~termusic 0.11.0~0.12.0, only called initially or having missed events, so everything should be reloaded.
+                self.player_update_current_track_after();
             }
             ServerReqResponse::FullPlaylist(playlist_tracks) => {
                 info!("Processing Playlist from server");


### PR DESCRIPTION
This PR changes the progress component's update to always show the title properly instead of a empty string if there is no current track.
Additionally, always reload data on `GetProgress` response, instead if only the Running status changed (as the running status might not have changed, but volume or progress might have changed when having had missed events).

This is something i noticed while working on #567 