### PR TITLE
Allow Multiple HTTP IP protocol versions at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### next
 
 - Change: updated MSRV to 1.88.
+- Feat: add support for listening (and connecting) to both IPv6 and IPv4 with `http` connection mode.
 - Feat(tui): change default theme to be "Native".
 - Fix(tui): fix that "native" and "termusic default" theme also get auto-selected in config editor, if active.
 - Fix(tui): fix a bunch of places where colors were not applied at all or not correctly applied.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5135,6 +5135,7 @@ dependencies = [
  "colored",
  "ctrlc",
  "flexi_logger",
+ "futures-util",
  "log",
  "parking_lot",
  "serde",

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -457,6 +457,10 @@ pub struct ComSettings {
     pub port: u16,
     /// gRPC server interface / address
     pub address: IpAddr,
+    /// Emulate dual-stack sockets.
+    ///
+    /// This will bind to both `IPv4` and `IPv6` if the address is `::0` / `0.0.0.0` or `::1` / `127.0.0.1` and will not fail if one is unavailable.
+    pub emulate_dual_stack: bool,
 }
 
 /// Helper function to get the default UDS socker path.
@@ -478,6 +482,7 @@ impl Default for ComSettings {
 
             port: 50101,
             address: "::1".parse().unwrap(),
+            emulate_dual_stack: true,
         }
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,6 +33,7 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tonic.workspace = true
 clap.workspace = true
+futures-util.workspace = true
 
 
 [features]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -2,7 +2,8 @@ mod cli;
 mod logger;
 mod music_player_service;
 
-use std::net::SocketAddr;
+use std::fmt::Write as _;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -10,6 +11,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result, bail};
 use clap::Parser;
+use futures_util::stream::SelectAll;
 use music_player_service::MusicPlayerService;
 use parking_lot::Mutex;
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
@@ -23,6 +25,7 @@ use termusicplayback::{
     Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
     PlayerErrorType, PlayerTrait, Playlist, SharedPlaylist, SpeedSigned, Volume, VolumeSigned,
 };
+use tokio::net::TcpListener;
 use tokio::runtime::Handle;
 use tokio::select;
 use tokio::sync::{broadcast, oneshot};
