### PR TITLE
fix(lib::track::find_folder_picture): correctly find images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix(server): on rusty backend, handle the case of symphonia having a initial 0-length buffer.
 - Fix(server): on mpv backend and linux compile, dont force `ao` to be `pulse`.
 - Fix: due to the Track database re-implementation, a bug where the database could grow with duplicated paths is fixed.
+- Fix: correctly find images in track's parent directory, if available.
 
 ### [V0.11.0]
 - Released on: July 1, 2025.

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -541,6 +541,11 @@ fn get_picture_for_music_track(track_path: &Path) -> Result<Option<Picture>> {
     Ok(Some(picture))
 }
 
+/// All extension we support to find in a parent folder of a given track to use as a cover image.
+///
+/// The matching is done via lowercase EQ.
+const SUPPORTED_IMG_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png"];
+
 /// Find a picture file and parse it in the parent directory of the given path.
 ///
 /// # Errors
@@ -569,7 +574,10 @@ fn find_folder_picture(track_path: &Path) -> Result<Option<Picture>> {
         };
 
         // only take some picture files we can handle and are common
-        if ext != "jpg" || ext != "png" {
+        if !SUPPORTED_IMG_EXTENSIONS
+            .iter()
+            .any(|v| ext.eq_ignore_ascii_case(v))
+        {
             continue;
         }
 

--- a/tui/src/ui/components/xywh.rs
+++ b/tui/src/ui/components/xywh.rs
@@ -121,7 +121,7 @@ impl Model {
                     Ok(v) => v,
                     Err(err) => {
                         error!(
-                            "Getting the track for \"{}\" failed! Error: {}",
+                            "Getting the cover for \"{}\" failed! Error: {}",
                             track_data.path().display(),
                             err
                         );


### PR DESCRIPTION
The previous "if" comparison will always result in the "continue" path. This way also allows us to easily add more extensions.

re #570

@Porkepix could you test?