### PR TITLE
chore(playback/Cargo.toml): remove "rusty-soundtouch" being enabled by default

### DIFF
--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -55,7 +55,7 @@ symphonia-adapter-libopus = { workspace = true, optional = true, features = ["bu
 [features]
 # NOTE: do NOT enable any backends here, enable them in crate "server"!
 # otherwise you will not be able to start that backend
-default = ["rusty-soundtouch"]
+default = []
 # cover = []
 gst = ["dep:gstreamer", "dep:glib"]
 mpv = ["dep:libmpv-sirno"]


### PR DESCRIPTION
It was not meant to actually be in the commit.

re 71f3138cedfad17a0205455502081c657023721f
fixes #680