### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   lint:
     name: Lint (Linux)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -46,6 +47,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         rust: [stable, "1.88"]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -79,6 +81,7 @@ jobs:
         rust: [stable]
         target: [aarch64-apple-darwin, x86_64-apple-darwin]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -117,6 +120,7 @@ jobs:
         os: [windows-latest]
         rust: [stable]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '00 01 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     tags:
-    - 'v[0-99]+.[0-99]+.[0-99]+'
+      - 'v[0-99]+.[0-99]+.[0-99]+'
+    branches: # validate workflow works as expected
+      - "*"
 
 env:
   BIN_NAME: termusic
@@ -57,14 +59,14 @@ jobs:
 
       - name: Install developer package dependencies (MacOS)
         if: runner.os == 'macos'
-        run: | 
+        run: |
             brew update
             brew install protobuf
-  
+
       - name: Install developer package dependencies (Windows)
         if: runner.os == 'windows'
         run: choco install protoc
-      
+
       - name: Run cargo test
         run: cargo test --release --target ${{ matrix.build.target }}
 
@@ -161,6 +163,7 @@ jobs:
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   dist:
     name: Dist
     runs-on: ${{ matrix.build.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
@@ -58,7 +59,6 @@ jobs:
             os: windows-latest
             target: x86_64-pc-windows-msvc
             features: rusty-soundtouch
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -121,6 +121,7 @@ jobs:
     name: Publish
     needs: [dist]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write  # for actions/checkout to fetch code and for "upload-release-action" to actually set a release
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,53 +51,55 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
 
-      - name: Install developer package dependencies
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux'
+      - name: Install developer package dependencies (Linux)
+        if: runner.os == 'linux'
         run: sudo apt-get update && sudo apt-get install libasound2-dev libdbus-1-dev pkg-config protobuf-compiler libgstreamer1.0-0 libunwind-dev libgstreamer1.0-dev libmpv-dev
 
-      - name: Install developer package dependencies
-        if: matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
+      - name: Install developer package dependencies (MacOS)
+        if: runner.os == 'macos'
         run: | 
             brew update
             brew install protobuf
   
-      - name: Install developer package dependencies
-        if: matrix.build == 'x86_64-windows'
-        run: choco install protoc 
+      - name: Install developer package dependencies (Windows)
+        if: runner.os == 'windows'
+        run: choco install protoc
       
-      - name: Run cargo test (cargo)
-        if: (matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos' || matrix.build == 'x86_64-windows')
+      - name: Run cargo test
         run: cargo test --release --target ${{ matrix.target }}
 
-      - name: Build release binary (cargo x86_64-linux and aarch64-linux)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux'
+      - name: Build release binary (Linux)
+        if: runner.os == 'linux'
         run: cargo build --features cover,all-backends,rusty-soundtouch --release --all --target ${{ matrix.target }}
 
-      - name: Build release binary (cargo x86_64-macos and aarch64-macos)
-        if: matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
+      - name: Build release binary (MacOS)
+        if: runner.os == 'macos'
         run: cargo build --features rusty-soundtouch,rusty-simd --release --all --target ${{ matrix.target }}
 
-      - name: Build release binary (cargo x86_64-windows)
-        if: matrix.build == 'x86_64-windows'
+      - name: Build release binary (Windows)
+        if: runner.os == 'windows'
         run: cargo build --features rusty-soundtouch --release --all --target ${{ matrix.target }}
 
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'x86_64-linux' || matrix.build == 'aarch64-linux' || matrix.build == 'x86_64-macos' || matrix.build == 'aarch64-macos'
+      - name: Strip release binary (Linux & MacOS)
+        if: runner.os == 'linux' || runner.os == 'macos'
         run: |
           strip "target/${{ matrix.target }}/release/$BIN_NAME"
           strip "target/${{ matrix.target }}/release/$BIN_NAME_SERVER"
 
-      - name: Build archive
+      - name: Build archive (Windows)
+        if: runner.os == 'windows'
+        run: |
+          mkdir dist
+          cp "target/${{ matrix.target }}/release/$BIN_NAME.exe" "dist/"
+          cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER.exe" "dist/"
+
+      - name: Build archive (Unix)
+        if: runner.os != 'windows'
         shell: bash
         run: |
           mkdir dist
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
-            cp "target/${{ matrix.target }}/release/$BIN_NAME.exe" "dist/"
-            cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER.exe" "dist/"
-          else
-            cp "target/${{ matrix.target }}/release/$BIN_NAME" "dist/"
-            cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER" "dist/"
-          fi
+          cp "target/${{ matrix.target }}/release/$BIN_NAME" "dist/"
+          cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER" "dist/"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build release binary
         run: cargo build --release --workspace --features ${{ matrix.build.features }} --target ${{ matrix.build.target }}
 
-      - name: Strip release binary (Linux & MacOS)
+      - name: Strip release binary (Unix)
         if: runner.os == 'linux' || runner.os == 'macos'
         run: |
           strip "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,10 @@ jobs:
         run: choco install protoc
 
       - name: Run cargo test
-        run: cargo test --release --features ${{ matrix.build.features }} --target ${{ matrix.build.target }}
+        run: cargo test --release --workspace --features ${{ matrix.build.features }} --target ${{ matrix.build.target }}
 
       - name: Build release binary
-        run: cargo build --release --features ${{ matrix.build.features }} --all --target ${{ matrix.build.target }}
+        run: cargo build --release --workspace --features ${{ matrix.build.features }} --target ${{ matrix.build.target }}
 
       - name: Strip release binary (Linux & MacOS)
         if: runner.os == 'linux' || runner.os == 'macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Release
 on:
+  workflow_dispatch: # allow manually running the workflow on a given branch to check that it works before running a release
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-    branches: # validate workflow works as expected
-      - "*"
+    paths:
+      - ".github/workflows/release.yml" # trigger this workflow to check itself being valid
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml" # trigger this workflow to check itself being valid
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,13 @@
 name: Release
 on:
-  # schedule:
-  # - cron: '0 0 * * *' # midnight UTC
-
   push:
     tags:
     - 'v[0-99]+.[0-99]+.[0-99]+'
-    ## - release
 
 env:
   BIN_NAME: termusic
-  BIN_NAME_SERVER: termusic-server 
-  PROJECT_NAME: termusic 
-  REPO_NAME: tramhao/termusic
-  # BREW_TAP: jondot/homebrew-tap
+  BIN_NAME_SERVER: termusic-server
+  PROJECT_NAME: termusic
 
 jobs:
   dist:
@@ -44,14 +38,6 @@ jobs:
           os: windows-latest
           rust: stable
           target: x86_64-pc-windows-msvc
-        # - build: x86_64-win-gnu
-        #   os: windows-2019
-        #   rust: stable-x86_64-gnu
-        #   target: x86_64-pc-windows-gnu
-        # - build: win32-msvc
-        #   os: windows-2019
-        #   rust: stable
-        #   target: i686-pc-windows-msvc
 
     steps:
       - name: Checkout sources
@@ -129,15 +115,9 @@ jobs:
           persist-credentials: false
 
       - uses: actions/download-artifact@v8
-        # with:
-        #   path: dist
-      # - run: ls -al ./dist
+
       - run: ls -al bins-*
 
-      # - uses: actions/download-artifact@v8
-      #   # with:
-      #   windowspath: dist
-      # - runchoco install protoc ls -al ./dist
       - name: Calculate tag name
         run: |
           name=dev
@@ -191,27 +171,3 @@ jobs:
         id: extract-version
         run: |
           printf "name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
-      # - uses: mislav/bump-homebrew-formula-action@v1
-      #   with:
-      #     formula-path: ${{env.PROJECT_NAME}}.rb
-      #     homebrew-tap: ${{ env.BREW_TAP }}
-      #     download-url: "https://github.com/${{ env.REPO_NAME }}/releases/download/${{ steps.extract-version.outputs.tag-name }}/${{env.PROJECT_NAME}}-${{ steps.extract-version.outputs.tag-name }}-x86_64-macos.tar.xz"
-      #     commit-message: updating formula for ${{ env.PROJECT_NAME }}
-      #   env:
-      #     COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-        #
-        # you can use this initial file in your homebrew-tap if you don't have an initial formula:
-        # <projectname>.rb
-        #
-        # class <Projectname capitalized> < Formula
-        #   desc "A test formula"
-        #   homepage "http://www.example.com"
-        #   url "-----"
-        #   version "-----"
-        #   sha256 "-----"
-
-        #   def install
-        #     bin.install "<bin-name>"
-        #   end
-        # end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,32 +12,32 @@ env:
 jobs:
   dist:
     name: Dist
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.build.os }}
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos] # x86_64-win-gnu, win32-msvc
-        include:
-        - build: x86_64-linux
-          os: ubuntu-latest
-          rust: stable
-          target: x86_64-unknown-linux-gnu
-        - build: aarch64-linux
-          os: ubuntu-24.04-arm
-          rust: stable
-          target: aarch64-unknown-linux-gnu
-        - build: x86_64-macos
-          os: macos-latest
-          rust: stable
-          target: x86_64-apple-darwin
-        - build: aarch64-macos
-          os: macos-latest
-          rust: stable
-          target: aarch64-apple-darwin
-        - build: x86_64-windows
-          os: windows-latest
-          rust: stable
-          target: x86_64-pc-windows-msvc
+        rust: [stable]
+        build:
+          # linux x86
+          - archive: x86_64-linux
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          # linux arm64
+          - archive: aarch64-linux
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          # mac x86
+          - archive: x86_64-macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          # mac arm64
+          - archive: aarch64-macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+          # windows x86
+          - archive: x86_64-windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout sources
@@ -49,7 +49,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.build.target }}
 
       - name: Install developer package dependencies (Linux)
         if: runner.os == 'linux'
