### PR TITLE
Some polishing for the config editor & add some missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Feat(tui): make the Config editor dynamically size elements.
 - Feat(tui): make the Config editor (at least rudementally) scrollable.
 - Feat(tui): collect spawned server logs until connected for better error, in case server exits before being connected.
+- Feat(tui): add config editor fields for `com.address`, `com.protocol`, `com.socket_path`, `player.backend`
 - Feat(server): add extra config section for metadata scanning and parsing.
 - Feat(server): on rusty backend, allow configuring output sample rate, now defaulting to 48_000Hz (instead of rodio default 44_100Hz).
 - Feat(server): on mpv backend, add option to configure `audio-device` property.
@@ -20,7 +21,8 @@
 - Fix(tui): when in podcast layout, always show the currently selected episode's description (instead of only when moving to it).
 - Fix(tui): properly reset lyric text once leaving podcast layout.
 - Fix(tui): always properly show Progress component's title (Status, Volume, Speed, etc).
-- Fix(server): when adding multipl tracks to the playlist, dont exit on first error and add remaining possible tracks.
+- Fix(tui): reword some config editor field titles.
+- Fix(server): when adding multiple tracks to the playlist, dont exit on first error and add remaining possible tracks.
 - Fix(server): on linux+mpris, set volume on start instead of only on change.
 - Fix(server): on rusty backend, behave correctly when a next/previous occurs while a source is pre-fetched.
 - Fix(server): on rusty backend, handle the case of symphonia having a initial 0-length buffer.

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -459,18 +459,22 @@ pub struct ComSettings {
     pub address: IpAddr,
 }
 
+/// Helper function to get the default UDS socker path.
+#[must_use]
+pub fn default_uds_socket_path() -> PathBuf {
+    // TODO: maybe default to include user id like "termusic-1000.socket"?
+    std::env::temp_dir().join("termusic.socket")
+}
+
 impl Default for ComSettings {
     fn default() -> Self {
-        // TODO: maybe default to include user id like "termusic-1000.socket"?
-        let socket_path = std::env::temp_dir().join("termusic.socket");
-
         Self {
             #[cfg(unix)]
             protocol: ComProtocol::UDS,
             #[cfg(not(unix))]
             protocol: ComProtocol::HTTP,
 
-            socket_path,
+            socket_path: default_uds_socket_path(),
 
             port: 50101,
             address: "::1".parse().unwrap(),

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -35,7 +35,7 @@ use tuirealm::ratatui::style::Modifier;
 use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, StateValue};
 
 use crate::ui::components::vendored::tui_realm_stdlib_input::Input;
-use crate::ui::ids::{Id, IdConfigEditor};
+use crate::ui::ids::{Id, IdCETheme, IdConfigEditor};
 use crate::ui::model::{Model, UserEvent};
 use crate::ui::msg::{ConfigEditorMsg, Msg};
 
@@ -227,31 +227,59 @@ impl CEColorSelect {
 
     const fn init_color_select(id: IdConfigEditor, theme: &ThemeWrap) -> usize {
         match id {
-            IdConfigEditor::LibraryForeground => theme.style.library.foreground_color.as_usize(),
-            IdConfigEditor::LibraryBackground => theme.style.library.background_color.as_usize(),
-            IdConfigEditor::LibraryBorder => theme.style.library.border_color.as_usize(),
-            IdConfigEditor::LibraryHighlight => theme.style.library.highlight_color.as_usize(),
+            IdConfigEditor::Theme(IdCETheme::LibraryForeground) => {
+                theme.style.library.foreground_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::LibraryBackground) => {
+                theme.style.library.background_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::LibraryBorder) => {
+                theme.style.library.border_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::LibraryHighlight) => {
+                theme.style.library.highlight_color.as_usize()
+            }
 
-            IdConfigEditor::PlaylistForeground => theme.style.playlist.foreground_color.as_usize(),
-            IdConfigEditor::PlaylistBackground => theme.style.playlist.background_color.as_usize(),
-            IdConfigEditor::PlaylistBorder => theme.style.playlist.border_color.as_usize(),
-            IdConfigEditor::PlaylistHighlight => theme.style.playlist.highlight_color.as_usize(),
+            IdConfigEditor::Theme(IdCETheme::PlaylistForeground) => {
+                theme.style.playlist.foreground_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::PlaylistBackground) => {
+                theme.style.playlist.background_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::PlaylistBorder) => {
+                theme.style.playlist.border_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::PlaylistHighlight) => {
+                theme.style.playlist.highlight_color.as_usize()
+            }
 
-            IdConfigEditor::ProgressForeground => theme.style.progress.foreground_color.as_usize(),
-            IdConfigEditor::ProgressBackground => theme.style.progress.background_color.as_usize(),
-            IdConfigEditor::ProgressBorder => theme.style.progress.border_color.as_usize(),
+            IdConfigEditor::Theme(IdCETheme::ProgressForeground) => {
+                theme.style.progress.foreground_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::ProgressBackground) => {
+                theme.style.progress.background_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::ProgressBorder) => {
+                theme.style.progress.border_color.as_usize()
+            }
 
-            IdConfigEditor::LyricForeground => theme.style.lyric.foreground_color.as_usize(),
-            IdConfigEditor::LyricBackground => theme.style.lyric.background_color.as_usize(),
-            IdConfigEditor::LyricBorder => theme.style.lyric.border_color.as_usize(),
+            IdConfigEditor::Theme(IdCETheme::LyricForeground) => {
+                theme.style.lyric.foreground_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::LyricBackground) => {
+                theme.style.lyric.background_color.as_usize()
+            }
+            IdConfigEditor::Theme(IdCETheme::LyricBorder) => {
+                theme.style.lyric.border_color.as_usize()
+            }
 
-            IdConfigEditor::ImportantPopupForeground => {
+            IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground) => {
                 theme.style.important_popup.foreground_color.as_usize()
             }
-            IdConfigEditor::ImportantPopupBackground => {
+            IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground) => {
                 theme.style.important_popup.background_color.as_usize()
             }
-            IdConfigEditor::ImportantPopupBorder => {
+            IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder) => {
                 theme.style.important_popup.border_color.as_usize()
             }
 
@@ -394,7 +422,7 @@ impl ConfigLibraryForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::LibraryForeground,
+                IdConfigEditor::Theme(IdCETheme::LibraryForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LibraryForegroundBlurDown),
@@ -421,7 +449,7 @@ impl ConfigLibraryBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::LibraryBackground,
+                IdConfigEditor::Theme(IdCETheme::LibraryBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LibraryBackgroundBlurDown),
@@ -448,7 +476,7 @@ impl ConfigLibraryBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::LibraryBorder,
+                IdConfigEditor::Theme(IdCETheme::LibraryBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LibraryBorderBlurDown),
@@ -475,7 +503,7 @@ impl ConfigLibraryHighlight {
         Self {
             component: CEColorSelect::new(
                 " Highlight ",
-                IdConfigEditor::LibraryHighlight,
+                IdConfigEditor::Theme(IdCETheme::LibraryHighlight),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightBlurDown),
@@ -523,7 +551,7 @@ impl ConfigPlaylistForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::PlaylistForeground,
+                IdConfigEditor::Theme(IdCETheme::PlaylistForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::PlaylistForegroundBlurDown),
@@ -550,7 +578,7 @@ impl ConfigPlaylistBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::PlaylistBackground,
+                IdConfigEditor::Theme(IdCETheme::PlaylistBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::PlaylistBackgroundBlurDown),
@@ -577,7 +605,7 @@ impl ConfigPlaylistBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::PlaylistBorder,
+                IdConfigEditor::Theme(IdCETheme::PlaylistBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::PlaylistBorderBlurDown),
@@ -604,7 +632,7 @@ impl ConfigPlaylistHighlight {
         Self {
             component: CEColorSelect::new(
                 " Highlight ",
-                IdConfigEditor::PlaylistHighlight,
+                IdConfigEditor::Theme(IdCETheme::PlaylistHighlight),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightBlurDown),
@@ -652,7 +680,7 @@ impl ConfigProgressForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::ProgressForeground,
+                IdConfigEditor::Theme(IdCETheme::ProgressForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ProgressForegroundBlurDown),
@@ -679,7 +707,7 @@ impl ConfigProgressBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::ProgressBackground,
+                IdConfigEditor::Theme(IdCETheme::ProgressBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ProgressBackgroundBlurDown),
@@ -706,7 +734,7 @@ impl ConfigProgressBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::ProgressBorder,
+                IdConfigEditor::Theme(IdCETheme::ProgressBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ProgressBorderBlurDown),
@@ -754,7 +782,7 @@ impl ConfigLyricForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::LyricForeground,
+                IdConfigEditor::Theme(IdCETheme::LyricForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LyricForegroundBlurDown),
@@ -781,7 +809,7 @@ impl ConfigLyricBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::LyricBackground,
+                IdConfigEditor::Theme(IdCETheme::LyricBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LyricBackgroundBlurDown),
@@ -808,7 +836,7 @@ impl ConfigLyricBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::LyricBorder,
+                IdConfigEditor::Theme(IdCETheme::LyricBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::LyricBorderBlurDown),
@@ -836,13 +864,13 @@ impl ConfigInputHighlight {
         let config_r = config.read();
         // TODO: this should likely not be here, because it is a runtime error if it is unhandled
         let highlight_str = match id {
-            IdConfigEditor::LibraryHighlightSymbol => {
+            IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => {
                 &config_r.settings.theme.style.library.highlight_symbol
             }
-            IdConfigEditor::PlaylistHighlightSymbol => {
+            IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => {
                 &config_r.settings.theme.style.playlist.highlight_symbol
             }
-            IdConfigEditor::CurrentlyPlayingTrackSymbol => {
+            IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => {
                 &config_r.settings.theme.style.playlist.current_track_symbol
             }
             _ => todo!("Unhandled IdConfigEditor Variant: {:#?}", id),
@@ -977,27 +1005,27 @@ impl Component<Msg, UserEvent> for ConfigInputHighlight {
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
             }) => match self.id {
-                IdConfigEditor::LibraryHighlightSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::LibraryHighlightSymbolBlurDown,
-                )),
-                IdConfigEditor::PlaylistHighlightSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::PlaylistHighlightSymbolBlurDown,
-                )),
-                IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown,
-                )),
+                IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightSymbolBlurDown),
+                ),
+                IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightSymbolBlurDown),
+                ),
+                IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown),
+                ),
                 _ => None,
             },
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => match self.id {
-                IdConfigEditor::LibraryHighlightSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::LibraryHighlightSymbolBlurUp,
-                )),
-                IdConfigEditor::PlaylistHighlightSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::PlaylistHighlightSymbolBlurUp,
-                )),
-                IdConfigEditor::CurrentlyPlayingTrackSymbol => Some(Msg::ConfigEditor(
-                    ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp,
-                )),
+                IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightSymbolBlurUp),
+                ),
+                IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightSymbolBlurUp),
+                ),
+                IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => Some(
+                    Msg::ConfigEditor(ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp),
+                ),
                 _ => None,
             },
 
@@ -1022,7 +1050,7 @@ impl ConfigLibraryHighlightSymbol {
         Self {
             component: ConfigInputHighlight::new(
                 " Highlight Symbol ",
-                IdConfigEditor::LibraryHighlightSymbol,
+                IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol),
                 config,
             ),
         }
@@ -1045,7 +1073,7 @@ impl ConfigPlaylistHighlightSymbol {
         Self {
             component: ConfigInputHighlight::new(
                 " Highlight Symbol ",
-                IdConfigEditor::PlaylistHighlightSymbol,
+                IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol),
                 config,
             ),
         }
@@ -1068,7 +1096,7 @@ impl ConfigCurrentlyPlayingTrackSymbol {
         Self {
             component: ConfigInputHighlight::new(
                 " Current Track Symbol ",
-                IdConfigEditor::CurrentlyPlayingTrackSymbol,
+                IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol),
                 config,
             ),
         }
