### PR TITLE
chore: rewording in README to make "it" more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To build with all backends and all cover protocols without copying binaries else
 make all-backends
 ```
 
-You can copy it anywhere in your `$PATH`. The configuration file for the TUI is located in `~/.config/termusic/tui.toml`, and the configuration file for the server is located in `~/.config/termusic/server.toml` (or on macOS, `~/Library/Application Support/termusic/tui.toml`, `~/Library/Application Support/termusic/server.toml`, respectively).
+You can copy the binary anywhere in your `$PATH`. The configuration file for the TUI is located in `~/.config/termusic/tui.toml`, and the configuration file for the server is located in `~/.config/termusic/server.toml` (or on macOS, `~/Library/Application Support/termusic/tui.toml`, `~/Library/Application Support/termusic/server.toml`, respectively).
 However, as this is a minimalistic program, you don't need to edit the configuration file and almost everything can be set from the app.
 
 ## TODO


### PR DESCRIPTION
It wasn't clear what "it" was referring to, so we explicit it's about the binary.

@hasezoey as we talked about this in https://github.com/tramhao/termusic/pull/570

Although the more I think about it, the more it seems to maybe come as unnecessary as we don't get much more from it compared to what comes before in the README.