### PR TITLE
fix(tui::ui::quit_server): use the correct EXE name for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix(tui): dont show error popup if `cover-ueberzug` is compiled-in but `ueberzug` command is not available.
 - Fix(tui): change the progressbar to use less-than-full blocks for smoother display.
 - Fix(tui): change Database `Playlist` search to work on all music roots, instead of current library root.
+- Fix(tui): correctly kill the server on windows systems if config option `behavior.quit_server_on_exit` is enabled.
 - Fix(server): on rusty backend, update symphonia to fix various issues.
 - Fix(server): on rusty backend, update `rusty-libopus` to dynamic link without custom environment variable.
 - Fix(server): dont panic if backend in config is unavailable when overridden by cli argument.

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -114,13 +114,22 @@ impl UI {
     /// Quit the server, if any is found with the proper name.
     // TODO: send the server a message to quit instead of a signal.
     fn quit_server() {
+        #[cfg(windows)]
+        const SERVER_EXE: &str = "termusic-server.exe";
+        #[cfg(not(windows))]
+        const SERVER_EXE: &str = "termusic-server";
+        #[cfg(windows)]
+        const TUI_EXE: &str = "termusic.exe";
+        #[cfg(not(windows))]
+        const TUI_EXE: &str = "termusic";
+
         let mut system = System::new();
         system.refresh_all();
         let mut target = None;
         let mut clients = 0;
         for proc in system.processes().values() {
             if let Some(exe) = proc.name().to_str() {
-                if exe == "termusic-server" {
+                if exe == SERVER_EXE {
                     if &proc.pid() == crate::SERVER_PID.get().unwrap_or(&Pid::from_u32(0))
                         || target.is_none()
                     {
@@ -132,14 +141,14 @@ impl UI {
                 match proc.parent() {
                     Some(s) => {
                         if let Some(parent) = system.processes().get(&s) {
-                            if parent.name() == "termusic" {
+                            if parent.name() == TUI_EXE {
                                 parent_is_termusic = true;
                             }
                         }
                     }
                     None => parent_is_termusic = false,
                 }
-                if exe == "termusic" && !parent_is_termusic {
+                if exe == TUI_EXE && !parent_is_termusic {
                     clients += 1;
                 }
             }


### PR DESCRIPTION
As the matching is a *exact* match not a *contains* anymore

re #603

This is just a quick fix until a RPC command to quit the server gracefully is implemented.

I just noticed #583 seemingly does nothing, so the same behavior of the TUI not exiting persists if the server is not set to quit.