@@ -66,44 +66,44 @@ jobs:
         run: choco install protoc
       
       - name: Run cargo test
-        run: cargo test --release --target ${{ matrix.target }}
+        run: cargo test --release --target ${{ matrix.build.target }}
 
       - name: Build release binary (Linux)
         if: runner.os == 'linux'
-        run: cargo build --features cover,all-backends,rusty-soundtouch --release --all --target ${{ matrix.target }}
+        run: cargo build --features cover,all-backends,rusty-soundtouch --release --all --target ${{ matrix.build.target }}
 
       - name: Build release binary (MacOS)
         if: runner.os == 'macos'
-        run: cargo build --features rusty-soundtouch,rusty-simd --release --all --target ${{ matrix.target }}
+        run: cargo build --features rusty-soundtouch,rusty-simd --release --all --target ${{ matrix.build.target }}
 
       - name: Build release binary (Windows)
         if: runner.os == 'windows'
-        run: cargo build --features rusty-soundtouch --release --all --target ${{ matrix.target }}
+        run: cargo build --features rusty-soundtouch --release --all --target ${{ matrix.build.target }}
 
       - name: Strip release binary (Linux & MacOS)
         if: runner.os == 'linux' || runner.os == 'macos'
         run: |
-          strip "target/${{ matrix.target }}/release/$BIN_NAME"
-          strip "target/${{ matrix.target }}/release/$BIN_NAME_SERVER"
+          strip "target/${{ matrix.build.target }}/release/$BIN_NAME"
+          strip "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER"
 
       - name: Build archive (Windows)
         if: runner.os == 'windows'
         run: |
           mkdir dist
