### PR TITLE
Fix collection of server logs

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -209,7 +209,7 @@ fn launch_server(args: &cli::Args) -> Result<Child> {
 
     // server can stay around after client exits (if supported by the system)
     #[allow(clippy::zombie_processes)]
-    let proc = spawn_process(&termusic_server_prog, false, &server_args).context(format!(
+    let proc = spawn_process(&termusic_server_prog, true, &server_args).context(format!(
         "Could not start binary \"{}\"",
         termusic_server_prog.display()
     ))?;


### PR DESCRIPTION
This was broken via #583, as that PR was based on changes before #586 (or #582) was merged, so i didnt notice i still had "piped" disabled, effectively disabling this feature again.
Also, just in case this happens again, make it not panic anymore and just log that it is unavailable.