### PR TITLE
docs(README): correctly list ffmpeg as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Note that using non-default features might increase the MSRV.
 |    `libdbus-1-dev`    |       `dbus`        |    X     |     unknown     |                     |                  MPRIS media control                  |          |
 |   `libasound2-dev`    |     `alsa-lib`      |    X     |     unknown     |                     |                     ALSA headers                      |          |
 |       `yt-dlp`        |      `yt-dlp`       |          |                 |                     |                 Download some tracks                  |          |
+|       `ffmpeg`        |      `ffmpeg`       |          |                 |                     |             Post-Processing for `yt-dlp`              |          |
 |         `mpv`         |        `mpv`        |          |                 |        `mpv`        |                      MPV Backend                      |          |
 |      `gstreamer`      |     `gstreamer`     |          |                 |        `gst`        |                   Gstreamer Backend                   |          |
 |       `libopus`       |      `libopus`      |    X     |                 |   `rusty-libopus`   |          Opus codec support in rusty backend          | `1.89.0` |
@@ -97,7 +98,7 @@ All the packages here can be installed via various sources, for ease of install 
 | `Microsoft.VisualStudio.BuildTools` |                                           |    X     |        X        |                     |           General Windows (C++) build tools           |          |
 |          `Google.Protobuf`          |                                           |    X     |        X        |                     | communication protocol between server and client(tui) |          |
 |              `yt-dlp`               |                                           |          |                 |                     |                 Download some tracks                  |          |
-|              `ffmpeg`               |                                           |    X     |                 |                     |                 Encode downloaded tracks              |
+|              `ffmpeg`               |                                           |          |                 |                     |             Post-Processing for `yt-dlp`              |          |
 |               unknown               |                                           |          |                 |        `mpv`        |                      MPV Backend                      |          |
 |               unknown               |                                           |          |                 |        `gst`        |                   Gstreamer Backend                   |          |
 |             unavailable             | [libopus official site][libopus-download] |    X     |                 |   `rusty-libopus`   |          Opus codec support in rusty backend          | `1.89.0` |


### PR DESCRIPTION
FFmpeg is not required by termusic and `yt-dlp` is also optional. Also to my knowledge, even in `yt-dlp` ffmpeg is *theoretically* optional (if you dont need to re-encode or remux or otherwise post-process).
Also adds it to the linux dependencies.

re 1f825ee1e4e2f89df28bd7a14c1b8d811548fdb7