@@ -1113,7 +1141,7 @@ impl ConfigImportantPopupForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::ImportantPopupForeground,
+                IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupForegroundBlurDown),
@@ -1140,7 +1168,7 @@ impl ConfigImportantPopupBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::ImportantPopupBackground,
+                IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBackgroundBlurDown),
@@ -1167,7 +1195,7 @@ impl ConfigImportantPopupBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::ImportantPopupBorder,
+                IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBorderBlurDown),
@@ -1215,7 +1243,7 @@ impl ConfigFallbackForeground {
         Self {
             component: CEColorSelect::new(
                 " Foreground ",
-                IdConfigEditor::FallbackForeground,
+                IdConfigEditor::Theme(IdCETheme::FallbackForeground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::FallbackForegroundBlurDown),
@@ -1242,7 +1270,7 @@ impl ConfigFallbackBackground {
         Self {
             component: CEColorSelect::new(
                 " Background ",
-                IdConfigEditor::FallbackBackground,
+                IdConfigEditor::Theme(IdCETheme::FallbackBackground),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::FallbackBackgroundBlurDown),
@@ -1269,7 +1297,7 @@ impl ConfigFallbackBorder {
         Self {
             component: CEColorSelect::new(
                 " Border ",
-                IdConfigEditor::FallbackBorder,
+                IdConfigEditor::Theme(IdCETheme::FallbackBorder),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::FallbackBorderBlurDown),
@@ -1296,7 +1324,7 @@ impl ConfigFallbackHighlight {
         Self {
             component: CEColorSelect::new(
                 " Highlight ",
-                IdConfigEditor::FallbackHighlight,
+                IdConfigEditor::Theme(IdCETheme::FallbackHighlight),
                 color,
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::FallbackHighlightBlurDown),
@@ -1328,149 +1356,149 @@ impl Model {
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryLabel)),
             Box::<ConfigLibraryTitle>::default(),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryForeground)),
             Box::new(ConfigLibraryForeground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryBackground)),
             Box::new(ConfigLibraryBackground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryBorder)),
             Box::new(ConfigLibraryBorder::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryHighlight),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryHighlight)),
             Box::new(ConfigLibraryHighlight::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistLabel)),
             Box::<ConfigPlaylistTitle>::default(),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistForeground)),
             Box::new(ConfigPlaylistForeground::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistBackground)),
             Box::new(ConfigPlaylistBackground::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistBorder)),
             Box::new(ConfigPlaylistBorder::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistHighlight),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistHighlight)),
             Box::new(ConfigPlaylistHighlight::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ProgressLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressLabel)),
             Box::<ConfigProgressTitle>::default(),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ProgressForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressForeground)),
             Box::new(ConfigProgressForeground::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ProgressBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressBackground)),
             Box::new(ConfigProgressBackground::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ProgressBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressBorder)),
             Box::new(ConfigProgressBorder::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LyricLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricLabel)),
             Box::<ConfigLyricTitle>::default(),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LyricForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricForeground)),
             Box::new(ConfigLyricForeground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LyricBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricBackground)),
             Box::new(ConfigLyricBackground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LyricBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricBorder)),
             Box::new(ConfigLyricBorder::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ImportantPopupLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupLabel)),
             Box::<ConfigImportantPopupTitle>::default(),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ImportantPopupForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground)),
             Box::new(ConfigImportantPopupForeground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ImportantPopupBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground)),
             Box::new(ConfigImportantPopupBackground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder)),
             Box::new(ConfigImportantPopupBorder::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::FallbackLabel),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackLabel)),
             Box::<ConfigFallbackTitle>::default(),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::FallbackForeground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackForeground)),
             Box::new(ConfigFallbackForeground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::FallbackBackground),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackBackground)),
             Box::new(ConfigFallbackBackground::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::FallbackBorder),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackBorder)),
             Box::new(ConfigFallbackBorder::new(config.clone())),
             Vec::new(),
         )?;
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::FallbackHighlight),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackHighlight)),
             Box::new(ConfigFallbackHighlight::new(config.clone())),
             Vec::new(),
         )?;
@@ -1485,19 +1513,21 @@ impl Model {
     /// Mount / Remount the Config-Editor's Second Page, Symbols
     fn remount_config_color_symbols(&mut self, config: &SharedTuiSettings) -> Result<()> {
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::LibraryHighlightSymbol),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol)),
             Box::new(ConfigLibraryHighlightSymbol::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol)),
             Box::new(ConfigPlaylistHighlightSymbol::new(config.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::CurrentlyPlayingTrackSymbol),
+            Id::ConfigEditor(IdConfigEditor::Theme(
+                IdCETheme::CurrentlyPlayingTrackSymbol,
+            )),
             Box::new(ConfigCurrentlyPlayingTrackSymbol::new(config.clone())),
             Vec::new(),
         )?;
@@ -1510,69 +1540,96 @@ impl Model {
         self.app
             .umount(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryLabel))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryForeground))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryLabel,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryForeground,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryBorder))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryHighlight))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryBorder,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryHighlight,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistLabel))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistLabel,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistForeground))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistForeground,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistBorder))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlight))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ProgressLabel))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistBorder,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistHighlight,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ProgressLabel,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ProgressForeground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ProgressBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ProgressBorder))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ProgressForeground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ProgressBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ProgressBorder,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LyricLabel))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LyricForeground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LyricBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LyricBorder))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LyricLabel,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LyricForeground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LyricBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LyricBorder,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ImportantPopupLabel))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ImportantPopupForeground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ImportantPopupLabel,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ImportantPopupForeground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ImportantPopupBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ImportantPopupBorder,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackLabel))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackForeground))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::FallbackLabel,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::FallbackForeground,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackBackground))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackBorder))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::FallbackHighlight))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::FallbackBackground,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::FallbackBorder,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::FallbackHighlight,
+        )))?;
 
         self.umount_config_color_symbols()?;
 
@@ -1581,13 +1638,15 @@ impl Model {
 
     /// Unmount the Config-Editor's Second Page, Symbols
     pub fn umount_config_color_symbols(&mut self) -> Result<()> {
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::LibraryHighlightSymbol))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol))?;
-        self.app.umount(&Id::ConfigEditor(
-            IdConfigEditor::CurrentlyPlayingTrackSymbol,
-        ))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::LibraryHighlightSymbol,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::PlaylistHighlightSymbol,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::CurrentlyPlayingTrackSymbol,
+        )))?;
 
         Ok(())
     }

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -37,7 +37,7 @@ use tuirealm::{AttrValue, Attribute, Component, Event, MockComponent, State, Sta
 use crate::ui::components::vendored::tui_realm_stdlib_input::Input;
 use crate::ui::ids::{Id, IdCETheme, IdConfigEditor};
 use crate::ui::model::{Model, UserEvent};
-use crate::ui::msg::{ConfigEditorMsg, Msg};
+use crate::ui::msg::{ConfigEditorMsg, KFMsg, Msg};
 
 const COLOR_LIST: [ColorTermusic; 19] = [
     ColorTermusic::Reset,
@@ -152,13 +152,13 @@ impl Component<Msg, UserEvent> for CEThemeSelectTable {
                 self.perform(Cmd::GoTo(Position::End))
             }
             Event::Keyboard(KeyEvent { code: Key::Tab, .. }) => {
-                return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeSelectBlurDown));
+                return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)));
             }
             Event::Keyboard(KeyEvent {
                 code: Key::BackTab,
                 modifiers: KeyModifiers::SHIFT,
             }) => {
-                return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeSelectBlurUp));
+                return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)));
             }
 
             Event::Keyboard(KeyEvent {
@@ -425,8 +425,8 @@ impl ConfigLibraryForeground {
                 IdConfigEditor::Theme(IdCETheme::LibraryForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -452,8 +452,8 @@ impl ConfigLibraryBackground {
                 IdConfigEditor::Theme(IdCETheme::LibraryBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -479,8 +479,8 @@ impl ConfigLibraryBorder {
                 IdConfigEditor::Theme(IdCETheme::LibraryBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -506,8 +506,8 @@ impl ConfigLibraryHighlight {
                 IdConfigEditor::Theme(IdCETheme::LibraryHighlight),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -554,8 +554,8 @@ impl ConfigPlaylistForeground {
                 IdConfigEditor::Theme(IdCETheme::PlaylistForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -581,8 +581,8 @@ impl ConfigPlaylistBackground {
                 IdConfigEditor::Theme(IdCETheme::PlaylistBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -608,8 +608,8 @@ impl ConfigPlaylistBorder {
                 IdConfigEditor::Theme(IdCETheme::PlaylistBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -635,8 +635,8 @@ impl ConfigPlaylistHighlight {
                 IdConfigEditor::Theme(IdCETheme::PlaylistHighlight),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -683,8 +683,8 @@ impl ConfigProgressForeground {
                 IdConfigEditor::Theme(IdCETheme::ProgressForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -710,8 +710,8 @@ impl ConfigProgressBackground {
                 IdConfigEditor::Theme(IdCETheme::ProgressBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -737,8 +737,8 @@ impl ConfigProgressBorder {
                 IdConfigEditor::Theme(IdCETheme::ProgressBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ProgressBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -785,8 +785,8 @@ impl ConfigLyricForeground {
                 IdConfigEditor::Theme(IdCETheme::LyricForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LyricForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LyricForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -812,8 +812,8 @@ impl ConfigLyricBackground {
                 IdConfigEditor::Theme(IdCETheme::LyricBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LyricBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LyricBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -839,8 +839,8 @@ impl ConfigLyricBorder {
                 IdConfigEditor::Theme(IdCETheme::LyricBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::LyricBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::LyricBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1004,30 +1004,10 @@ impl Component<Msg, UserEvent> for ConfigInputHighlight {
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
-            }) => match self.id {
-                IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightSymbolBlurDown),
-                ),
-                IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightSymbolBlurDown),
-                ),
-                IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown),
-                ),
-                _ => None,
-            },
-            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => match self.id {
-                IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::LibraryHighlightSymbolBlurUp),
-                ),
-                IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::PlaylistHighlightSymbolBlurUp),
-                ),
-                IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => Some(
-                    Msg::ConfigEditor(ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp),
-                ),
-                _ => None,
-            },
+            }) => Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next))),
+            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
+                Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)))
+            }
 
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..
@@ -1144,8 +1124,8 @@ impl ConfigImportantPopupForeground {
                 IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1171,8 +1151,8 @@ impl ConfigImportantPopupBackground {
                 IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1198,8 +1178,8 @@ impl ConfigImportantPopupBorder {
                 IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::ImportantPopupBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1246,8 +1226,8 @@ impl ConfigFallbackForeground {
                 IdConfigEditor::Theme(IdCETheme::FallbackForeground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackForegroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackForegroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1273,8 +1253,8 @@ impl ConfigFallbackBackground {
                 IdConfigEditor::Theme(IdCETheme::FallbackBackground),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackBackgroundBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackBackgroundBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1300,8 +1280,8 @@ impl ConfigFallbackBorder {
                 IdConfigEditor::Theme(IdCETheme::FallbackBorder),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackBorderBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackBorderBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }
@@ -1327,8 +1307,8 @@ impl ConfigFallbackHighlight {
                 IdConfigEditor::Theme(IdCETheme::FallbackHighlight),
                 color,
                 config,
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackHighlightBlurDown),
-                Msg::ConfigEditor(ConfigEditorMsg::FallbackHighlightBlurUp),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)),
+                Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)),
             ),
         }
     }

--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -1350,7 +1350,7 @@ impl Model {
     ) -> Result<()> {
         // Mount color page
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::CEThemeSelect),
+            Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ThemeSelectTable)),
             Box::new(CEThemeSelectTable::new(config.clone())),
             Vec::new(),
         )?;
@@ -1537,8 +1537,9 @@ impl Model {
 
     /// Unmount the Config-Editor's Second Page, the Theme, Color & Symbol Options
     pub(super) fn umount_config_color(&mut self) -> Result<()> {
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
+            IdCETheme::ThemeSelectTable,
+        )))?;
 
         self.app.umount(&Id::ConfigEditor(IdConfigEditor::Theme(
             IdCETheme::LibraryLabel,

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -34,7 +34,7 @@ use tuirealm::{
 
 use crate::CombinedSettings;
 use crate::ui::components::vendored::tui_realm_stdlib_input::Input;
-use crate::ui::ids::{Id, IdConfigEditor};
+use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor};
 use crate::ui::model::{Model, UserEvent};
 use crate::ui::msg::{ConfigEditorMsg, Msg};
 
@@ -924,97 +924,97 @@ impl Model {
     pub(super) fn remount_config_general(&mut self) -> Result<()> {
         // Mount general page
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::MusicDir),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::MusicDir)),
             Box::new(MusicDir::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ExitConfirmation),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExitConfirmation)),
             Box::new(ExitConfirmation::new(self.config_tui.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)),
             Box::new(PlaylistDisplaySymbol::new(self.config_tui.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomTrack)),
             Box::new(PlaylistRandomTrack::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomAlbum)),
             Box::new(PlaylistRandomAlbum::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PodcastDir),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastDir)),
             Box::new(PodcastDir::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastSimulDownload)),
             Box::new(PodcastSimulDownload::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastMaxRetries)),
             Box::new(PodcastMaxRetries::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::AlbumPhotoAlign)),
             Box::new(AlbumPhotoAlign::new(self.config_tui.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::SaveLastPosition),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SaveLastPosition)),
             Box::new(SaveLastPosition::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::SeekStep),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SeekStep)),
             Box::new(ConfigSeekStep::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::KillDamon),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)),
             Box::new(KillDaemon::new(self.config_tui.clone())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlayerUseMpris),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)),
             Box::new(PlayerUseMpris::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)),
             Box::new(PlayerUseDiscord::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::PlayerPort),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)),
             Box::new(PlayerPort::new(self.get_combined_settings())),
             Vec::new(),
         )?;
 
         self.app.remount(
-            Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs),
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)),
             Box::new(ExtraYtdlpArgs::new(self.get_combined_settings())),
             Vec::new(),
         )?;
