### PR TITLE
fix: bump alphanumeric-sort to 1.5.5 to restore builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alphanumeric-sort"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d67c60c5f10f11c6ee04de72b2dd98bb9d2548cbc314d22a609bfa8bd9e87e8f"
+checksum = "774ffdfeac16e9b4d75e41225dc2545d9c2082a0634b5d7f6f70e168546eecb1"
 
 [[package]]
 name = "alsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ wildmatch = "2.4"
 windows = { default-features = false, version = "0.61", features = ["Win32_System_Threading"] }
 ytd-rs = { version = "0.1", features = ["yt-dlp"] }
 futures-util = "0.3.31"
-alphanumeric-sort = "1.5"
+alphanumeric-sort = "1.5.5"
 # for less dependencies, keep in sync with the version ratatui uses
 lru = "0.12.5"
 either = "1.15"


### PR DESCRIPTION
## Summary
- pin `alphanumeric-sort` to `1.5.5` in `Cargo.toml` so Cargo resolves to a non-yanked release
- update `Cargo.lock` from `alphanumeric-sort 1.5.3` (yanked) to `1.5.5` with matching checksum
- keep the change dependency-only and scoped to issue #662 build breakage

## Testing
- `cargo --version` (fails in this runner: `cargo: command not found`)
- manual validation by diff inspection confirms both manifest and lockfile now target `alphanumeric-sort 1.5.5`, avoiding the yanked `1.5.3`

## Related
Fixes #662