### PR TITLE
feat(lib): replace "serde::__private" with "serde-content"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,9 +4218,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4237,18 +4237,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,6 +4227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-content"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,6 +4986,7 @@ dependencies = [
  "sanitize-filename",
  "semver",
  "serde",
+ "serde-content",
  "serde_json",
  "serde_yaml",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,7 @@ rss = { version = "2.0.12", default-features = false }
 rusqlite = { version = "0.37", features = ["bundled"] }
 sanitize-filename = "0.6"
 semver = "1.0.26"
-# locked as the next version removes access to "__private"
-serde = { version = "=1.0.221", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9"
 serde-content = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ semver = "1.0.26"
 serde = { version = "=1.0.221", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9"
+serde-content = "0.1.2"
 shellexpand = { version = "3.1.1", features = ["path"] }
 shell-words = "1.1.0"
 soundtouch = { version = "0.5.1", features = ["bundled"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -55,6 +55,7 @@ semver.workspace = true #   = "^1"
 serde.workspace = true #  = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true #  = "1.0"
 serde_yaml.workspace = true
+serde-content.workspace = true
 shellexpand.workspace = true #  = "3"
 textwrap.workspace = true #   = "0.16"
 toml.workspace = true #  = "0.7"

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -50,7 +50,7 @@ impl<'a, 'de> Deserialize<'de> for ServerConfigVersionedDefaulted<'a> {
                 let _ = write!(err_res, "{err:#}");
             }
         }
-        match <Intermediate<'a>>::deserialize(deserializer)
+        match Intermediate::deserialize(deserializer)
             .map(|v| ServerConfigVersionedDefaulted::Unversioned(v.into_settings()))
         {
             Ok(val) => return Ok(val),
@@ -187,18 +187,18 @@ impl ServerConfigVersioned<'_> {
 /// see <https://github.com/rushmorem/serde-content/issues/27>.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum Intermediate<'a> {
-    Some(Cow<'a, ApplicationType>),
+pub enum Intermediate {
+    Some(ApplicationType),
 }
 
-impl Intermediate<'_> {
+impl Intermediate {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
     #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         match self {
-            Intermediate::Some(v) => v.into_owned(),
+            Intermediate::Some(v) => v,
         }
     }
 }

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -37,14 +37,12 @@ impl<'a, 'de> Deserialize<'de> for ServerConfigVersionedDefaulted<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        // Note that those are marked "private", but are used in the derives, and there is no to me known public way, but saves some implementation complexity
-        let content =
-            <serde::__private::de::Content<'_> as serde::Deserialize>::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
+        let content = serde_content::Value::deserialize(deserializer)?;
+        let deserializer = serde_content::Deserializer::new(content).coerce_numbers();
 
         let mut err_res = String::new();
 
-        match <ServerConfigVersioned<'a>>::deserialize(deserializer)
+        match <ServerConfigVersioned<'a>>::deserialize(deserializer.clone())
             .map(ServerConfigVersionedDefaulted::Versioned)
         {
             Ok(val) => return Ok(val),
@@ -52,8 +50,8 @@ impl<'a, 'de> Deserialize<'de> for ServerConfigVersionedDefaulted<'a> {
                 let _ = write!(err_res, "{err:#}");
             }
         }
-        match ServerSettings::deserialize(deserializer)
-            .map(ServerConfigVersionedDefaulted::Unversioned)
+        match <Intermediate<'a>>::deserialize(deserializer)
+            .map(|v| ServerConfigVersionedDefaulted::Unversioned(v.into_settings()))
         {
             Ok(val) => return Ok(val),
             // no need to check if "err_res" is empty, as this code can only be executed if the above has failed
@@ -181,6 +179,26 @@ impl ServerConfigVersioned<'_> {
     pub fn into_settings(self) -> ApplicationType {
         match self {
             ServerConfigVersioned::V2(v) => v.into_owned(),
+        }
+    }
+}
+
+/// This type exists due to a bug in `serde-content`, where without it fails to properly parse untagged enum values
+/// see <https://github.com/rushmorem/serde-content/issues/27>.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Intermediate<'a> {
+    Some(Cow<'a, ApplicationType>),
+}
+
+impl Intermediate<'_> {
+    /// Convert Into the type used by the application, instead of what is parsed
+    ///
+    /// Will convert any version into the latest
+    #[must_use]
+    pub fn into_settings(self) -> ApplicationType {
+        match self {
+            Intermediate::Some(v) => v.into_owned(),
         }
     }
 }

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -37,14 +37,12 @@ impl<'a, 'de> Deserialize<'de> for TuiConfigVersionedDefaulted<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        // Note that those are marked "private", but are used in the derives, and there is no to me known public way, but saves some implementation complexity
-        let content =
-            <serde::__private::de::Content<'_> as serde::Deserialize>::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
+        let content = serde_content::Value::deserialize(deserializer)?;
+        let deserializer = serde_content::Deserializer::new(content);
 
         let mut err_res = String::new();
 
-        match <TuiConfigVersioned<'a>>::deserialize(deserializer)
+        match <TuiConfigVersioned<'a>>::deserialize(deserializer.clone())
             .map(TuiConfigVersionedDefaulted::Versioned)
         {
             Ok(val) => return Ok(val),
@@ -52,7 +50,9 @@ impl<'a, 'de> Deserialize<'de> for TuiConfigVersionedDefaulted<'a> {
                 let _ = write!(err_res, "{err:#}");
             }
         }
-        match TuiSettings::deserialize(deserializer).map(TuiConfigVersionedDefaulted::Unversioned) {
+        match Intermediate::deserialize(deserializer)
+            .map(|v| TuiConfigVersionedDefaulted::Unversioned(v.into_settings()))
+        {
             Ok(val) => return Ok(val),
             // no need to check if "err_res" is empty, as this code can only be executed if the above has failed
             Err(err) => {
@@ -207,6 +207,26 @@ impl TuiConfigVersioned<'_> {
     fn resolve_com(&mut self, tui_path: &Path) -> Result<()> {
         match self {
             TuiConfigVersioned::V2(v) => v.to_mut().resolve_com(tui_path),
+        }
+    }
+}
+
+/// This type exists due to a bug in `serde-content`, where without it fails to properly parse untagged enum values
+/// see <https://github.com/rushmorem/serde-content/issues/27>.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Intermediate<'a> {
+    Some(Cow<'a, ApplicationType>),
+}
+
+impl Intermediate<'_> {
+    /// Convert Into the type used by the application, instead of what is parsed
+    ///
+    /// Will convert any version into the latest
+    #[must_use]
+    pub fn into_settings(self) -> ApplicationType {
+        match self {
+            Intermediate::Some(v) => v.into_owned(),
         }
     }
 }

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -215,18 +215,18 @@ impl TuiConfigVersioned<'_> {
 /// see <https://github.com/rushmorem/serde-content/issues/27>.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum Intermediate<'a> {
-    Some(Cow<'a, ApplicationType>),
+pub enum Intermediate {
+    Some(ApplicationType),
 }
 
-impl Intermediate<'_> {
+impl Intermediate {
     /// Convert Into the type used by the application, instead of what is parsed
     ///
     /// Will convert any version into the latest
     #[must_use]
     pub fn into_settings(self) -> ApplicationType {
         match self {
-            Intermediate::Some(v) => v.into_owned(),
+            Intermediate::Some(v) => v,
         }
     }
 }


### PR DESCRIPTION
This is a experimental change from `serde::__private` to `serde-content` due to serde making access to `__private` way harder and they just wont stabilize the content inside.

Experimental due to the `Intermediate` struct required and some more additional testing.

fixes #578