@@ -1024,49 +1024,65 @@ impl Model {
 
     /// Unmount the Config-Editor's First Page, the General Options
     pub(super) fn umount_config_general(&mut self) -> Result<()> {
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::MusicDir))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::MusicDir,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ExitConfirmation))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::ExitConfirmation,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlaylistDisplaySymbol,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlaylistRandomAlbum,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlaylistRandomTrack,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PodcastDir))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries))?;
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PodcastDir,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PodcastSimulDownload,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PodcastMaxRetries,
+        )))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::AlbumPhotoAlign,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::SaveLastPosition))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::SaveLastPosition,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::SeekStep))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::SeekStep,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::KillDamon))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::KillDamon,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlayerUseMpris))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlayerUseMpris,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlayerUseDiscord,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::PlayerPort))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PlayerPort,
+        )))?;
 
-        self.app
-            .umount(&Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs))?;
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::ExtraYtdlpArgs,
+        )))?;
 
         Ok(())
     }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -36,7 +36,7 @@ use crate::CombinedSettings;
 use crate::ui::components::vendored::tui_realm_stdlib_input::Input;
 use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor};
 use crate::ui::model::{Model, UserEvent};
-use crate::ui::msg::{ConfigEditorMsg, Msg};
+use crate::ui::msg::{ConfigEditorMsg, KFMsg, Msg};
 
 #[derive(MockComponent)]
 pub struct MusicDir {
@@ -85,8 +85,8 @@ impl Component<Msg, UserEvent> for MusicDir {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::MusicDirBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -197,8 +197,8 @@ impl Component<Msg, UserEvent> for ExitConfirmation {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::ExitConfirmationBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -285,8 +285,8 @@ impl Component<Msg, UserEvent> for PlaylistDisplaySymbol {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistDisplaySymbolBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -336,8 +336,8 @@ impl Component<Msg, UserEvent> for PlaylistRandomTrack {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomTrackBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -390,8 +390,8 @@ impl Component<Msg, UserEvent> for PlaylistRandomAlbum {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlaylistRandomAlbumBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -444,8 +444,8 @@ impl Component<Msg, UserEvent> for PodcastDir {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastDirBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -498,8 +498,8 @@ impl Component<Msg, UserEvent> for PodcastSimulDownload {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastSimulDownloadBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -552,8 +552,8 @@ impl Component<Msg, UserEvent> for PodcastMaxRetries {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PodcastMaxRetriesBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -596,8 +596,8 @@ impl Component<Msg, UserEvent> for AlbumPhotoAlign {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::AlbumPhotoAlignBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -650,8 +650,8 @@ impl Component<Msg, UserEvent> for SaveLastPosition {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::SaveLastPositionBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::SaveLastPosotionBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -696,8 +696,8 @@ impl Component<Msg, UserEvent> for ConfigSeekStep {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::SeekStepBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -735,8 +735,8 @@ impl Component<Msg, UserEvent> for KillDaemon {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::KillDaemonBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -777,8 +777,8 @@ impl Component<Msg, UserEvent> for PlayerUseMpris {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerUseMprisBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -819,8 +819,8 @@ impl Component<Msg, UserEvent> for PlayerUseDiscord {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerUseDiscordBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -866,8 +866,8 @@ impl Component<Msg, UserEvent> for PlayerPort {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::PlayerPortBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }
@@ -913,8 +913,8 @@ impl Component<Msg, UserEvent> for ExtraYtdlpArgs {
             &mut self.component,
             ev,
             &self.config.read().settings.keys,
-            Msg::ConfigEditor(ConfigEditorMsg::ExtraYtdlpArgsBlurDown),
-            Msg::ConfigEditor(ConfigEditorMsg::ExtraYtdlpArgsBlurUp),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
         )
     }
 }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -271,7 +271,7 @@ impl PlaylistDisplaySymbol {
             .choices(["Yes", "No"])
             .foreground(config_r.settings.theme.library_highlight())
             .rewind(true)
-            .title(" Display symbol in playlist title? ", Alignment::Left)
+            .title(" Use symbols for playlist loop mode? ", Alignment::Left)
             .value(usize::from(!enabled));
 
         drop(config_r);
@@ -473,7 +473,7 @@ impl PodcastSimulDownload {
                     "between 1 ~ 5 suggested",
                     Style::default().fg(Color::Rgb(128, 128, 128)),
                 )
-                .title(" Podcast Simultanious Download: ", Alignment::Left)
+                .title(" Podcast Simultaneous Download: ", Alignment::Left)
                 .value(
                     config
                         .server
@@ -582,7 +582,7 @@ impl AlbumPhotoAlign {
             .choices(["BottomRight", "BottomLeft", "TopRight", "TopLeft"])
             .foreground(config_r.settings.theme.library_highlight())
             .rewind(true)
-            .title(" Album Photo Align: ", Alignment::Left)
+            .title(" Coverart Align: ", Alignment::Left)
             .value(align);
 
         drop(config_r);
@@ -721,7 +721,7 @@ impl KillDaemon {
             .choices(["Yes", "No"])
             .foreground(config_r.settings.theme.library_highlight())
             .rewind(true)
-            .title(" Kill daemon when quit termusic? ", Alignment::Left)
+            .title(" Stop Server on TUI exit? ", Alignment::Left)
             .value(usize::from(!enabled));
 
         drop(config_r);

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -761,7 +761,7 @@ impl PlayerUseMpris {
             .choices(["Yes", "No"])
             .foreground(config_tui.settings.theme.library_highlight())
             .rewind(true)
-            .title(" Support Mpris? ", Alignment::Left)
+            .title(" Support Media Controls? ", Alignment::Left)
             .value(usize::from(!enabled));
 
         drop(config_tui);

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1479,7 +1479,7 @@ impl ConfigGlobalPlayerTogglePause {
     pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
-                " Pause Toggle ",
+                " Toggle Pause/Play ",
                 IdKey::Global(IdKeyGlobal::PlayerTogglePause),
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::KeyFocusGlobal(KFMsg::Next)),
@@ -1578,7 +1578,7 @@ impl ConfigGlobalVolumeUp {
     pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
-                " Volume + ",
+                " Increase Volume ",
                 IdKey::Global(IdKeyGlobal::PlayerVolumeUp),
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::KeyFocusGlobal(KFMsg::Next)),
@@ -1603,7 +1603,7 @@ impl ConfigGlobalVolumeDown {
     pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
-                " Volume - ",
+                " Decrease Volume ",
                 IdKey::Global(IdKeyGlobal::PlayerVolumeDown),
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::KeyFocusGlobal(KFMsg::Next)),
@@ -1678,7 +1678,7 @@ impl ConfigGlobalPlayerSpeedUp {
     pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
-                " Speed Up ",
+                " Increase Playback Speed ",
                 IdKey::Global(IdKeyGlobal::PlayerSpeedUp),
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::KeyFocusGlobal(KFMsg::Next)),
@@ -1703,7 +1703,7 @@ impl ConfigGlobalPlayerSpeedDown {
     pub fn new(config: SharedTuiSettings) -> Self {
         Self {
             component: KEModifierSelect::new(
-                " Speed Down ",
+                " Decrease Playback Speed ",
                 IdKey::Global(IdKeyGlobal::PlayerSpeedDown),
                 config,
                 Msg::ConfigEditor(ConfigEditorMsg::KeyFocusGlobal(KFMsg::Next)),

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -8,7 +8,7 @@ use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
 use termusiclib::utils::get_app_config_path;
 
 use crate::ui::Model;
-use crate::ui::ids::{Id, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::msg::{ConfigEditorMsg, KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, Msg};
 use crate::ui::tui_cmd::TuiCmd;
 
@@ -41,95 +41,127 @@ impl Model {
             // Handle focus of general page
             ConfigEditorMsg::ExtraYtdlpArgsBlurDown | ConfigEditorMsg::ExitConfirmationBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::MusicDir))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::MusicDir,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::MusicDirBlurDown | ConfigEditorMsg::PlaylistDisplaySymbolBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ExitConfirmation))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::ExitConfirmation,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::ExitConfirmationBlurDown
             | ConfigEditorMsg::PlaylistRandomTrackBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlaylistDisplaySymbol,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistDisplaySymbolBlurDown
             | ConfigEditorMsg::PlaylistRandomAlbumBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlaylistRandomTrack,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistRandomTrackBlurDown | ConfigEditorMsg::PodcastDirBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlaylistRandomAlbum,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistRandomAlbumBlurDown
             | ConfigEditorMsg::PodcastSimulDownloadBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PodcastDir))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PodcastDir,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PodcastDirBlurDown | ConfigEditorMsg::PodcastMaxRetriesBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PodcastSimulDownload,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PodcastSimulDownloadBlurDown
             | ConfigEditorMsg::AlbumPhotoAlignBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PodcastMaxRetries,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::PodcastMaxRetriesBlurDown
             | ConfigEditorMsg::SaveLastPosotionBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::AlbumPhotoAlign,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::AlbumPhotoAlignBlurDown | ConfigEditorMsg::SeekStepBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::SaveLastPosition))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::SaveLastPosition,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::SaveLastPositionBlurDown | ConfigEditorMsg::KillDaemonBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::SeekStep))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::SeekStep,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::SeekStepBlurDown | ConfigEditorMsg::PlayerUseMprisBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::KillDamon))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::KillDamon,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::KillDaemonBlurDown | ConfigEditorMsg::PlayerUseDiscordBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlayerUseMpris))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlayerUseMpris,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::PlayerUseMprisBlurDown | ConfigEditorMsg::PlayerPortBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlayerUseDiscord,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::PlayerUseDiscordBlurDown | ConfigEditorMsg::ExtraYtdlpArgsBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlayerPort))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::PlayerPort,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::PlayerPortBlurDown | ConfigEditorMsg::MusicDirBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs))
+                    .active(&Id::ConfigEditor(IdConfigEditor::General(
+                        IdCEGeneral::ExtraYtdlpArgs,
+                    )))
                     .ok();
             }
 

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -8,7 +8,7 @@ use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
 use termusiclib::utils::get_app_config_path;
 
 use crate::ui::Model;
-use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{Id, IdCEGeneral, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::msg::{ConfigEditorMsg, KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, Msg};
 use crate::ui::tui_cmd::TuiCmd;
 
@@ -213,7 +213,9 @@ impl Model {
             // Focus of color page
             ConfigEditorMsg::ThemeSelectBlurDown | ConfigEditorMsg::LibraryBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LibraryForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LibraryForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryForegroundBlurUp
@@ -224,138 +226,182 @@ impl Model {
             }
             ConfigEditorMsg::LibraryForegroundBlurDown | ConfigEditorMsg::LibraryBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LibraryBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LibraryBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryBackgroundBlurDown
             | ConfigEditorMsg::LibraryHighlightBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LibraryBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LibraryBorder,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryBorderBlurDown
             | ConfigEditorMsg::LibraryHighlightSymbolBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LibraryHighlight))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LibraryHighlight,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryHighlightBlurDown
             | ConfigEditorMsg::PlaylistForegroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LibraryHighlightSymbol))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LibraryHighlightSymbol,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryHighlightSymbolBlurDown
             | ConfigEditorMsg::PlaylistBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::PlaylistForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistForegroundBlurDown | ConfigEditorMsg::PlaylistBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::PlaylistBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistBackgroundBlurDown
             | ConfigEditorMsg::PlaylistHighlightBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::PlaylistBorder,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistBorderBlurDown
             | ConfigEditorMsg::PlaylistHighlightSymbolBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlight))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::PlaylistHighlight,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistHighlightBlurDown
             | ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::PlaylistHighlightSymbol,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::PlaylistHighlightSymbolBlurDown
             | ConfigEditorMsg::ProgressForegroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(
-                        IdConfigEditor::CurrentlyPlayingTrackSymbol,
-                    ))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::CurrentlyPlayingTrackSymbol,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown
             | ConfigEditorMsg::ProgressBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ProgressForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ProgressForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::ProgressForegroundBlurDown | ConfigEditorMsg::ProgressBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ProgressBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ProgressBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::ProgressBackgroundBlurDown
             | ConfigEditorMsg::LyricForegroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ProgressBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ProgressBorder,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::ProgressBorderBlurDown | ConfigEditorMsg::LyricBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LyricForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LyricForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LyricForegroundBlurDown | ConfigEditorMsg::LyricBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LyricBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LyricBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LyricBackgroundBlurDown
             | ConfigEditorMsg::ImportantPopupForegroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::LyricBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::LyricBorder,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::LyricBorderBlurDown
             | ConfigEditorMsg::ImportantPopupBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ImportantPopupForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::ImportantPopupForegroundBlurDown
             | ConfigEditorMsg::ImportantPopupBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ImportantPopupBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::ImportantPopupBackgroundBlurDown
             | ConfigEditorMsg::FallbackForegroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ImportantPopupBorder,
