### PR TITLE
chore: README updates about mac and make options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Then install with:
 make install
 ```
 
-By default, termusic can display album covers in Kitty or iTerm2 (mac, not tested).
+By default, termusic can display album covers in Kitty or iTerm2.
 If you need album covers displayed on other terminals, you can enable the `sixel` protocol or use a ueberzug implementation(x11/xwayland only).
 
-To build with all backends and all cover protocols:
+To build all backends and all cover protocols and install them in your home:
 
 ```bash
 make full
@@ -161,7 +161,13 @@ Finally, you can run it with:
 ~/.local/share/cargo/bin/termusic
 ```
 
-You can copy it anywhere in your `$PATH`. The configuration file for the TUI is located in `~/.config/termusic/tui.toml`, and the configuration file for the server is located in `~/.config/termusic/server.toml` (or on macOS, `~/Library/Application Support/termusic/tui.toml`, `~/Library/Application Support/termusic/server.toml`, respectively). <!---The MacOS, i assume it has the same rules as linux, so its a good idea to check, as i lack and macOS machine.-->
+To build with all backends and all cover protocols without copying binaries elsewhere:
+
+```bash
+make all-backends
+```
+
+You can copy it anywhere in your `$PATH`. The configuration file for the TUI is located in `~/.config/termusic/tui.toml`, and the configuration file for the server is located in `~/.config/termusic/server.toml` (or on macOS, `~/Library/Application Support/termusic/tui.toml`, `~/Library/Application Support/termusic/server.toml`, respectively).
 However, as this is a minimalistic program, you don't need to edit the configuration file and almost everything can be set from the app.
 
 ## TODO


### PR DESCRIPTION
This commit aims for two objectives:

First make it clearer that `make` examples already in the `README` were installing binaries outside of the repo and `target/` directory, in user's home and provide its counterpart to only build and not install them (tell me if that'd be too much, unnecessary and so on).

Secondly, seeing some mentions there, I took the occasion that I currently must work on a mac for $job to try to build `termusic` on it and get rid of some of the uncertainties in `README`, while giving a status on `termusic` on mac.

I could easily verify configuration files location, and then I tried the various build options. I had to tinker and add some dependencies for some of them, using Homebrew.
In the end, I could compile every features providing installation of the required dependencies from Homebrew  excepted for two: `cover-viuer-sixel` and `mpv`, despite trying to install `libsixel` (https://formulae.brew.sh/formula/libsixel - https://github.com/Homebrew/homebrew-core/blob/main/Formula/lib/libsixel.rb) for the first as it was complaining about failing to find the `sixel` library, and `mpv` (https://formulae.brew.sh/formula/mpv - https://github.com/Homebrew/homebrew-core/blob/main/Formula/m/mpv.rb) for the second one as it couldn't find the `mpv` library, in both cases at linking step with `cc`.

I'm not sure as to why `cc` does not find what it looks for (not sure which file I should be looking for), but other solutions would be to try to provide these dependencies by either manually providing them by a local build on the computer, or trying other package managers such as Macports or Nix/Lix (although I'm not sure about that one, I'm not sure, but it seems it still mainly works on x86 and doesn't have native ARM support, only through Rosetta).

Finally regarding covers, I could verify iTerm2 correctly showing covers when provided through ID3 tags/metadata (although iTerm2 shoots a pop-up requesting permission to display a file named "Unnamed file").
[EDIT: Funnily, cover seems to display before user answer anything to that popup even for several tracks, stacking the popups, but then if user answer "No", the TUI is turning full garbage, completely breaking)].

But while checking this, I also saw that it didn't display anything when instead of a tags/metadas-included cover it was only a `cover.jpg` in the directory. As I think I remembered it to work in the past, I check this from a Linux computer and could see it not working there either, despite https://github.com/tramhao/termusic/issues/59 that tend to show it used to work?