### PR TITLE
fix: change default port to 5101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change: updated MSRV to 1.88.
 - Feat(tui): change default theme to be "Native".
+- Fix: change default port to `5101` to be below 49k
 - Fix(tui): fix that "native" and "termusic default" theme also get auto-selected in config editor, if active.
 - Fix(tui): fix a bunch of places where colors were not applied at all or not correctly applied.
 

--- a/lib/src/config/v1/mod.rs
+++ b/lib/src/config/v1/mod.rs
@@ -167,7 +167,7 @@ impl Default for Settings {
             kill_daemon_when_quit: true,
             player_use_mpris: true,
             player_use_discord: true,
-            player_port: 50101,
+            player_port: 5101,
             player_interface: "::1".parse().unwrap(),
         }
     }

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -476,7 +476,7 @@ impl Default for ComSettings {
 
             socket_path: default_uds_socket_path(),
 
-            port: 50101,
+            port: 5101,
             address: "::1".parse().unwrap(),
         }
     }
@@ -657,7 +657,7 @@ mod v1_interop {
                 converted.com,
                 ComSettings {
                     protocol: ComProtocol::HTTP,
-                    port: 50101,
+                    port: 5101,
                     address: "::1".parse().unwrap(),
                     ..Default::default()
                 }


### PR DESCRIPTION
To be below the 49k "Dynamic Port" range, which seemingly causes issues on windows.

This only affects new users / those who reset their config.

fixes #647