+                    )))
                     .ok();
             }
 
             ConfigEditorMsg::ImportantPopupBorderBlurDown
             | ConfigEditorMsg::FallbackBackgroundBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackForeground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::FallbackForeground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::FallbackForegroundBlurDown | ConfigEditorMsg::FallbackBorderBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackBackground))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::FallbackBackground,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::FallbackBackgroundBlurDown
             | ConfigEditorMsg::FallbackHighlightBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackBorder))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::FallbackBorder,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::FallbackBorderBlurDown | ConfigEditorMsg::ThemeSelectBlurUp => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::FallbackHighlight))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::FallbackHighlight,
+                    )))
                     .ok();
             }
 
@@ -370,13 +416,13 @@ impl Model {
                 self.config_editor.config_changed = true;
 
                 match id {
-                    IdConfigEditor::LibraryHighlightSymbol => {
+                    IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol) => {
                         self.config_editor.theme.style.library.highlight_symbol = symbol;
                     }
-                    IdConfigEditor::PlaylistHighlightSymbol => {
+                    IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol) => {
                         self.config_editor.theme.style.playlist.highlight_symbol = symbol;
                     }
-                    IdConfigEditor::CurrentlyPlayingTrackSymbol => {
+                    IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol) => {
                         self.config_editor.theme.style.playlist.current_track_symbol = symbol;
                     }
                     _ => {}
@@ -665,46 +711,46 @@ impl Model {
         let style = &mut self.config_editor.theme.style;
 
         match id {
-            IdConfigEditor::LibraryForeground => {
+            IdConfigEditor::Theme(IdCETheme::LibraryForeground) => {
                 style.library.foreground_color = color_config;
             }
-            IdConfigEditor::LibraryBackground => {
+            IdConfigEditor::Theme(IdCETheme::LibraryBackground) => {
                 style.library.background_color = color_config;
             }
-            IdConfigEditor::LibraryBorder => {
+            IdConfigEditor::Theme(IdCETheme::LibraryBorder) => {
                 style.library.border_color = color_config;
             }
-            IdConfigEditor::LibraryHighlight => {
+            IdConfigEditor::Theme(IdCETheme::LibraryHighlight) => {
                 style.library.highlight_color = color_config;
             }
-            IdConfigEditor::PlaylistForeground => {
+            IdConfigEditor::Theme(IdCETheme::PlaylistForeground) => {
                 style.playlist.foreground_color = color_config;
             }
-            IdConfigEditor::PlaylistBackground => {
+            IdConfigEditor::Theme(IdCETheme::PlaylistBackground) => {
                 style.playlist.background_color = color_config;
             }
-            IdConfigEditor::PlaylistBorder => {
+            IdConfigEditor::Theme(IdCETheme::PlaylistBorder) => {
                 style.playlist.border_color = color_config;
             }
-            IdConfigEditor::PlaylistHighlight => {
+            IdConfigEditor::Theme(IdCETheme::PlaylistHighlight) => {
                 style.playlist.highlight_color = color_config;
             }
-            IdConfigEditor::ProgressForeground => {
+            IdConfigEditor::Theme(IdCETheme::ProgressForeground) => {
                 style.progress.foreground_color = color_config;
             }
-            IdConfigEditor::ProgressBackground => {
+            IdConfigEditor::Theme(IdCETheme::ProgressBackground) => {
                 style.progress.background_color = color_config;
             }
-            IdConfigEditor::ProgressBorder => {
+            IdConfigEditor::Theme(IdCETheme::ProgressBorder) => {
                 style.progress.border_color = color_config;
             }
-            IdConfigEditor::LyricForeground => {
+            IdConfigEditor::Theme(IdCETheme::LyricForeground) => {
                 style.lyric.foreground_color = color_config;
             }
-            IdConfigEditor::LyricBackground => {
+            IdConfigEditor::Theme(IdCETheme::LyricBackground) => {
                 style.lyric.background_color = color_config;
             }
-            IdConfigEditor::LyricBorder => {
+            IdConfigEditor::Theme(IdCETheme::LyricBorder) => {
                 style.lyric.border_color = color_config;
             }
 

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -11,6 +11,7 @@ use crate::ui::Model;
 use crate::ui::ids::{Id, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::msg::{
     ConfigEditorMsg, GENERAL_FOCUS_ORDER, KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, Msg,
+    THEME_FOCUS_ORDER,
 };
 use crate::ui::tui_cmd::TuiCmd;
 
@@ -40,8 +41,8 @@ impl Model {
             }
             ConfigEditorMsg::ChangeLayout => self.action_change_layout(),
             ConfigEditorMsg::ConfigChanged => self.config_editor.config_changed = true,
-            // Handle focus of general page
             ConfigEditorMsg::General(msg) => self.update_general(msg),
+            ConfigEditorMsg::Theme(msg) => self.update_theme(msg),
 
             ConfigEditorMsg::ConfigSaveOk => {
                 self.app
@@ -86,203 +87,6 @@ impl Model {
                     .umount(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))
                     .ok();
                 self.umount_config_editor();
-            }
-
-            // Focus of color page
-            ConfigEditorMsg::ThemeSelectBlurDown | ConfigEditorMsg::LibraryBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LibraryForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryForegroundBlurUp
-            | ConfigEditorMsg::FallbackHighlightBlurDown => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ThemeSelectTable,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryForegroundBlurDown | ConfigEditorMsg::LibraryBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LibraryBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryBackgroundBlurDown
-            | ConfigEditorMsg::LibraryHighlightBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LibraryBorder,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryBorderBlurDown
-            | ConfigEditorMsg::LibraryHighlightSymbolBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LibraryHighlight,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryHighlightBlurDown
-            | ConfigEditorMsg::PlaylistForegroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LibraryHighlightSymbol,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LibraryHighlightSymbolBlurDown
-            | ConfigEditorMsg::PlaylistBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::PlaylistForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::PlaylistForegroundBlurDown | ConfigEditorMsg::PlaylistBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::PlaylistBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::PlaylistBackgroundBlurDown
-            | ConfigEditorMsg::PlaylistHighlightBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::PlaylistBorder,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::PlaylistBorderBlurDown
-            | ConfigEditorMsg::PlaylistHighlightSymbolBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::PlaylistHighlight,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::PlaylistHighlightBlurDown
-            | ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::PlaylistHighlightSymbol,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::PlaylistHighlightSymbolBlurDown
-            | ConfigEditorMsg::ProgressForegroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::CurrentlyPlayingTrackSymbol,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::CurrentlyPlayingTrackSymbolBlurDown
-            | ConfigEditorMsg::ProgressBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ProgressForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::ProgressForegroundBlurDown | ConfigEditorMsg::ProgressBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ProgressBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::ProgressBackgroundBlurDown
-            | ConfigEditorMsg::LyricForegroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ProgressBorder,
-                    )))
-                    .ok();
-            }
-
-            ConfigEditorMsg::ProgressBorderBlurDown | ConfigEditorMsg::LyricBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LyricForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LyricForegroundBlurDown | ConfigEditorMsg::LyricBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LyricBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::LyricBackgroundBlurDown
-            | ConfigEditorMsg::ImportantPopupForegroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::LyricBorder,
-                    )))
-                    .ok();
-            }
-
-            ConfigEditorMsg::LyricBorderBlurDown
-            | ConfigEditorMsg::ImportantPopupBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ImportantPopupForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::ImportantPopupForegroundBlurDown
-            | ConfigEditorMsg::ImportantPopupBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ImportantPopupBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::ImportantPopupBackgroundBlurDown
-            | ConfigEditorMsg::FallbackForegroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::ImportantPopupBorder,
-                    )))
-                    .ok();
-            }
-
-            ConfigEditorMsg::ImportantPopupBorderBlurDown
-            | ConfigEditorMsg::FallbackBackgroundBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::FallbackForeground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::FallbackForegroundBlurDown | ConfigEditorMsg::FallbackBorderBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::FallbackBackground,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::FallbackBackgroundBlurDown
-            | ConfigEditorMsg::FallbackHighlightBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::FallbackBorder,
-                    )))
-                    .ok();
-            }
-            ConfigEditorMsg::FallbackBorderBlurDown | ConfigEditorMsg::ThemeSelectBlurUp => {
-                self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
-                        IdCETheme::FallbackHighlight,
-                    )))
-                    .ok();
             }
 
             ConfigEditorMsg::ThemeSelectLoad(index) => {
@@ -396,6 +200,41 @@ impl Model {
                 .skip_while(|v| **v != focus_elem)
                 .nth(1)
                 .unwrap_or(GENERAL_FOCUS_ORDER.last().unwrap()),
+        };
+
+        let _ = self.app.active(&Id::ConfigEditor(focus.into()));
+    }
+
+    /// Handle focus of the "Theme" tab
+    fn update_theme(&mut self, msg: KFMsg) {
+        let focus_elem = self.app.focus().and_then(|v| {
+            if let Id::ConfigEditor(IdConfigEditor::Theme(id)) = *v {
+                Some(id)
+            } else {
+                None
+            }
+        });
+
+        // fallback in case somehow the focus gets lost or is on a weird element, reset it to the first element
+        let Some(focus_elem) = focus_elem else {
+            let _ = self
+                .app
+                .active(&Id::ConfigEditor(THEME_FOCUS_ORDER[0].into()));
+            return;
+        };
+
+        let focus = match msg {
+            KFMsg::Next => THEME_FOCUS_ORDER
+                .iter()
+                .skip_while(|v| **v != focus_elem)
+                .nth(1)
+                .unwrap_or(&THEME_FOCUS_ORDER[0]),
+            KFMsg::Previous => THEME_FOCUS_ORDER
+                .iter()
+                .rev()
+                .skip_while(|v| **v != focus_elem)
+                .nth(1)
+                .unwrap_or(THEME_FOCUS_ORDER.last().unwrap()),
         };
 
         let _ = self.app.active(&Id::ConfigEditor(focus.into()));

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -41,8 +41,6 @@ impl Model {
             }
             ConfigEditorMsg::ChangeLayout => self.action_change_layout(),
             ConfigEditorMsg::ConfigChanged => self.config_editor.config_changed = true,
-            ConfigEditorMsg::General(msg) => self.update_general(msg),
-            ConfigEditorMsg::Theme(msg) => self.update_theme(msg),
 
             ConfigEditorMsg::ConfigSaveOk => {
                 self.app
@@ -114,6 +112,10 @@ impl Model {
             }
 
             ConfigEditorMsg::KeyChange(id, binding) => self.update_key(id, binding),
+
+            // Focus handling
+            ConfigEditorMsg::General(msg) => self.update_general(msg),
+            ConfigEditorMsg::Theme(msg) => self.update_theme(msg),
             ConfigEditorMsg::KeyFocusGlobal(msg) => self.update_key_focus_global(msg),
             ConfigEditorMsg::KeyFocusOther(msg) => self.update_key_focus_other(msg),
         }

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -221,7 +221,9 @@ impl Model {
             ConfigEditorMsg::LibraryForegroundBlurUp
             | ConfigEditorMsg::FallbackHighlightBlurDown => {
                 self.app
-                    .active(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))
+                    .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                        IdCETheme::ThemeSelectTable,
+                    )))
                     .ok();
             }
             ConfigEditorMsg::LibraryForegroundBlurDown | ConfigEditorMsg::LibraryBorderBlurUp => {

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -40,7 +40,7 @@ use crate::ui::components::config_editor::update::THEMES_WITHOUT_FILES;
 use crate::ui::components::raw::dynamic_height_grid::DynamicHeightGrid;
 use crate::ui::components::raw::uniform_dynamic_grid::UniformDynamicGrid;
 use crate::ui::components::{CEHeader, ConfigSavePopup, GlobalListener};
-use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{Id, IdCEGeneral, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::{ConfigEditorLayout, Model, UserEvent};
 use crate::ui::msg::{KFGLOBAL_FOCUS_ORDER, KFOTHER_FOCUS_ORDER, Msg};
 use crate::ui::utils::draw_area_in_absolute;
@@ -252,35 +252,59 @@ impl Model {
             };
         }
 
-        let library_foreground_len: u16 = is_expanded!(IdConfigEditor::LibraryForeground, 8, 3);
-        let library_background_len: u16 = is_expanded!(IdConfigEditor::LibraryBackground, 8, 3);
-        let library_border_len: u16 = is_expanded!(IdConfigEditor::LibraryBorder, 8, 3);
-        let library_highlight_len: u16 = is_expanded!(IdConfigEditor::LibraryHighlight, 8, 3);
+        let library_foreground_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LibraryForeground), 8, 3);
+        let library_background_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LibraryBackground), 8, 3);
+        let library_border_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LibraryBorder), 8, 3);
+        let library_highlight_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LibraryHighlight), 8, 3);
 
