### PR TITLE
Re-enable aarch64-linux (Linux arm64) builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     name: Test Linux
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         rust: [stable, "1.88"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -43,7 +45,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -74,7 +78,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -110,7 +116,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,9 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          submodules: true
+          persist-credentials: false
 
       - name: Install ${{ matrix.rust }} toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -155,9 +155,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          submodules: false
+          persist-credentials: false
 
       - uses: actions/download-artifact@v4
         # with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,18 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux,x86_64-macos,x86_64-windows,aarch64-macos] #, aarch64-linux] #, x86_64-win-gnu, win32-msvc
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos] # x86_64-win-gnu, win32-msvc
         include:
         - build: x86_64-linux
           os: ubuntu-latest
           rust: stable
           target: x86_64-unknown-linux-gnu
           cross: false
-        # - build: aarch64-linux
-        #   os: ubuntu-20.04
-        #   rust: stable
-        #   target: aarch64-unknown-linux-gnu
-        #   cross: true
+        - build: aarch64-linux
+          os: ubuntu-24.04-arm
+          rust: stable
+          target: aarch64-unknown-linux-gnu
+          cross: false
         - build: x86_64-macos
           os: macos-latest
           rust: stable
@@ -71,7 +71,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install developer package dependencies
-        if: matrix.build == 'x86_64-linux'
+        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux'
         run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config protobuf-compiler libgstreamer1.0-0 libunwind-dev libgstreamer1.0-dev libmpv-dev
 
       - name: Install developer package dependencies
@@ -85,14 +85,14 @@ jobs:
         run: choco install protoc 
       
       - name: Run cargo test (cargo)
-        if: (matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && !matrix.cross
+        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && !matrix.cross
         run: cargo test --release --target ${{ matrix.target }}
 
-      - name: Build release binary (cargo x86_64-linux)
-        if: matrix.build == 'x86_64-linux'
+      - name: Build release binary (cargo x86_64-linux and aarch64-linux)
+        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux'
         run: cargo build --features cover,all-backends,rusty-soundtouch --release --all --target ${{ matrix.target }}
 
-      - name: Build release binary (cargo x86_64-macos)
+      - name: Build release binary (cargo x86_64-macos and aarch64-macos)
         if: matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
         run: cargo build --features rusty-soundtouch,rusty-simd --release --all --target ${{ matrix.target }}
 
@@ -105,7 +105,7 @@ jobs:
         run: cargo install cross
 
       - name: Run cargo test (cross)
-        if: (matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && matrix.cross
+        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && matrix.cross
         run: cargo test --release --target ${{ matrix.target }}
 
       - name: Build release binary (cross)
@@ -113,24 +113,10 @@ jobs:
         run: cargo build --features cover,all-backends --release --all --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
+        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
         run: |
           strip "target/${{ matrix.target }}/release/$BIN_NAME"
           strip "target/${{ matrix.target }}/release/$BIN_NAME_SERVER"
-
-      - name: Strip release binary (arm)
-        if: matrix.build == 'aarch64-linux'
-        run: |
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:${{ matrix.target }} \
-            aarch64-linux-gnu-strip \
-            /target/${{ matrix.target }}/release/$BIN_NAME
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:${{ matrix.target }} \
-            aarch64-linux-gnu-strip \
-            /target/${{ matrix.target }}/release/$BIN_NAME_SERVER
 
       - name: Build archive
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,13 +159,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         # with:
         #   path: dist
       # - run: ls -al ./dist
       - run: ls -al bins-*
 
-      # - uses: actions/download-artifact@v2
+      # - uses: actions/download-artifact@v8
       #   # with:
       #   windowspath: dist
       # - runchoco install protoc ls -al ./dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,27 +28,22 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: x86_64-unknown-linux-gnu
-          cross: false
         - build: aarch64-linux
           os: ubuntu-24.04-arm
           rust: stable
           target: aarch64-unknown-linux-gnu
-          cross: false
         - build: x86_64-macos
           os: macos-latest
           rust: stable
           target: x86_64-apple-darwin
-          cross: false
         - build: aarch64-macos
           os: macos-latest
           rust: stable
           target: aarch64-apple-darwin
-          cross: false
         - build: x86_64-windows
           os: windows-latest
           rust: stable
           target: x86_64-pc-windows-msvc
-          cross: false
         # - build: x86_64-win-gnu
         #   os: windows-2019
         #   rust: stable-x86_64-gnu
@@ -85,7 +80,7 @@ jobs:
         run: choco install protoc 
       
       - name: Run cargo test (cargo)
-        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && !matrix.cross
+        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows')
         run: cargo test --release --target ${{ matrix.target }}
 
       - name: Build release binary (cargo x86_64-linux and aarch64-linux)
@@ -99,18 +94,6 @@ jobs:
       - name: Build release binary (cargo x86_64-windows)
         if: matrix.build == 'x86_64-windows'
         run: cargo build --features rusty-soundtouch --release --all --target ${{ matrix.target }}
-
-      - name: Install cross (cross)
-        if: matrix.cross
-        run: cargo install cross
-
-      - name: Run cargo test (cross)
-        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows') && matrix.cross
-        run: cargo test --release --target ${{ matrix.target }}
-
-      - name: Build release binary (cross)
-        if: matrix.cross
-        run: cargo build --features cover,all-backends --release --all --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
             cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER" "dist/"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bins-${{ matrix.build }}
           path: dist


### PR DESCRIPTION
Trying to re-enable `aarch64-linux` (Linux on arm64 architecture) builds. It's built successfully at Homebrew, so no reason it wouldn't here.

It feels like older attempts were probably done with emulation, native ARM runner were maybe not existing back then so I cleaned some details that seems on-point on the matter - although I'm clearly unsure here

Other remarks:
- I'm not sure what "cross" steps or jobs are, is this related to cross-compilation? If yes, is this still necessary? It feels like it could be even more simplified and cleared for anything related to cross.
- Workflow files have a lot of things commented here and there, maybe can they require some cleaning?
- Parts related to Homebrew, will this still be used in the future? eg. is there plan to someday have a Tap (private repo)? It's now officially added and auto-updated on Homebrew-core.
- I had some hesitation about adding some linting for these files as pre-commits and/or workflows, but as of now they could be quite unhappy about some details and blocks.
- I probably forgot one or two details to mention here.

Let me know what do you think about those remarks.