### PR TITLE
add cargo-binstall metadata to tui and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### next
 
+- Feat: add `cargo-binstall` metadata to tui and server crates for pre-built binary installs.
 - Change: updated MSRV to 1.88.
 - Change: enable feature `rusty-soundtouch` for linux, macos & windows CI builds
 - Change: enable feature `rusty-simd` on macos CI builds

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ Note that log files are only created on the first log line to be saved.
 cargo install termusic termusic-server --locked
 ```
 
+#### cargo-binstall
+
+```bash
+cargo binstall termusic termusic-server
+```
+
 ### From Source
 
 ```bash

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,27 @@ tonic.workspace = true
 clap.workspace = true
 
 
+# archive is named "termusic-v..." not "termusic-server-v..."
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/termusic-v{ version }-x86_64-linux.tar.xz"
+bin-dir = "termusic-v{ version }-x86_64-linux/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/termusic-v{ version }-x86_64-linux.tar.xz"
+bin-dir = "termusic-v{ version }-x86_64-linux/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/termusic-v{ version }-x86_64-macos.tar.xz"
+bin-dir = "termusic-v{ version }-x86_64-macos/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/termusic-v{ version }-x86_64-windows.zip"
+bin-dir = "termusic-v{ version }-x86_64-windows/{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+
 [features]
 # NOTE: this package fails to compile if not one of the backends (rusty, gst, mpv) are compiled in!
 default = []

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -81,6 +81,26 @@ cover-viuer-iterm = []
 cover-viuer-kitty = []
 cover-viuer-sixel = ["viuer/icy_sixel"]
 
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-linux.tar.xz"
+bin-dir = "{ name }-v{ version }-x86_64-linux/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-linux.tar.xz"
+bin-dir = "{ name }-v{ version }-x86_64-linux/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-macos.tar.xz"
+bin-dir = "{ name }-v{ version }-x86_64-macos/{ bin }{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-x86_64-windows.zip"
+bin-dir = "{ name }-v{ version }-x86_64-windows/{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+
 [dev-dependencies]
 pretty_assertions.workspace = true # = "1"
 # anyhow = "1"


### PR DESCRIPTION
Enables `cargo binstall termusic` and `cargo binstall termusic-server` - to install without compiling.