-          cp "target/${{ matrix.target }}/release/$BIN_NAME.exe" "dist/"
-          cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER.exe" "dist/"
+          cp "target/${{ matrix.build.target }}/release/$BIN_NAME.exe" "dist/"
+          cp "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER.exe" "dist/"
 
       - name: Build archive (Unix)
         if: runner.os != 'windows'
         shell: bash
         run: |
           mkdir dist
-          cp "target/${{ matrix.target }}/release/$BIN_NAME" "dist/"
-          cp "target/${{ matrix.target }}/release/$BIN_NAME_SERVER" "dist/"
+          cp "target/${{ matrix.build.target }}/release/$BIN_NAME" "dist/"
+          cp "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER" "dist/"
 
       - uses: actions/upload-artifact@v7
         with:
-          name: bins-${{ matrix.build }}
+          name: bins-${{ matrix.build.archive }}
           path: dist
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,23 +85,23 @@ jobs:
       - name: Strip release binary (Linux & MacOS)
         if: runner.os == 'linux' || runner.os == 'macos'
         run: |
-          strip "target/${{ matrix.build.target }}/release/$BIN_NAME"
-          strip "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER"
+          strip "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME }}"
+          strip "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME_SERVER }}"
 
       - name: Build archive (Windows)
         if: runner.os == 'windows'
         run: |
           mkdir dist
