### PR TITLE
fix(playback::rusty): handle the case of initial 0-length buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix(tui): properly reset lyric text once leaving podcast layout.
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
+- Fix(server): on rusty backend, handle the case of symphonia having a initial 0-length buffer.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.
 - Fix: due to the Track database re-implementation, a bug where the database could grow with duplicated paths is fixed.
 


### PR DESCRIPTION
This may happen in symphonia for ogg-vorbis for some reason. Also the "written" future was never polled correctly for exhausted (0-length) buffer in the first place.

Copy-pasting the description of my findings from #566:

At the end i could pin-point the problem to 2 issues, which had 1 root cause:
- symphonia for ogg-vorbis, *somehow* may return a 0-length initial buffer
  - which in rodio and so by us gets interpreted as "stream done" (symphonia does not have a official way to detect End-of-Stream in 0.5)
  - if the buffer was 0-length / exhausted, the write future (async decode) was never polled correctly, meaning another decode was not attempted

(turns out when you use `res = fut, if COND` in `select`, the future only gets polled if `COND`, not just my previous interpretation of "the callback functions gets called if COND"; effectively making the select only wait on `seek` to send something, which never happens)

fixes #566

@theeasternfurry could you test this PR and report back?