### PR TITLE
Add macOS/Homebrew to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ pamac install termusic-git
 
 macOS users can install termusic from [Homebrew](https://brew.sh/) through its [Formula](https://formulae.brew.sh/formula/termusic)
 
-```bash`
+```bash
 brew install termusic
 ```
 


### PR DESCRIPTION
Adding `termusic` from Homebrew to `README` following addition in https://github.com/Homebrew/homebrew-core/pull/268693

I opted for the only feature used in the CI builds around here. Please let me know if more features should be added by default, looking at the couple of other ones as options around listed here and there.

I also added other AUR helpers in the meantime seeing the `termusic-git` here.
I even had some doubts, in my opinion this README shouldn't mention a specific AUR helper and should rather point  to the `PKGBUILD` and maybe also the AUR helpers I added here, but not push to a specific one. I can change this too if needs be.