@@ -246,7 +249,20 @@ async fn start_service(
     let handle = match protocol {
         ComProtocol::HTTP => {
             let (tcp_stream, addr) = tcp_stream(config).await?;
-            info!("Server listening on {addr}");
+            info!(
+                "Server listening on {}",
+                addr.iter()
+                    .enumerate()
+                    .fold(String::new(), |mut acc, (idx, v)| {
+                        // Unwrap should never fail as we write directly into a string
+                        if idx == 0 {
+                            write!(acc, "{v}").unwrap();
+                        } else {
+                            write!(acc, " & {v}").unwrap();
+                        }
+                        acc
+                    })
+            );
 
             tokio::spawn(
                 Server::builder()
@@ -277,11 +293,79 @@ async fn start_service(
     Ok(handle)
 }
 
+/// Convert the given results to a [`SelectAll`], depending on which one started.
+///
+/// Mainly uses to de-duplicate the paths regarding `::0` and `::1`.
+fn tcp_stream_convert_dual_stack(
+    tcp_ipv6: std::io::Result<TcpListener>,
+    tcp_ipv4: std::io::Result<TcpListener>,
+) -> Result<(SelectAll<TcpIncoming>, Vec<SocketAddr>)> {
+    let mut stream = SelectAll::new();
+
+    Ok(match (tcp_ipv6, tcp_ipv4) {
+        (Ok(tcp_ipv6), Ok(tcp_ipv4)) => {
+            let addr_v6 = tcp_ipv6.local_addr()?;
+            let addr_v4 = tcp_ipv4.local_addr()?;
+            let stream_v6 = TcpIncoming::from(tcp_ipv6).with_nodelay(Some(true));
+            let stream_v4 = TcpIncoming::from(tcp_ipv4).with_nodelay(Some(true));
+
+            stream.push(stream_v6);
+            stream.push(stream_v4);
+
+            (stream, vec![addr_v6, addr_v4])
+        }
+        (Ok(tcp_ipv6), Err(err_v4)) => {
+            info!("Binding to IPv4 address failed: {}", err_v4);
+            let addr = tcp_ipv6.local_addr()?;
+
+            stream.push(TcpIncoming::from(tcp_ipv6).with_nodelay(Some(true)));
+
+            (stream, vec![addr])
+        }
+        (Err(err_v6), Ok(tcp_ipv4)) => {
+            info!("Binding to IPv6 address failed: {}", err_v6);
+            let addr = tcp_ipv4.local_addr()?;
+
+            stream.push(TcpIncoming::from(tcp_ipv4).with_nodelay(Some(true)));
+
+            (stream, vec![addr])
+        }
+        (Err(err_v6), Err(err_v4)) => {
+            info!("Binding to address v4 failed: {}", err_v4);
+
+            return Err(err_v6.into());
+        }
+    })
+}
+
 /// Create the TCP Stream for HTTP requests.
-async fn tcp_stream(config: &SharedServerSettings) -> Result<(TcpIncoming, SocketAddr)> {
+async fn tcp_stream(
+    config: &SharedServerSettings,
+) -> Result<(SelectAll<TcpIncoming>, Vec<SocketAddr>)> {
     let addr = SocketAddr::from(&config.read().settings.com);
 
-    // workaround to print address once sever "actually" is started and address is known
+    if config.read_recursive().settings.com.emulate_dual_stack {
+        // ::1 / 127.0.0.1 (loopback)
+        if addr.ip().is_loopback() {
+            let tcp_ipv6_fut = tokio::net::TcpListener::bind((Ipv6Addr::LOCALHOST, addr.port()));
+            let tcp_ipv4_fut = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, addr.port()));
+
+            let (tcp_ipv6, tcp_ipv4) = tokio::join!(tcp_ipv6_fut, tcp_ipv4_fut);
+
+            return tcp_stream_convert_dual_stack(tcp_ipv6, tcp_ipv4);
+        }
+        // ::0 / 0.0.0.0 (unspecified)
+        if addr.ip().is_unspecified() {
+            let tcp_ipv6_fut = tokio::net::TcpListener::bind((Ipv6Addr::UNSPECIFIED, addr.port()));
+            let tcp_ipv4_fut = tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, addr.port()));
+
+            let (tcp_ipv6, tcp_ipv4) = tokio::join!(tcp_ipv6_fut, tcp_ipv4_fut);
+
+            return tcp_stream_convert_dual_stack(tcp_ipv6, tcp_ipv4);
+        }
+    }
+
+    // workaround to print address once sever is "actually" started and address is known
     // see https://github.com/hyperium/tonic/issues/351
     let tcp_listener = tokio::net::TcpListener::bind(addr)
         .await
@@ -290,9 +374,10 @@ async fn tcp_stream(config: &SharedServerSettings) -> Result<(TcpIncoming, Socke
     // workaround as "TcpIncoming" does not provide a function to get the address
     let socket_addr = tcp_listener.local_addr()?;
 
-    let stream = TcpIncoming::from(tcp_listener).with_nodelay(Some(true));
+    let mut stream = SelectAll::new();
+    stream.push(TcpIncoming::from(tcp_listener).with_nodelay(Some(true)));
 
-    Ok((stream, socket_addr))
+    Ok((stream, vec![socket_addr]))
 }
 
 #[cfg(unix)]

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::ops::ControlFlow;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,6 +11,7 @@ use std::{error::Error, path::Path};
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use flexi_logger::LogSpecification;
+use futures_util::future::OptionFuture;
 use parking_lot::Mutex;
 use sysinfo::{Pid, ProcessStatus, System};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
@@ -26,6 +28,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tokio::task::AbortHandle;
 use tokio_util::sync::CancellationToken;
+use tonic::transport::Channel;
 
 use ui::UI;
 
@@ -321,13 +324,41 @@ async fn wait_till_connected_tcp(
     config: &CombinedSettings,
     pid: u32,
 ) -> Result<(MusicPlayerClient<tonic::transport::Channel>, String)> {
-    let addr = {
+    let (mut addr1, mut addr2) = {
         let config_read = config.tui.read();
-        SocketAddr::from(config_read.settings.get_com().ok_or(anyhow::anyhow!(
+        let com = config_read.settings.get_com().ok_or(anyhow::anyhow!(
             "Expected tui-com settings to be resolved at this point"
-        ))?)
+        ))?;
+        match (
+            com.emulate_dual_stack,
+            com.address.is_loopback(),
+            com.address.is_unspecified(),
+        ) {
+            // ::1 / 127.0.0.1 (loopback)
+            (true, true, false) => (
+                format!(
+                    "http://{}",
+                    SocketAddr::from((Ipv6Addr::LOCALHOST, com.port))
+                ),
+                Some(format!(
+                    "http://{}",
+                    SocketAddr::from((Ipv4Addr::LOCALHOST, com.port))
+                )),
+            ),
+            // ::0 / 0.0.0.0 (unspecified)
+            (true, false, true) => (
+                format!(
+                    "http://{}",
+                    SocketAddr::from((Ipv6Addr::UNSPECIFIED, com.port))
+                ),
+                Some(format!(
+                    "http://{}",
+                    SocketAddr::from((Ipv4Addr::UNSPECIFIED, com.port))
+                )),
+            ),
+            _ => (format!("http://{}", SocketAddr::from(com)), None),
+        }
     };
-    let addr = format!("http://{addr}");
 
     let mut sys = sysinfo::System::new();
     let sys_pid = Pid::from_u32(pid);
@@ -351,22 +382,65 @@ async fn wait_till_connected_tcp(
             anyhow::bail!("Process {pid} exited before being able to connect!");
         }
 
-        match MusicPlayerClient::connect(addr.clone()).await {
-            Err(err) => {
-                // downcast "tonic::transport::Error" to a "std::io::Error"(kind: Os)
-                if let Some(os_err) = find_source::<std::io::Error>(&err)
-                    && os_err.kind() == std::io::ErrorKind::ConnectionRefused
-                {
-                    debug!("Connection refused found!");
-                    tokio::time::sleep(WAIT_INTERVAL).await;
-                    continue;
-                }
+        let fut1 = MusicPlayerClient::connect(addr1.clone());
+        let fut2_is_some = addr2.is_some();
+        let fut2 = OptionFuture::from(addr2.clone().map(MusicPlayerClient::connect));
 
-                // return the error and stop if it is anything other than "Connection Refused"
-                anyhow::bail!(err);
+        let res = tokio::select! {
+            biased; // we want to use the main address if both are ready
+            res = fut1 => {
+                match wait_tcp_handle_connect_result(res).await {
+                    Ok(v) => (v, &addr1),
+                    Err(err) => {
+                        // continue trying other address if available
+                        if let Some(addr2) = addr2.take() {
+                            info!("Connecting to secondary {} failed: {}", &addr1, err);
+                            addr1 = addr2;
+                            continue;
+                        }
+                        return Err(err);
+                    }
+                }
+             },
+            res = fut2, if fut2_is_some => {
+                // unwrap is safe here due to this branch only being possible if it is "Some"
+                match wait_tcp_handle_connect_result(res.unwrap()).await {
+                    Ok(v) => (v, addr2.as_ref().unwrap()),
+                    Err(err) => {
+                        info!("Connecting to secondary {} failed: {}", addr2.as_ref().unwrap(), err);
+                        addr2.take();
+                        continue;
+                    }
+                }
             }
-            Ok(client) => return Ok((client, addr)),
+        };
+
+        if let ControlFlow::Break(val) = res.0 {
+            return Ok((val, res.1.clone()));
         }
+        // otherwise continue
+    }
+}
+
+/// Convert the given result to contine or break, while also mapping the error cases.
+async fn wait_tcp_handle_connect_result(
+    res: Result<MusicPlayerClient<Channel>, tonic::transport::Error>,
+) -> Result<ControlFlow<MusicPlayerClient<tonic::transport::Channel>, ()>> {
+    match res {
+        Err(err) => {
+            // downcast "tonic::transport::Error" to a "std::io::Error"(kind: Os)
+            if let Some(os_err) = find_source::<std::io::Error>(&err)
+                && os_err.kind() == std::io::ErrorKind::ConnectionRefused
+            {
+                debug!("Connection refused found!");
+                tokio::time::sleep(WAIT_INTERVAL).await;
+                return Ok(ControlFlow::Continue(()));
+            }
+
+            // return the error and stop if it is anything other than "Connection Refused"
+            anyhow::bail!(err);
+        }
+        Ok(client) => Ok(ControlFlow::Break(client)),
     }
 }
 


### PR DESCRIPTION
This PR changes server & tui to allow (manual) dual-stack sockets.
This is done by adding a new server config property: `[com.emulate_dual_stack]` which defaults to `true`, which in turn will try to listen to both ipv4 and ipv6 on the given port, but does not fail if either has error-ed, but not both.

This should fix #402

Tagging some users involved and hope for feedback on if this PR fixes the issue if the config is `protocol: http` and default address of `::1`: @Owlyat @valkyrieglasc @DrVoidest

This should NOT be merged until some testing is done.