-        let playlist_foreground_len: u16 = is_expanded!(IdConfigEditor::PlaylistForeground, 8, 3);
-        let playlist_background_len: u16 = is_expanded!(IdConfigEditor::PlaylistBackground, 8, 3);
-        let playlist_border_len: u16 = is_expanded!(IdConfigEditor::PlaylistBorder, 8, 3);
-        let playlist_highlight_len: u16 = is_expanded!(IdConfigEditor::PlaylistHighlight, 8, 3);
+        let playlist_foreground_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::PlaylistForeground), 8, 3);
+        let playlist_background_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::PlaylistBackground), 8, 3);
+        let playlist_border_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::PlaylistBorder), 8, 3);
+        let playlist_highlight_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::PlaylistHighlight), 8, 3);
 
-        let progress_foreground_len: u16 = is_expanded!(IdConfigEditor::ProgressForeground, 8, 3);
-        let progress_background_len: u16 = is_expanded!(IdConfigEditor::ProgressBackground, 8, 3);
-        let progress_border_len: u16 = is_expanded!(IdConfigEditor::ProgressBorder, 8, 3);
+        let progress_foreground_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::ProgressForeground), 8, 3);
+        let progress_background_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::ProgressBackground), 8, 3);
+        let progress_border_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::ProgressBorder), 8, 3);
 
-        let lyric_foreground_len: u16 = is_expanded!(IdConfigEditor::LyricForeground, 8, 3);
-        let lyric_background_len: u16 = is_expanded!(IdConfigEditor::LyricBackground, 8, 3);
-        let lyric_border_len: u16 = is_expanded!(IdConfigEditor::LyricBorder, 8, 3);
+        let lyric_foreground_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LyricForeground), 8, 3);
+        let lyric_background_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LyricBackground), 8, 3);
+        let lyric_border_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::LyricBorder), 8, 3);
 
-        let important_popup_foreground_len: u16 =
-            is_expanded!(IdConfigEditor::ImportantPopupForeground, 8, 3);
-        let important_popup_background_len: u16 =
-            is_expanded!(IdConfigEditor::ImportantPopupBackground, 8, 3);
+        let important_popup_foreground_len: u16 = is_expanded!(
+            IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground),
+            8,
+            3
+        );
+        let important_popup_background_len: u16 = is_expanded!(
+            IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground),
+            8,
+            3
+        );
         let important_popup_border_len: u16 =
-            is_expanded!(IdConfigEditor::ImportantPopupBorder, 8, 3);
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder), 8, 3);
 
-        let fallback_foreground_len: u16 = is_expanded!(IdConfigEditor::FallbackForeground, 8, 3);
-        let fallback_background_len: u16 = is_expanded!(IdConfigEditor::FallbackBackground, 8, 3);
-        let fallback_border_len: u16 = is_expanded!(IdConfigEditor::FallbackBorder, 8, 3);
-        let fallback_highlight_len: u16 = is_expanded!(IdConfigEditor::FallbackHighlight, 8, 3);
+        let fallback_foreground_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::FallbackForeground), 8, 3);
+        let fallback_background_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::FallbackBackground), 8, 3);
+        let fallback_border_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::FallbackBorder), 8, 3);
+        let fallback_highlight_len: u16 =
+            is_expanded!(IdConfigEditor::Theme(IdCETheme::FallbackHighlight), 8, 3);
 
         let [left, right] = Layout::horizontal([Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
             .areas(chunk_main);
@@ -348,39 +372,42 @@ impl Model {
                 }
             })
             .and_then(|v| {
-                Some(match v {
-                    IdConfigEditor::LibraryLabel
-                    | IdConfigEditor::LibraryForeground
-                    | IdConfigEditor::LibraryBackground
-                    | IdConfigEditor::LibraryBorder
-                    | IdConfigEditor::LibraryHighlight
-                    | IdConfigEditor::LibraryHighlightSymbol => 0,
-                    IdConfigEditor::PlaylistLabel
-                    | IdConfigEditor::PlaylistForeground
-                    | IdConfigEditor::PlaylistBackground
-                    | IdConfigEditor::PlaylistBorder
-                    | IdConfigEditor::PlaylistHighlight
-                    | IdConfigEditor::PlaylistHighlightSymbol
-                    | IdConfigEditor::CurrentlyPlayingTrackSymbol => 1,
-                    IdConfigEditor::ProgressLabel
-                    | IdConfigEditor::ProgressForeground
-                    | IdConfigEditor::ProgressBackground
-                    | IdConfigEditor::ProgressBorder => 2,
-                    IdConfigEditor::LyricLabel
-                    | IdConfigEditor::LyricForeground
-                    | IdConfigEditor::LyricBackground
-                    | IdConfigEditor::LyricBorder => 3,
-                    IdConfigEditor::ImportantPopupLabel
-                    | IdConfigEditor::ImportantPopupForeground
-                    | IdConfigEditor::ImportantPopupBackground
-                    | IdConfigEditor::ImportantPopupBorder => 4,
-                    IdConfigEditor::FallbackLabel
-                    | IdConfigEditor::FallbackForeground
-                    | IdConfigEditor::FallbackBackground
-                    | IdConfigEditor::FallbackBorder
-                    | IdConfigEditor::FallbackHighlight => 5,
-                    _ => return None,
-                })
+                if let IdConfigEditor::Theme(v) = v {
+                    Some(match v {
+                        IdCETheme::LibraryLabel
+                        | IdCETheme::LibraryForeground
+                        | IdCETheme::LibraryBackground
+                        | IdCETheme::LibraryBorder
+                        | IdCETheme::LibraryHighlight
+                        | IdCETheme::LibraryHighlightSymbol => 0,
+                        IdCETheme::PlaylistLabel
+                        | IdCETheme::PlaylistForeground
+                        | IdCETheme::PlaylistBackground
+                        | IdCETheme::PlaylistBorder
+                        | IdCETheme::PlaylistHighlight
+                        | IdCETheme::PlaylistHighlightSymbol
+                        | IdCETheme::CurrentlyPlayingTrackSymbol => 1,
+                        IdCETheme::ProgressLabel
+                        | IdCETheme::ProgressForeground
+                        | IdCETheme::ProgressBackground
+                        | IdCETheme::ProgressBorder => 2,
+                        IdCETheme::LyricLabel
+                        | IdCETheme::LyricForeground
+                        | IdCETheme::LyricBackground
+                        | IdCETheme::LyricBorder => 3,
+                        IdCETheme::ImportantPopupLabel
+                        | IdCETheme::ImportantPopupForeground
+                        | IdCETheme::ImportantPopupBackground
+                        | IdCETheme::ImportantPopupBorder => 4,
+                        IdCETheme::FallbackLabel
+                        | IdCETheme::FallbackForeground
+                        | IdCETheme::FallbackBackground
+                        | IdCETheme::FallbackBorder
+                        | IdCETheme::FallbackHighlight => 5,
+                    })
+                } else {
+                    None
+                }
             });
 
         let cells = DynamicHeightGrid::new(elem_height, 16 + 2)
@@ -455,43 +482,43 @@ impl Model {
 
             &Id::ConfigEditor(IdConfigEditor::CEThemeSelect) => left,
 
-            &Id::ConfigEditor(IdConfigEditor::LibraryLabel) => chunks_library[0],
-            &Id::ConfigEditor(IdConfigEditor::LibraryForeground) => chunks_library[1],
-            &Id::ConfigEditor(IdConfigEditor::LibraryBackground) => chunks_library[2],
-            &Id::ConfigEditor(IdConfigEditor::LibraryBorder) => chunks_library[3],
-            &Id::ConfigEditor(IdConfigEditor::LibraryHighlight) => chunks_library[4],
-            &Id::ConfigEditor(IdConfigEditor::LibraryHighlightSymbol) => chunks_library[5],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryLabel)) => chunks_library[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryForeground)) => chunks_library[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryBackground)) => chunks_library[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryBorder)) => chunks_library[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryHighlight)) => chunks_library[4],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryHighlightSymbol)) => chunks_library[5],
 
-            &Id::ConfigEditor(IdConfigEditor::PlaylistLabel) => chunks_playlist[0],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistForeground) => chunks_playlist[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistLabel)) => chunks_playlist[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistForeground)) => chunks_playlist[1],
 
