### PR TITLE
deps(serde) update to 1.0.221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,18 +4218,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,8 @@ rss = { version = "2.0.12", default-features = false }
 rusqlite = { version = "0.37", features = ["bundled"] }
 sanitize-filename = "0.6"
 semver = "1.0.26"
-serde = { version = "1.0.219", features = ["derive"] }
+# locked as the next version removes access to "__private"
+serde = { version = "=1.0.221", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9"
 shellexpand = { version = "3.1.1", features = ["path"] }


### PR DESCRIPTION
And lock the version until a alternative for "__private" can be found.

This is only a quick-fix until a proper solution can be found. I am already looking into [`serde-content`](https://github.com/rushmorem/serde-content), but with that i am currently running into what seems to be https://github.com/rushmorem/serde-content/issues/27.

re #578