### PR TITLE
fix(server): dont panic if config backend is unavailable and overridden by cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix(tui): change the progressbar to use less-than-full blocks for smoother display.
 - Fix(server): on rusty backend, update symphonia to fix various issues.
 - Fix(server): on rusty backend, update `rusty-libopus` to dynamic link without custom environment variable.
+- Fix(server): dont panic if backend in config is unavailable when overridden by cli argument.
 
 ### [V0.12.0]
 - Released on: October 10, 2025.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -109,14 +109,20 @@ async fn actual_main() -> Result<()> {
 
     // do this before anything else so that we exit early on invalid/unavailable backends
     let backend = {
-        let config_backend = config.settings.player.backend.try_into()?;
+        let config_backend = config.settings.player.backend.try_into();
 
         if let Some(backend) = args.backend {
             trace!("Backend from CLI");
+
+            // dont panic if the config backend is unavailable, but also warn somehow
+            if let Err(err) = config_backend {
+                warn!("Error parsing backend from config: {err}");
+            }
+
             backend.into()
         } else {
             trace!("Backend from Config");
-            config_backend
+            config_backend?
         }
     };
 


### PR DESCRIPTION
If it is overriden by a cli argument, then i think it should not panic (but still somehow show).