-            &Id::ConfigEditor(IdConfigEditor::PlaylistBackground) => chunks_playlist[2],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistBorder) => chunks_playlist[3],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistHighlight) => chunks_playlist[4],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistHighlightSymbol) => chunks_playlist[5],
-            &Id::ConfigEditor(IdConfigEditor::CurrentlyPlayingTrackSymbol) => chunks_playlist[6],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistBackground)) => chunks_playlist[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistBorder)) => chunks_playlist[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistHighlight)) => chunks_playlist[4],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::PlaylistHighlightSymbol)) => chunks_playlist[5],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::CurrentlyPlayingTrackSymbol)) => chunks_playlist[6],
 
-            &Id::ConfigEditor(IdConfigEditor::ProgressLabel) => chunks_progress[0],
-            &Id::ConfigEditor(IdConfigEditor::ProgressForeground) => chunks_progress[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressLabel)) => chunks_progress[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressForeground)) => chunks_progress[1],
 
-            &Id::ConfigEditor(IdConfigEditor::ProgressBackground) => chunks_progress[2],
-            &Id::ConfigEditor(IdConfigEditor::ProgressBorder) => chunks_progress[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressBackground)) => chunks_progress[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ProgressBorder)) => chunks_progress[3],
 
-            &Id::ConfigEditor(IdConfigEditor::LyricLabel) => chunks_lyric[0],
-            &Id::ConfigEditor(IdConfigEditor::LyricForeground) => chunks_lyric[1],
-            &Id::ConfigEditor(IdConfigEditor::LyricBackground) => chunks_lyric[2],
-            &Id::ConfigEditor(IdConfigEditor::LyricBorder) => chunks_lyric[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricLabel)) => chunks_lyric[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricForeground)) => chunks_lyric[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricBackground)) => chunks_lyric[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LyricBorder)) => chunks_lyric[3],
 
-            &Id::ConfigEditor(IdConfigEditor::ImportantPopupLabel) => chunks_important_popup[0],
-            &Id::ConfigEditor(IdConfigEditor::ImportantPopupForeground) => chunks_important_popup[1],
-            &Id::ConfigEditor(IdConfigEditor::ImportantPopupBackground) => chunks_important_popup[2],
-            &Id::ConfigEditor(IdConfigEditor::ImportantPopupBorder) => chunks_important_popup[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupLabel)) => chunks_important_popup[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupForeground)) => chunks_important_popup[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupBackground)) => chunks_important_popup[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ImportantPopupBorder)) => chunks_important_popup[3],
 
-            &Id::ConfigEditor(IdConfigEditor::FallbackLabel) => chunks_fallback[0],
-            &Id::ConfigEditor(IdConfigEditor::FallbackForeground) => chunks_fallback[1],
-            &Id::ConfigEditor(IdConfigEditor::FallbackBackground) => chunks_fallback[2],
-            &Id::ConfigEditor(IdConfigEditor::FallbackBorder) => chunks_fallback[3],
-            &Id::ConfigEditor(IdConfigEditor::FallbackHighlight) => chunks_fallback[4],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackLabel)) => chunks_fallback[0],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackForeground)) => chunks_fallback[1],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackBackground)) => chunks_fallback[2],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackBorder)) => chunks_fallback[3],
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::FallbackHighlight)) => chunks_fallback[4],
         }
     }
 

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -404,6 +404,7 @@ impl Model {
                         | IdCETheme::FallbackBackground
                         | IdCETheme::FallbackBorder
                         | IdCETheme::FallbackHighlight => 5,
+                        IdCETheme::ThemeSelectTable => return None,
                     })
                 } else {
                     None
@@ -480,7 +481,7 @@ impl Model {
         app_view! {
             app, f,
 
-            &Id::ConfigEditor(IdConfigEditor::CEThemeSelect) => left,
+            &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ThemeSelectTable)) => left,
 
             &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryLabel)) => chunks_library[0],
             &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::LibraryForeground)) => chunks_library[1],
@@ -631,7 +632,9 @@ impl Model {
                 .ok(),
             ConfigEditorLayout::Color => self
                 .app
-                .active(&Id::ConfigEditor(IdConfigEditor::CEThemeSelect))
+                .active(&Id::ConfigEditor(IdConfigEditor::Theme(
+                    IdCETheme::ThemeSelectTable,
+                )))
                 .ok(),
             ConfigEditorLayout::Key1 => self
                 .app
@@ -914,7 +917,7 @@ impl Model {
         let table = table.build();
         self.app
             .attr(
-                &Id::ConfigEditor(IdConfigEditor::CEThemeSelect),
+                &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ThemeSelectTable)),
                 Attribute::Content,
                 AttrValue::Table(table),
             )