-          cp "target/${{ matrix.build.target }}/release/$BIN_NAME.exe" "dist/"
-          cp "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER.exe" "dist/"
+          cp "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME }}.exe" "dist/"
+          cp "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME_SERVER }}.exe" "dist/"
 
       - name: Build archive (Unix)
         if: runner.os != 'windows'
         shell: bash
         run: |
           mkdir dist
-          cp "target/${{ matrix.build.target }}/release/$BIN_NAME" "dist/"
-          cp "target/${{ matrix.build.target }}/release/$BIN_NAME_SERVER" "dist/"
+          cp "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME }}" "dist/"
+          cp "target/${{ matrix.build.target }}/release/${{ env.BIN_NAME_SERVER }}" "dist/"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     branches: # validate workflow works as expected
       - "*"
 
+permissions:
+  contents: read
+
 env:
   BIN_NAME: termusic
   BIN_NAME_SERVER: termusic-server
@@ -112,6 +115,8 @@ jobs:
     name: Publish
     needs: [dist]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for actions/checkout to fetch code and for "upload-release-action" to actually set a release
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 on:
   workflow_dispatch: # allow manually running the workflow on a given branch to check that it works before running a release
+  schedule:
+    - cron: '0 0 * * 1' # Once every monday
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,22 +24,31 @@ jobs:
           - archive: x86_64-linux
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            features: cover,all-backends,rusty-soundtouch
+
           # linux arm64
           - archive: aarch64-linux
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            features: cover,all-backends,rusty-soundtouch
+
           # mac x86
           - archive: x86_64-macos
             os: macos-latest
             target: x86_64-apple-darwin
+            features: rusty-soundtouch,rusty-simd
+
           # mac arm64
           - archive: aarch64-macos
             os: macos-latest
             target: aarch64-apple-darwin
+            features: rusty-soundtouch,rusty-simd
+
           # windows x86
           - archive: x86_64-windows
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            features: rusty-soundtouch
 
     steps:
       - name: Checkout sources
@@ -70,17 +79,8 @@ jobs:
       - name: Run cargo test
         run: cargo test --release --target ${{ matrix.build.target }}
 
-      - name: Build release binary (Linux)
-        if: runner.os == 'linux'
-        run: cargo build --features cover,all-backends,rusty-soundtouch --release --all --target ${{ matrix.build.target }}
-
-      - name: Build release binary (MacOS)
-        if: runner.os == 'macos'
-        run: cargo build --features rusty-soundtouch,rusty-simd --release --all --target ${{ matrix.build.target }}
-
-      - name: Build release binary (Windows)
-        if: runner.os == 'windows'
-        run: cargo build --features rusty-soundtouch --release --all --target ${{ matrix.build.target }}
+      - name: Build release binary
+        run: cargo build --features ${{ matrix.build.features }} --release --all --target ${{ matrix.build.target }}
 
       - name: Strip release binary (Linux & MacOS)
         if: runner.os == 'linux' || runner.os == 'macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,10 @@ jobs:
         run: choco install protoc
 
       - name: Run cargo test
