### PR TITLE
fix: fix inverted help text for "import/export" command

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -69,12 +69,12 @@ impl std::fmt::Display for Backend {
 /// Subcommands for the binary
 #[derive(Subcommand, Debug)]
 pub enum Action {
-    /// Import Podcast feeds from a opml file.
+    /// Export Podcast feeds to a opml file.
     Export {
         #[arg(value_name = "FILE")]
         file: PathBuf,
     },
-    /// Export Podcast feeds to a opml file.
+    /// Import Podcast feeds from a opml file.
     Import {
         #[arg(value_name = "FILE")]
         file: PathBuf,

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -66,12 +66,12 @@ impl std::fmt::Display for Backend {
 /// Subcommands for the binary
 #[derive(Subcommand, Debug)]
 pub enum Action {
-    /// Import Podcast feeds from a opml file.
+    /// Export Podcast feeds to a opml file.
     Export {
         #[arg(value_name = "FILE")]
         file: PathBuf,
     },
-    /// Export Podcast feeds to a opml file.
+    /// Import Podcast feeds from a opml file.
     Import {
         #[arg(value_name = "FILE")]
         file: PathBuf,


### PR DESCRIPTION
re #574