### PR TITLE
Workaround bug in tui-realm's remount focus handling

### DIFF
--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -1328,6 +1328,8 @@ impl Model {
         config: &SharedTuiSettings,
         theme_idx: Option<usize>,
     ) -> Result<()> {
+        let old_focus = self.app.focus().copied();
+
         // Mount color page
         self.app.remount(
             Id::ConfigEditor(IdConfigEditor::Theme(IdCETheme::ThemeSelectTable)),
@@ -1486,6 +1488,12 @@ impl Model {
         self.remount_config_color_symbols(config)?;
 
         self.theme_select_sync(theme_idx);
+
+        // TODO: this should be removed once https://github.com/veeso/tui-realm/issues/118 is fixed
+        // workaround a bug in tui-realm's remount that unsets focus, even though it should still be there
+        if let Some(id) = old_focus {
+            let _ = self.app.attr(&id, Attribute::Focus, AttrValue::Flag(true));
+        }
 
         Ok(())
     }

--- a/tui/src/ui/components/music_library.rs
+++ b/tui/src/ui/components/music_library.rs
@@ -396,6 +396,8 @@ impl Model {
         self.library.tree_path = root_path;
         self.library.tree = Tree::new(root_node);
 
+        let old_focus = self.app.focus().copied();
+
         // remount preserves focus
         let _ = self.app.remount(
             Id::Library,
@@ -406,6 +408,14 @@ impl Model {
             )),
             Vec::new(),
         );
+
+        // TODO: this should be removed once https://github.com/veeso/tui-realm/issues/118 is fixed
+        // workaround a bug in tui-realm's remount that unsets focus, even though it should still be there
+        if let Some(Id::Library) = old_focus {
+            let _ = self
+                .app
+                .attr(&Id::Library, Attribute::Focus, AttrValue::Flag(true));
+        }
 
         // focus the specified node
         if let Some(id) = focus_node {


### PR DESCRIPTION
This PR properly re-set's the `Focus` flag again if the same element had focus as the one that gets remounted.
This workaround should be able to be removed once tui-realm fixes the issue.

re https://github.com/tramhao/termusic/issues/589#issuecomment-3407369150
re https://github.com/veeso/tui-realm/issues/118