-        run: cargo test --release --target ${{ matrix.build.target }}
+        run: cargo test --release --features ${{ matrix.build.features }} --target ${{ matrix.build.target }}
 
       - name: Build release binary
-        run: cargo build --features ${{ matrix.build.features }} --release --all --target ${{ matrix.build.target }}
+        run: cargo build --release --features ${{ matrix.build.features }} --all --target ${{ matrix.build.target }}
 
       - name: Strip release binary (Linux & MacOS)
         if: runner.os == 'linux' || runner.os == 'macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-    paths:
-      - ".github/workflows/release.yml" # trigger this workflow to check itself being valid
+    # paths:
+    #   - ".github/workflows/release.yml" # trigger this workflow to check itself being valid
   pull_request:
     paths:
       - ".github/workflows/release.yml" # trigger this workflow to check itself being valid

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-99]+.[0-99]+.[0-99]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     branches: # validate workflow works as expected
       - "*"
 
@@ -69,8 +69,8 @@ jobs:
       - name: Install developer package dependencies (MacOS)
         if: runner.os == 'macos'
         run: |
-            brew update
-            brew install protobuf
+          brew update
+          brew install protobuf
 
       - name: Install developer package dependencies (Windows)
         if: runner.os == 'windows'
@@ -120,7 +120,8 @@ jobs:
 
       - uses: actions/download-artifact@v8
 
-      - run: ls -al bins-*
+      - name: List all input binaries
+        run: ls -al bins-*
 
       - name: Calculate tag name
         run: |
@@ -163,14 +164,14 @@ jobs:
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
+        # only actually publish things if a tag started this workflow
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*
           file_glob: true
-          # tag: ${{ steps.tagname.outputs.TAG }}
           tag: ${{ github.ref }}
-          overwrite: true
+          # overwrite: true
 
       - name: Extract version
         id: extract-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change: provide arm64 binaries for macos
 - Change: add `cargo-binstall` metadata to tui and server crates for pre-built binary installs.
 - Fix: change default port to `5101` to be below 49k
+- Fix server cannot be closed properly under windows, configuration are not saved.
 - Fix(tui): fix that "native" and "termusic default" theme also get auto-selected in config editor, if active.
 - Fix(tui): fix a bunch of places where colors were not applied at all or not correctly applied.
 - Fix(tui): fix help popup not having "fast navigation" (like PageUp / PageDown, Home / End).
@@ -19,10 +20,8 @@
 - Fix(tui): fix migu search/lyric download error.
 - Fix(server): on rusty backend with `soundtouch`, fix a issue causing seemingly long delay between tempo changes.
 - Fix(server): on rusty backend with `soundtouch`, fix not being able to build on "eager" linkers (ex windows-msvc and windows-gnu)
-- Fix(server and tui): server cannot be closed properly under windows, configuration are not saved.
 - Feat: add ability to control startup playing state behavior.
 - Feat: add playlist loop mode to only play the playlist once, then stop.
-- Feat: add ability to control startup playing state behavior.
 - Feat(tui): change default theme to be "Native".
 - Feat(server): change volume scaling from linear to cubic for better perceptual volume consistency.
 


### PR DESCRIPTION
This PR applies some changes with regards to what was discussed in #695.
In detail:
- (explicitly) limit permissions available
- make the `release` workflow easier to parse at a glance
- add options to test the `release` workflow other than actually releasing things
  - `workflow_dispatch`: manually trigger a run (without releasing), to make sure it actually fully builds and is still valid
  - `pull_request`: make sure it is valid and working when a pull request changes it
  - `schedule`: make sure it stays valid and builds correctly (once every week)

Note that i could *not* make a broader `push` test, as `paths` combined with either `tags` or `branches` creates a AND condition instead of a OR. (in this case, only triggers a workflow run if a tag is pushed *and* that tag modified the given files)
Additionally, i could not figure out a good way to merge `build` and `release` yet, but this is still a improvement.