### PR TITLE
Fix usage of private serde modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### next
 
-- Feat: add `cargo-binstall` metadata to tui and server crates for pre-built binary installs.
 - Change: updated MSRV to 1.88.
 - Change: enable feature `rusty-soundtouch` for linux, macos & windows CI builds
 - Change: enable feature `rusty-simd` on macos CI builds
 - Change: provide arm64 binaries for macos
+- Change: add `cargo-binstall` metadata to tui and server crates for pre-built binary installs.
 - Fix: change default port to `5101` to be below 49k
 - Fix(tui): fix that "native" and "termusic default" theme also get auto-selected in config editor, if active.
 - Fix(tui): fix a bunch of places where colors were not applied at all or not correctly applied.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,9 +4525,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4544,18 +4544,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.221"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4534,6 +4534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_content_ref"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c74845e7ae722292dd2ab47da219bd844554bd0cf6099dd21ac9e7cbb38c69"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5277,6 +5286,7 @@ dependencies = [
  "sanitize-filename",
  "semver",
  "serde",
+ "serde_content_ref",
  "serde_json",
  "serde_yaml",
  "shellexpand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,13 +2478,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4597,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5294,7 +5295,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml 0.9.6",
+ "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -5568,17 +5569,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.6"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.1",
- "toml_datetime 0.7.1",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.10",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5592,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.1"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5625,18 +5626,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.10",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -6669,6 +6670,12 @@ checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ sanitize-filename = "0.6"
 semver = "1.0.27"
 # locked as the next version removes access to "__private"
 serde = { version = "=1.0.221", features = ["derive"] }
+serde_content_ref = "0.1"
 serde_json = "1.0.149"
 serde_yaml = "0.9"
 shellexpand = { version = "3.1.1", features = ["path"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,7 @@ textwrap = "0.16.2"
 tokio = { version = "1.50", features = ["sync", "macros", "rt", "rt-multi-thread", "parking_lot", "process"] }
 tokio-util = "0.7.18"
 tokio-stream = { version = "0.1.18", features = ["sync"] }
-# versions >=0.9.7 require serde higher than 1.0.221
-toml = "0.9.6"
+toml = "1.1.2"
 # only update prost and tonic major versions together
 prost = "0.14.3"
 tonic = "0.14.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,7 @@ rss = { version = "2.0.12", default-features = false }
 rusqlite = { version = "0.38", features = ["bundled"] }
 sanitize-filename = "0.6"
 semver = "1.0.27"
-# locked as the next version removes access to "__private"
-serde = { version = "=1.0.221", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_content_ref = "0.1"
 serde_json = "1.0.149"
 serde_yaml = "0.9"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -52,6 +52,7 @@ rusqlite.workspace = true #  = { version = "0.29", features = ["bundled"]}
 sanitize-filename.workspace = true #   = "0.4"
 semver.workspace = true #   = "^1"
 serde.workspace = true #  = { version = "1.0", features = ["derive"] }
+serde_content_ref.workspace = true
 serde_json.workspace = true #  = "1.0"
 serde_yaml.workspace = true
 shellexpand.workspace = true #  = "3"

--- a/lib/src/config/v2/server/config_extra.rs
+++ b/lib/src/config/v2/server/config_extra.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, fmt::Write as _, path::Path};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_content_ref::{Content, ContentRefDeserializer};
 
 use crate::utils::get_app_config_path;
 
@@ -33,10 +34,8 @@ impl<'a, 'de> Deserialize<'de> for ServerConfigVersionedDefaulted<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        // Note that those are marked "private", but are used in the derives, and there is no to me known public way, but saves some implementation complexity
-        let content =
-            <serde::__private::de::Content<'_> as serde::Deserialize>::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
+        let content = Content::deserialize(deserializer)?;
+        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
 
         let mut err_res = String::new();
 

--- a/lib/src/config/v2/tui/config_extra.rs
+++ b/lib/src/config/v2/tui/config_extra.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, fmt::Write as _, path::Path};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_content_ref::{Content, ContentRefDeserializer};
 
 use crate::utils::get_app_config_path;
 
@@ -33,10 +34,8 @@ impl<'a, 'de> Deserialize<'de> for TuiConfigVersionedDefaulted<'a> {
     where
         D: serde::Deserializer<'de>,
     {
-        // Note that those are marked "private", but are used in the derives, and there is no to me known public way, but saves some implementation complexity
-        let content =
-            <serde::__private::de::Content<'_> as serde::Deserialize>::deserialize(deserializer)?;
-        let deserializer = serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content);
+        let content = Content::deserialize(deserializer)?;
+        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
 
         let mut err_res = String::new();
 


### PR DESCRIPTION
This PR is a alternative to #580, using `serde_content_ref` instead of `serde-content`, which is literally the same code serde has privately, so it is a drop-in replacement.

Also updates related dependencies that were needed to be held back because of the serde version.

fixes #578
closes #580