@@ -940,7 +943,7 @@ impl Model {
         assert!(
             self.app
                 .attr(
-                    &Id::ConfigEditor(IdConfigEditor::CEThemeSelect),
+                    &Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ThemeSelectTable)),
                     Attribute::Value,
                     AttrValue::Payload(PropPayload::One(PropValue::Usize(index))),
                 )

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -1,3 +1,4 @@
+use std::net::IpAddr;
 /**
  * MIT License
  *
@@ -176,14 +177,15 @@ impl Model {
                         IdCEGeneral::PlayerUseMpris => 12,
                         IdCEGeneral::PlayerUseDiscord => 13,
                         IdCEGeneral::PlayerPort => 14,
-                        IdCEGeneral::ExtraYtdlpArgs => 15,
+                        IdCEGeneral::PlayerAddress => 15,
+                        IdCEGeneral::ExtraYtdlpArgs => 16,
                     })
                 } else {
                     None
                 }
             });
 
-        let cells = UniformDynamicGrid::new(16, 3, 56 + 2)
+        let cells = UniformDynamicGrid::new(17, 3, 56 + 2)
             .draw_row_low_space()
             .distribute_row_space()
             .focus_node(focus_elem)
@@ -213,8 +215,9 @@ impl Model {
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)) => cells[12],
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)) => cells[13],
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[14],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerAddress)) => cells[15],
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[15],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[16],
         }
     }
 
@@ -827,6 +830,14 @@ impl Model {
                 } else {
                     bail!(" It's not recommended to use ports below 1024 for the player. ");
                 }
+            }
+        }
+
+        if let Ok(State::One(StateValue::String(player_port))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::PlayerAddress),
+        )) {
+            if let Ok(addr) = player_port.parse::<IpAddr>() {
+                config_server.settings.com.address = addr;
             }
         }
 

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -181,14 +181,15 @@ impl Model {
                         IdCEGeneral::PlayerPort => 14,
                         IdCEGeneral::PlayerAddress => 15,
                         IdCEGeneral::PlayerProtocol => 16,
-                        IdCEGeneral::ExtraYtdlpArgs => 17,
+                        IdCEGeneral::PlayerUDSPath => 17,
+                        IdCEGeneral::ExtraYtdlpArgs => 18,
                     })
                 } else {
                     None
                 }
             });
 
-        let cells = UniformDynamicGrid::new(18, 3, 56 + 2)
+        let cells = UniformDynamicGrid::new(19, 3, 56 + 2)
             .draw_row_low_space()
             .distribute_row_space()
             .focus_node(focus_elem)
@@ -220,8 +221,9 @@ impl Model {
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[14],
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerAddress)) => cells[15],
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerProtocol)) => cells[16],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUDSPath)) => cells[17],
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[17],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[18],
         }
     }
 
@@ -861,6 +863,23 @@ impl Model {
                 _ => unreachable!(),
             };
             config_server.settings.com.protocol = protocol;
+        }
+
+        if let Ok(State::One(StateValue::String(podcast_dir))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::PlayerUDSPath),
+        )) {
+            let abs_path = shellexpand::path::tilde(&podcast_dir);
+
+            if !abs_path.has_root()
+                || abs_path.file_name().is_none()
+                || abs_path.extension().is_none_or(|v| v != "socket")
+            {
+                bail!(
+                    "Invalid UDS socket Path.\nPath need to be absolute and end with \".socket\"."
+                );
+            }
+
+            config_server.settings.com.socket_path = abs_path.into_owned();
         }
 
         if let Ok(State::One(StateValue::String(extra_ytdlp_args))) = self.app.state(

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -40,7 +40,7 @@ use crate::ui::components::config_editor::update::THEMES_WITHOUT_FILES;
 use crate::ui::components::raw::dynamic_height_grid::DynamicHeightGrid;
 use crate::ui::components::raw::uniform_dynamic_grid::UniformDynamicGrid;
 use crate::ui::components::{CEHeader, ConfigSavePopup, GlobalListener};
-use crate::ui::ids::{Id, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{Id, IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::{ConfigEditorLayout, Model, UserEvent};
 use crate::ui::msg::{KFGLOBAL_FOCUS_ORDER, KFOTHER_FOCUS_ORDER, Msg};
 use crate::ui::utils::draw_area_in_absolute;
@@ -159,25 +159,28 @@ impl Model {
                 }
             })
             .and_then(|v| {
-                Some(match v {
-                    IdConfigEditor::MusicDir => 0,
-                    IdConfigEditor::ExitConfirmation => 1,
-                    IdConfigEditor::PlaylistDisplaySymbol => 2,
-                    IdConfigEditor::PlaylistRandomTrack => 3,
-                    IdConfigEditor::PlaylistRandomAlbum => 4,
-                    IdConfigEditor::PodcastDir => 5,
-                    IdConfigEditor::PodcastSimulDownload => 6,
-                    IdConfigEditor::PodcastMaxRetries => 7,
-                    IdConfigEditor::AlbumPhotoAlign => 8,
-                    IdConfigEditor::SaveLastPosition => 9,
-                    IdConfigEditor::SeekStep => 10,
-                    IdConfigEditor::KillDamon => 11,
-                    IdConfigEditor::PlayerUseMpris => 12,
-                    IdConfigEditor::PlayerUseDiscord => 13,
-                    IdConfigEditor::PlayerPort => 14,
-                    IdConfigEditor::ExtraYtdlpArgs => 15,
-                    _ => return None,
-                })
+                if let IdConfigEditor::General(v) = v {
+                    Some(match v {
+                        IdCEGeneral::MusicDir => 0,
+                        IdCEGeneral::ExitConfirmation => 1,
+                        IdCEGeneral::PlaylistDisplaySymbol => 2,
+                        IdCEGeneral::PlaylistRandomTrack => 3,
+                        IdCEGeneral::PlaylistRandomAlbum => 4,
+                        IdCEGeneral::PodcastDir => 5,
+                        IdCEGeneral::PodcastSimulDownload => 6,
+                        IdCEGeneral::PodcastMaxRetries => 7,
+                        IdCEGeneral::AlbumPhotoAlign => 8,
+                        IdCEGeneral::SaveLastPosition => 9,
+                        IdCEGeneral::SeekStep => 10,
+                        IdCEGeneral::KillDamon => 11,
+                        IdCEGeneral::PlayerUseMpris => 12,
+                        IdCEGeneral::PlayerUseDiscord => 13,
+                        IdCEGeneral::PlayerPort => 14,
+                        IdCEGeneral::ExtraYtdlpArgs => 15,
+                    })
+                } else {
+                    None
+                }
             });
 
         let cells = UniformDynamicGrid::new(16, 3, 56 + 2)
@@ -189,29 +192,29 @@ impl Model {
         app_view! {
             app, f,
 
-            &Id::ConfigEditor(IdConfigEditor::MusicDir) => cells[0],
-            &Id::ConfigEditor(IdConfigEditor::ExitConfirmation) => cells[1],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::MusicDir)) => cells[0],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExitConfirmation)) => cells[1],
 
-            &Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol) => cells[2],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack) => cells[3],
-            &Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum) => cells[4],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)) => cells[2],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomTrack)) => cells[3],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomAlbum)) => cells[4],
 
-            &Id::ConfigEditor(IdConfigEditor::PodcastDir) => cells[5],
-            &Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload) => cells[6],
-            &Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries) => cells[7],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastDir)) => cells[5],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastSimulDownload)) => cells[6],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastMaxRetries)) => cells[7],
 
-            &Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign) => cells[8],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::AlbumPhotoAlign)) => cells[8],
 
-            &Id::ConfigEditor(IdConfigEditor::SaveLastPosition) => cells[9],
-            &Id::ConfigEditor(IdConfigEditor::SeekStep) => cells[10],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SaveLastPosition)) => cells[9],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SeekStep)) => cells[10],
 
-            &Id::ConfigEditor(IdConfigEditor::KillDamon) => cells[11],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)) => cells[11],
 
-            &Id::ConfigEditor(IdConfigEditor::PlayerUseMpris) => cells[12],
-            &Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord) => cells[13],
-            &Id::ConfigEditor(IdConfigEditor::PlayerPort) => cells[14],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)) => cells[12],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)) => cells[13],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[14],
 
-            &Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs) => cells[15],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[15],
         }
     }
 
@@ -525,7 +528,9 @@ impl Model {
         // Active Config Editor
         assert!(
             self.app
-                .active(&Id::ConfigEditor(IdConfigEditor::MusicDir))
+                .active(&Id::ConfigEditor(IdConfigEditor::General(
+                    IdCEGeneral::MusicDir
+                )))
                 .is_ok()
         );
 
@@ -593,7 +598,9 @@ impl Model {
         match self.config_editor.layout {
             ConfigEditorLayout::General => self
                 .app
-                .active(&Id::ConfigEditor(IdConfigEditor::MusicDir))
+                .active(&Id::ConfigEditor(IdConfigEditor::General(
+                    IdCEGeneral::MusicDir,
+                )))
                 .ok(),
             ConfigEditorLayout::Color => self
                 .app
@@ -639,11 +646,9 @@ impl Model {
 
         let mut config_server = self.config_server.write();
 
-        if let Ok(State::One(StateValue::String(music_dir))) =
-            self.app.state(&Id::ConfigEditor(IdConfigEditor::MusicDir))
-        {
-            // config.music_dir = music_dir;
-            // let mut vec = Vec::new();
+        if let Ok(State::One(StateValue::String(music_dir))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::MusicDir),
+        )) {
             let vec = music_dir
                 .split(';')
                 .map(PathBuf::from)
@@ -655,17 +660,15 @@ impl Model {
             config_server.settings.player.music_dirs = vec;
         }
 
-        if let Ok(State::One(StateValue::Usize(exit_confirmation))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::ExitConfirmation))
-        {
+        if let Ok(State::One(StateValue::Usize(exit_confirmation))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExitConfirmation)),
+        ) {
             config_tui.settings.behavior.confirm_quit = matches!(exit_confirmation, 0);
         }
 
-        if let Ok(State::One(StateValue::Usize(display_symbol))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlaylistDisplaySymbol))
-        {
+        if let Ok(State::One(StateValue::Usize(display_symbol))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)),
+        ) {
             config_tui
                 .settings
                 .theme
@@ -674,45 +677,40 @@ impl Model {
                 .use_loop_mode_symbol = matches!(display_symbol, 0);
         }
 
-        if let Ok(State::One(StateValue::String(random_track_quantity_str))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomTrack))
-        {
+        if let Ok(State::One(StateValue::String(random_track_quantity_str))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomTrack)),
+        ) {
             if let Ok(quantity) = random_track_quantity_str.parse::<NonZeroU32>() {
                 config_server.settings.player.random_track_quantity = quantity;
             }
         }
 
-        if let Ok(State::One(StateValue::String(random_album_quantity_str))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlaylistRandomAlbum))
-        {
+        if let Ok(State::One(StateValue::String(random_album_quantity_str))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomAlbum)),
+        ) {
             if let Ok(quantity) = random_album_quantity_str.parse::<NonZeroU32>() {
                 config_server.settings.player.random_album_min_quantity = quantity;
             }
         }
 
-        if let Ok(State::One(StateValue::String(podcast_dir))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PodcastDir))
-        {
+        if let Ok(State::One(StateValue::String(podcast_dir))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::PodcastDir),
+        )) {
             let absolute_dir = shellexpand::path::tilde(&podcast_dir);
             if absolute_dir.exists() {
                 config_server.settings.podcast.download_dir = absolute_dir.into_owned();
             }
         }
-        if let Ok(State::One(StateValue::String(podcast_simul_download))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PodcastSimulDownload))
-        {
+        if let Ok(State::One(StateValue::String(podcast_simul_download))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastSimulDownload)),
+        ) {
             if let Ok(quantity) = podcast_simul_download.parse::<NonZeroU8>() {
                 config_server.settings.podcast.concurrent_downloads_max = quantity;
             }
         }
-        if let Ok(State::One(StateValue::String(podcast_max_retries))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PodcastMaxRetries))
-        {
+        if let Ok(State::One(StateValue::String(podcast_max_retries))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastMaxRetries)),
+        ) {
             if let Ok(quantity) = podcast_max_retries.parse::<u8>() {
                 if (1..11).contains(&quantity) {
                     config_server.settings.podcast.max_download_retries = quantity;
@@ -721,10 +719,9 @@ impl Model {
                 }
             }
         }
-        if let Ok(State::One(StateValue::Usize(align))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::AlbumPhotoAlign))
-        {
+        if let Ok(State::One(StateValue::Usize(align))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::AlbumPhotoAlign),
+        )) {
             let align = match align {
                 0 => XywhAlign::BottomRight,
                 1 => XywhAlign::BottomLeft,
@@ -734,10 +731,9 @@ impl Model {
             config_tui.settings.coverart.align = align;
         }
 
-        if let Ok(State::One(StateValue::Usize(save_last_position))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::SaveLastPosition))
-        {
+        if let Ok(State::One(StateValue::Usize(save_last_position))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SaveLastPosition)),
+        ) {
             // NOTE: value "0" means to not save the value
             if save_last_position != 0 {
                 let new_val = match save_last_position {
@@ -759,9 +755,9 @@ impl Model {
             // config_server.settings.player.remember_position = save_last_position;
         }
 
-        if let Ok(State::One(StateValue::Usize(seek_step))) =
-            self.app.state(&Id::ConfigEditor(IdConfigEditor::SeekStep))
-        {
+        if let Ok(State::One(StateValue::Usize(seek_step))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::SeekStep),
+        )) {
             // NOTE: seek_step is currently unsupported to be set
             let _ = seek_step;
 
@@ -774,30 +770,27 @@ impl Model {
             // config_server.settings.player.seek_step = seek_step;
         }
 
-        if let Ok(State::One(StateValue::Usize(kill_daemon))) =
-            self.app.state(&Id::ConfigEditor(IdConfigEditor::KillDamon))
-        {
+        if let Ok(State::One(StateValue::Usize(kill_daemon))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::KillDamon),
+        )) {
             config_tui.settings.behavior.quit_server_on_exit = matches!(kill_daemon, 0);
         }
 
-        if let Ok(State::One(StateValue::Usize(player_use_mpris))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseMpris))
-        {
+        if let Ok(State::One(StateValue::Usize(player_use_mpris))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)),
+        ) {
             config_server.settings.player.use_mediacontrols = matches!(player_use_mpris, 0);
         }
 
-        if let Ok(State::One(StateValue::Usize(player_use_discord))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlayerUseDiscord))
-        {
+        if let Ok(State::One(StateValue::Usize(player_use_discord))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)),
+        ) {
             config_server.settings.player.set_discord_status = matches!(player_use_discord, 0);
         }
 
-        if let Ok(State::One(StateValue::String(player_port))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::PlayerPort))
-        {
+        if let Ok(State::One(StateValue::String(player_port))) = self.app.state(&Id::ConfigEditor(
+            IdConfigEditor::General(IdCEGeneral::PlayerPort),
+        )) {
             if let Ok(port) = player_port.parse::<u16>() {
                 if (1024..u16::MAX).contains(&port) {
                     config_server.settings.com.port = port;
@@ -807,10 +800,9 @@ impl Model {
             }
         }
 
-        if let Ok(State::One(StateValue::String(extra_ytdlp_args))) = self
-            .app
-            .state(&Id::ConfigEditor(IdConfigEditor::ExtraYtdlpArgs))
-        {
+        if let Ok(State::One(StateValue::String(extra_ytdlp_args))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)),
+        ) {
             config_tui.settings.ytdlp.extra_args = extra_ytdlp_args;
         }
         Ok(())

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -128,6 +128,7 @@ pub enum IdCEGeneral {
     PlayerPort,
     PlayerAddress,
     PlayerProtocol,
+    PlayerUDSPath,
     PlayerUseDiscord,
     PlayerUseMpris,
 

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -128,6 +128,18 @@ pub enum IdCEGeneral {
     KillDamon,
 }
 
+impl From<IdCEGeneral> for IdConfigEditor {
+    fn from(value: IdCEGeneral) -> Self {
+        IdConfigEditor::General(value)
+    }
+}
+
+impl From<&IdCEGeneral> for IdConfigEditor {
+    fn from(value: &IdCEGeneral) -> Self {
+        IdConfigEditor::General(*value)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdKeyGlobal {
     LayoutTreeview,

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -104,6 +104,18 @@ pub enum IdCETheme {
     FallbackLabel,
 }
 
+impl From<IdCETheme> for IdConfigEditor {
+    fn from(value: IdCETheme) -> Self {
+        IdConfigEditor::Theme(value)
+    }
+}
+
+impl From<&IdCETheme> for IdConfigEditor {
+    fn from(value: &IdCETheme) -> Self {
+        IdConfigEditor::Theme(*value)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdCEGeneral {
     MusicDir,

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -51,16 +51,15 @@ pub enum IdTagEditor {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdConfigEditor {
-    AlbumPhotoAlign,
-    CEThemeSelect,
     ConfigSavePopup,
-    ExitConfirmation,
-    ExtraYtdlpArgs,
-    Footer,
+
     Header,
+    Footer,
+
+    General(IdCEGeneral),
+    CEThemeSelect,
     KeyGlobal(IdKeyGlobal),
     KeyOther(IdKeyOther),
-    KillDamon,
 
     LibraryBackground,
     LibraryBorder,
@@ -74,34 +73,19 @@ pub enum IdConfigEditor {
     LyricForeground,
     LyricLabel,
 
-    MusicDir,
-    PlayerPort,
-    PlayerUseDiscord,
-    PlayerUseMpris,
-
     PlaylistBackground,
     PlaylistBorder,
-    PlaylistDisplaySymbol,
     PlaylistForeground,
     PlaylistHighlight,
     PlaylistHighlightSymbol,
     PlaylistLabel,
-    PlaylistRandomAlbum,
-    PlaylistRandomTrack,
 
     CurrentlyPlayingTrackSymbol,
-
-    PodcastDir,
-    PodcastMaxRetries,
-    PodcastSimulDownload,
 
     ProgressBackground,
     ProgressBorder,
     ProgressForeground,
     ProgressLabel,
-
-    SaveLastPosition,
-    SeekStep,
 
     ImportantPopupLabel,
     ImportantPopupBackground,
@@ -113,6 +97,30 @@ pub enum IdConfigEditor {
     FallbackForeground,
     FallbackHighlight,
     FallbackLabel,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+pub enum IdCEGeneral {
+    MusicDir,
+    ExitConfirmation,
+    AlbumPhotoAlign,
+    ExtraYtdlpArgs,
+    SaveLastPosition,
+    SeekStep,
+
+    PlayerPort,
+    PlayerUseDiscord,
+    PlayerUseMpris,
+
+    PodcastDir,
+    PodcastMaxRetries,
+    PodcastSimulDownload,
+
+    PlaylistRandomAlbum,
+    PlaylistRandomTrack,
+    PlaylistDisplaySymbol,
+
+    KillDamon,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -129,6 +129,7 @@ pub enum IdCEGeneral {
     PlayerAddress,
     PlayerProtocol,
     PlayerUDSPath,
+    PlayerBackend,
     PlayerUseDiscord,
     PlayerUseMpris,
 

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -126,6 +126,7 @@ pub enum IdCEGeneral {
     SeekStep,
 
     PlayerPort,
+    PlayerAddress,
     PlayerUseDiscord,
     PlayerUseMpris,
 

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -127,6 +127,7 @@ pub enum IdCEGeneral {
 
     PlayerPort,
     PlayerAddress,
+    PlayerProtocol,
     PlayerUseDiscord,
     PlayerUseMpris,
 

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -58,9 +58,13 @@ pub enum IdConfigEditor {
 
     General(IdCEGeneral),
     CEThemeSelect,
+    Theme(IdCETheme),
     KeyGlobal(IdKeyGlobal),
     KeyOther(IdKeyOther),
+}
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
+pub enum IdCETheme {
     LibraryBackground,
     LibraryBorder,
     LibraryForeground,

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -57,7 +57,6 @@ pub enum IdConfigEditor {
     Footer,
 
     General(IdCEGeneral),
-    CEThemeSelect,
     Theme(IdCETheme),
     KeyGlobal(IdKeyGlobal),
     KeyOther(IdKeyOther),
@@ -65,6 +64,8 @@ pub enum IdConfigEditor {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum IdCETheme {
+    ThemeSelectTable,
+
     LibraryBackground,
     LibraryBorder,
     LibraryForeground,

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -215,6 +215,7 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::PlayerAddress,
     IdCEGeneral::PlayerProtocol,
     IdCEGeneral::PlayerUDSPath,
+    IdCEGeneral::PlayerBackend,
     IdCEGeneral::ExtraYtdlpArgs,
 ];
 

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -214,6 +214,7 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::PlayerPort,
     IdCEGeneral::PlayerAddress,
     IdCEGeneral::PlayerProtocol,
+    IdCEGeneral::PlayerUDSPath,
     IdCEGeneral::ExtraYtdlpArgs,
 ];
 

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -213,6 +213,7 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::PlayerUseDiscord,
     IdCEGeneral::PlayerPort,
     IdCEGeneral::PlayerAddress,
+    IdCEGeneral::PlayerProtocol,
     IdCEGeneral::ExtraYtdlpArgs,
 ];
 

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -9,7 +9,7 @@ use termusiclib::podcast::{PodcastDLResult, PodcastFeed, PodcastSyncResult};
 use termusiclib::songtag::{SongtagSearchResult, TrackDLMsg};
 
 use crate::ui::components::TETrack;
-use crate::ui::ids::{IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::youtube_options::{YTDLMsg, YoutubeData, YoutubeOptions};
 
 /// Main message type that encapsulates everything else.
@@ -176,39 +176,24 @@ pub enum LIMsg {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ConfigEditorMsg {
-    PodcastDirBlurDown,
-    PodcastDirBlurUp,
-    PodcastSimulDownloadBlurDown,
-    PodcastSimulDownloadBlurUp,
-    PodcastMaxRetriesBlurDown,
-    PodcastMaxRetriesBlurUp,
-
-    AlbumPhotoAlignBlurDown,
-    AlbumPhotoAlignBlurUp,
     ChangeLayout,
     CloseCancel,
     CloseOk,
     ColorChanged(IdConfigEditor, ColorTermusic),
     SymbolChanged(IdConfigEditor, String),
+    KeyChange(IdKey, KeyBinding),
     ConfigChanged,
     ConfigSaveOk,
     ConfigSaveCancel,
-    ExitConfirmationBlurDown,
-    ExitConfirmationBlurUp,
-    ExtraYtdlpArgsBlurDown,
-    ExtraYtdlpArgsBlurUp,
+
     Open,
     KeyFocusGlobal(KFMsg),
     KeyFocusOther(KFMsg),
-    MusicDirBlurDown,
-    MusicDirBlurUp,
+    General(KFMsg),
 
-    PlaylistDisplaySymbolBlurDown,
-    PlaylistDisplaySymbolBlurUp,
-    PlaylistRandomTrackBlurDown,
-    PlaylistRandomTrackBlurUp,
-    PlaylistRandomAlbumBlurDown,
-    PlaylistRandomAlbumBlurUp,
+    ThemeSelectBlurDown,
+    ThemeSelectBlurUp,
+    ThemeSelectLoad(usize),
 
     LibraryForegroundBlurDown,
     LibraryForegroundBlurUp,
@@ -246,25 +231,6 @@ pub enum ConfigEditorMsg {
     LyricBorderBlurDown,
     LyricBorderBlurUp,
 
-    ThemeSelectBlurDown,
-    ThemeSelectBlurUp,
-    ThemeSelectLoad(usize),
-
-    KeyChange(IdKey, KeyBinding),
-    SaveLastPositionBlurDown,
-    SaveLastPosotionBlurUp,
-    SeekStepBlurDown,
-    SeekStepBlurUp,
-    KillDaemonBlurDown,
-    KillDaemonBlurUp,
-
-    PlayerUseMprisBlurDown,
-    PlayerUseMprisBlurUp,
-    PlayerUseDiscordBlurDown,
-    PlayerUseDiscordBlurUp,
-    PlayerPortBlurDown,
-    PlayerPortBlurUp,
-
     CurrentlyPlayingTrackSymbolBlurDown,
     CurrentlyPlayingTrackSymbolBlurUp,
 
@@ -284,6 +250,26 @@ pub enum ConfigEditorMsg {
     FallbackHighlightBlurDown,
     FallbackHighlightBlurUp,
 }
+
+/// This array defines the order the IDs listed are displayed and which gains next / previous focus.
+pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
+    IdCEGeneral::MusicDir,
+    IdCEGeneral::ExitConfirmation,
+    IdCEGeneral::PlaylistDisplaySymbol,
+    IdCEGeneral::PlaylistRandomTrack,
+    IdCEGeneral::PlaylistRandomAlbum,
+    IdCEGeneral::PodcastDir,
+    IdCEGeneral::PodcastSimulDownload,
+    IdCEGeneral::PodcastMaxRetries,
+    IdCEGeneral::AlbumPhotoAlign,
+    IdCEGeneral::SaveLastPosition,
+    IdCEGeneral::SeekStep,
+    IdCEGeneral::KillDamon,
+    IdCEGeneral::PlayerUseMpris,
+    IdCEGeneral::PlayerUseDiscord,
+    IdCEGeneral::PlayerPort,
+    IdCEGeneral::ExtraYtdlpArgs,
+];
 
 /// This array defines the order the IDs listed are displayed and which gains next / previous focus.
 pub const KFGLOBAL_FOCUS_ORDER: &[IdKey] = &[

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -212,6 +212,7 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::PlayerUseMpris,
     IdCEGeneral::PlayerUseDiscord,
     IdCEGeneral::PlayerPort,
+    IdCEGeneral::PlayerAddress,
     IdCEGeneral::ExtraYtdlpArgs,
 ];
 

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -9,7 +9,7 @@ use termusiclib::podcast::{PodcastDLResult, PodcastFeed, PodcastSyncResult};
 use termusiclib::songtag::{SongtagSearchResult, TrackDLMsg};
 
 use crate::ui::components::TETrack;
-use crate::ui::ids::{IdCEGeneral, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
+use crate::ui::ids::{IdCEGeneral, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::youtube_options::{YTDLMsg, YoutubeData, YoutubeOptions};
 
 /// Main message type that encapsulates everything else.
@@ -190,65 +190,9 @@ pub enum ConfigEditorMsg {
     KeyFocusGlobal(KFMsg),
     KeyFocusOther(KFMsg),
     General(KFMsg),
+    Theme(KFMsg),
 
-    ThemeSelectBlurDown,
-    ThemeSelectBlurUp,
     ThemeSelectLoad(usize),
-
-    LibraryForegroundBlurDown,
-    LibraryForegroundBlurUp,
-    LibraryBackgroundBlurDown,
-    LibraryBackgroundBlurUp,
-    LibraryBorderBlurDown,
-    LibraryBorderBlurUp,
-    LibraryHighlightBlurDown,
-    LibraryHighlightBlurUp,
-    LibraryHighlightSymbolBlurDown,
-    LibraryHighlightSymbolBlurUp,
-
-    PlaylistForegroundBlurDown,
-    PlaylistForegroundBlurUp,
-    PlaylistBackgroundBlurDown,
-    PlaylistBackgroundBlurUp,
-    PlaylistBorderBlurDown,
-    PlaylistBorderBlurUp,
-    PlaylistHighlightBlurDown,
-    PlaylistHighlightBlurUp,
-    PlaylistHighlightSymbolBlurDown,
-    PlaylistHighlightSymbolBlurUp,
-
-    ProgressForegroundBlurDown,
-    ProgressForegroundBlurUp,
-    ProgressBackgroundBlurDown,
-    ProgressBackgroundBlurUp,
-    ProgressBorderBlurDown,
-    ProgressBorderBlurUp,
-
-    LyricForegroundBlurDown,
-    LyricForegroundBlurUp,
-    LyricBackgroundBlurDown,
-    LyricBackgroundBlurUp,
-    LyricBorderBlurDown,
-    LyricBorderBlurUp,
-
-    CurrentlyPlayingTrackSymbolBlurDown,
-    CurrentlyPlayingTrackSymbolBlurUp,
-
-    ImportantPopupForegroundBlurDown,
-    ImportantPopupForegroundBlurUp,
-    ImportantPopupBackgroundBlurDown,
-    ImportantPopupBackgroundBlurUp,
-    ImportantPopupBorderBlurDown,
-    ImportantPopupBorderBlurUp,
-
-    FallbackForegroundBlurDown,
-    FallbackForegroundBlurUp,
-    FallbackBackgroundBlurDown,
-    FallbackBackgroundBlurUp,
-    FallbackBorderBlurDown,
-    FallbackBorderBlurUp,
-    FallbackHighlightBlurDown,
-    FallbackHighlightBlurUp,
 }
 
 /// This array defines the order the IDs listed are displayed and which gains next / previous focus.
@@ -269,6 +213,35 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::PlayerUseDiscord,
     IdCEGeneral::PlayerPort,
     IdCEGeneral::ExtraYtdlpArgs,
+];
+
+/// This array defines the order the IDs listed are displayed and which gains next / previous focus.
+pub const THEME_FOCUS_ORDER: &[IdCETheme] = &[
+    IdCETheme::ThemeSelectTable,
+    IdCETheme::LibraryForeground,
+    IdCETheme::LibraryBackground,
+    IdCETheme::LibraryBorder,
+    IdCETheme::LibraryHighlight,
+    IdCETheme::LibraryHighlightSymbol,
+    IdCETheme::PlaylistForeground,
+    IdCETheme::PlaylistBackground,
+    IdCETheme::PlaylistBorder,
+    IdCETheme::PlaylistHighlight,
+    IdCETheme::PlaylistHighlightSymbol,
+    IdCETheme::CurrentlyPlayingTrackSymbol,
+    IdCETheme::ProgressForeground,
+    IdCETheme::ProgressBackground,
+    IdCETheme::ProgressBorder,
+    IdCETheme::LyricForeground,
+    IdCETheme::LyricBackground,
+    IdCETheme::LyricBorder,
+    IdCETheme::ImportantPopupForeground,
+    IdCETheme::ImportantPopupBackground,
+    IdCETheme::ImportantPopupBorder,
+    IdCETheme::FallbackForeground,
+    IdCETheme::FallbackBackground,
+    IdCETheme::FallbackBorder,
+    IdCETheme::FallbackHighlight,
 ];
 
 /// This array defines the order the IDs listed are displayed and which gains next / previous focus.


### PR DESCRIPTION
This PR changes some things in the config editor:
- split IDs to be better separated
- rework focus handling from `*BlurUp/*BlurDown` messages to simple `Next/Previous` with array (like keys)
- reword some titles to fix typos, better describe what it is about & read more naturally
- add some missing fields (now that it is very easy to actually add fields)

PS: i am considering splitting some of the options to their own tab, or using separators like `<hr>` in HTML (example:)

---

I also am considering adding the backend specific options as their own tab. Or should they rather stay config-file only?

PPS: it would likely be good to refactor the error display to possibly display all lines in the error and not cutting stuff off; also value collection in config editor should likely be looked again and properly error instead of ignoring invalid data.