### PR TITLE
Partially revert server log collect on tui startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Change(tui): convert event-loop to be practically fully event-driven. (less cpu cycles wasted)
 - Feat(tui): make the Config editor dynamically size elements.
 - Feat(tui): make the Config editor (at least rudementally) scrollable.
-- Feat(tui): collect spawned server logs until connected for better error, in case server exits before being connected.
+<!-- - Feat(tui): collect spawned server logs until connected for better error, in case server exits before being connected. -->
 - Feat(tui): add config editor fields for `com.address`, `com.protocol`, `com.socket_path`, `player.backend`
 - Feat(server): add extra config section for metadata scanning and parsing.
 - Feat(server): on rusty backend, allow configuring output sample rate, now defaulting to 48_000Hz (instead of rodio default 44_100Hz).

--- a/server/src/logger.rs
+++ b/server/src/logger.rs
@@ -19,7 +19,7 @@ pub fn setup(args: &Args) -> LoggerHandle {
                 log_format,
                 color_log_format,
             ))
-            .panic_if_error_channel_is_broken(false)
+            // .panic_if_error_channel_is_broken(false)
             .log_to_stderr();
 
         if args.log_options.log_to_file {


### PR DESCRIPTION
Due to logging completely stopping (even to file) after stopping stdio logging.

This is a quick-fix that disabled that functionality again, until i can further debug this and push a fix. (or report to flexi_logger)

Edit: found the issue in flexi_logger, waiting for it to be fixed before reverting this PR again https://github.com/emabee/flexi_logger/issues/198