### PR TITLE
Some refactor for `TagEditor` and Band-Aid fix for lyric reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix(tui): fix yt-dlp download error caused by orx treeview.
 - Fix(tui): fix netease lyric download error.
 - Fix(tui): fix migu search/lyric download error.
+- Fix(tui): in tag editor, dont save the track on lyric delete (now only on "Save" action is the change actually persistet).
 - Fix(server): on rusty backend with `soundtouch`, fix a issue causing seemingly long delay between tempo changes.
 - Fix(server): on rusty backend with `soundtouch`, fix not being able to build on "eager" linkers (ex windows-msvc and windows-gnu)
 - Feat: add ability to control startup playing state behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix(tui): fix netease lyric download error.
 - Fix(tui): fix migu search/lyric download error.
 - Fix(tui): in tag editor, dont save the track on lyric delete (now only on "Save" action is the change actually persistet).
+- Fix(tui): on tag editor close, force reload of lyrics if the current track was modified.
 - Fix(server): on rusty backend with `soundtouch`, fix a issue causing seemingly long delay between tempo changes.
 - Fix(server): on rusty backend with `soundtouch`, fix not being able to build on "eager" linkers (ex windows-msvc and windows-gnu)
 - Feat: add ability to control startup playing state behavior.

--- a/lib/src/track.rs
+++ b/lib/src/track.rs
@@ -501,6 +501,15 @@ impl Track {
             Err(Some(err)) => Err(err),
         }
     }
+
+    /// Remove the given path from the Lyric parse cache, forcing a reload upon next access.
+    ///
+    /// If the key does not exist, it will not fail.
+    pub fn unset_cache_for_path(path: &Path) {
+        LYRIC_CACHE.with_borrow_mut(|cache| {
+            cache.pop(path);
+        });
+    }
 }
 
 impl PartialEq<PlaylistTrackSource> for &Track {

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -6,8 +6,8 @@ use termusiclib::common::const_unknown::{UNKNOWN_ARTIST, UNKNOWN_TITLE};
 use termusiclib::config::SharedTuiSettings;
 use termusiclib::player::RunningStatus;
 use termusiclib::podcast::episode::Episode;
-use termusiclib::track::MediaTypes;
 use termusiclib::track::MediaTypesSimple;
+use termusiclib::track::{MediaTypes, Track};
 use tui_realm_stdlib::Textarea;
 use tuirealm::command::{Cmd, Direction, Position};
 use tuirealm::event::{Key, KeyEvent, KeyModifiers};
@@ -124,6 +124,7 @@ impl Component<Msg, UserEvent> for Lyric {
 }
 
 impl Model {
+    /// Remount and reload the lyrics from the current track.
     pub fn lyric_reload(&mut self) {
         assert!(
             self.app
@@ -136,6 +137,20 @@ impl Model {
         );
         self.lyric_update_title();
         self.lyric_update();
+    }
+
+    /// Force reload lyrics from file. For example after a Tag Editor exit.
+    ///
+    /// If the current track type is [`Track`], then also unset the Lyric cache for the current track's path.
+    pub fn lyric_reload_from_file(&mut self) {
+        info!("Forcing reload of lyrics");
+        self.current_track_lyric.take();
+
+        if let Some(track) = self.playback.current_track().and_then(|v| v.as_track()) {
+            Track::unset_cache_for_path(track.path());
+        }
+
+        self.lyric_reload();
     }
 
     pub fn lyric_update_for_podcast_by_current_track(&mut self) {

--- a/tui/src/ui/components/tag_editor/mod.rs
+++ b/tui/src/ui/components/tag_editor/mod.rs
@@ -11,7 +11,7 @@ mod view;
 
 // -- exports
 pub use te_counter_delete_lyric::{TECounterDelete, TECounterSave};
-pub use te_input::*;
+pub use te_input::{TEInputAlbum, TEInputArtist, TEInputGenre, TEInputTitle};
 pub use te_select_lyric::TESelectLyric;
 pub use te_table_lyric_options::TETableLyricOptions;
 pub use te_textarea_lyric::TETextareaLyric;

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -218,7 +218,7 @@ pub struct TECounterDelete {
 }
 
 impl TECounterDelete {
-    pub fn new(initial_value: Option<usize>, text: &str, config: SharedTuiSettings) -> Self {
+    pub fn new(initial_value: Option<usize>, config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Counter::default()
@@ -240,7 +240,7 @@ impl TECounterDelete {
                         .get_color_from_theme(ColorTermusic::Red),
                 )
                 .modifiers(TextModifiers::BOLD)
-                .text(text)
+                .text("Delete Selected")
                 .value(initial_value)
         };
 
@@ -300,7 +300,7 @@ pub struct TECounterSave {
 }
 
 impl TECounterSave {
-    pub fn new(initial_value: Option<usize>, text: &str, config: SharedTuiSettings) -> Self {
+    pub fn new(initial_value: Option<usize>, config: SharedTuiSettings) -> Self {
         let component = {
             let config = config.read();
             Counter::default()
@@ -313,7 +313,7 @@ impl TECounterSave {
                         .modifiers(BorderType::Rounded),
                 )
                 .modifiers(TextModifiers::BOLD)
-                .text(text)
+                .text("Export LRC")
                 .value(initial_value)
         };
 

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -135,7 +135,7 @@ impl MockComponent for Counter {
             let text = if let Some(value) = value {
                 format!("{text_base} ({value})")
             } else {
-                "{text_base} (-)".to_string()
+                "None selected (-)".to_string()
             };
 
             let alignment = self

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -398,9 +398,9 @@ impl Model {
     }
 
     /// Save the currently selected Lyric text as a LRC file.
-    pub fn te_save_lyric(&mut self) -> Result<()> {
+    pub fn te_export_lyric(&mut self) -> Result<()> {
         if let Some(track) = self.tageditor_song.as_mut() {
-            track.save_lrc_selected()?;
+            track.export_lrc_selected()?;
         }
         Ok(())
     }

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -370,7 +370,7 @@ impl Model {
     ///
     /// This function only modifies the in-memory date and does *not* save the changed data.
     pub fn te_delete_lyric(&mut self) {
-        if let Some(song) = self.tageditor_song.as_mut() {
+        if let Some(song) = self.tageditor.song.as_mut() {
             if song.lyric_frames().is_empty() {
                 song.set_parsed_lyrics(None);
                 return;
@@ -383,7 +383,7 @@ impl Model {
             }
 
             // The unwrap should never fail as we literally just had a exclusive reference to it.
-            let song = self.tageditor_song.take().unwrap();
+            let song = self.tageditor.song.take().unwrap();
             // The unwrap should also never happen as all components should be properly mounted
             match self.init_by_song(song) {
                 Ok(()) => {}
@@ -394,7 +394,7 @@ impl Model {
 
     /// Save the currently selected Lyric text as a LRC file.
     pub fn te_export_lyric(&mut self) -> Result<()> {
-        if let Some(track) = self.tageditor_song.as_mut() {
+        if let Some(track) = self.tageditor.song.as_mut() {
             track.export_lrc_selected()?;
         }
         Ok(())

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -366,6 +366,8 @@ impl Component<Msg, UserEvent> for TECounterSave {
     }
 }
 impl Model {
+    /// Delete the currently selected lyric index and save the track.
+    // TODO: this should likely only delete it in-memory, and wait for a `Save` event to actually save.
     pub fn te_delete_lyric(&mut self) {
         if let Some(song) = self.tageditor_song.as_mut() {
             if song.lyric_frames().is_empty() {
@@ -395,6 +397,7 @@ impl Model {
         }
     }
 
+    /// Save the currently selected Lyric text as a LRC file.
     pub fn te_save_lyric(&mut self) -> Result<()> {
         if let Some(track) = self.tageditor_song.as_mut() {
             track.save_lrc_selected()?;

--- a/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
+++ b/tui/src/ui/components/tag_editor/te_counter_delete_lyric.rs
@@ -366,8 +366,9 @@ impl Component<Msg, UserEvent> for TECounterSave {
     }
 }
 impl Model {
-    /// Delete the currently selected lyric index and save the track.
-    // TODO: this should likely only delete it in-memory, and wait for a `Save` event to actually save.
+    /// Delete the currently selected lyric index.
+    ///
+    /// This function only modifies the in-memory date and does *not* save the changed data.
     pub fn te_delete_lyric(&mut self) {
         if let Some(song) = self.tageditor_song.as_mut() {
             if song.lyric_frames().is_empty() {
@@ -380,19 +381,13 @@ impl Model {
             {
                 song.set_lyric_selected_index(song.lyric_selected_index() - 1);
             }
-            match song.save_tag() {
-                Ok(()) => {
-                    // the unwrap should never happen as we are in a branch where we had a reference to it
-                    let song = self.tageditor_song.take().unwrap();
-                    // the unwrap should also never happen as all components should be properly mounted
-                    match self.init_by_song(song) {
-                        Ok(()) => {}
-                        Err(e) => self.mount_error_popup(e),
-                    }
-                }
-                Err(e) => {
-                    self.mount_error_popup(e);
-                }
+
+            // The unwrap should never fail as we literally just had a exclusive reference to it.
+            let song = self.tageditor_song.take().unwrap();
+            // The unwrap should also never happen as all components should be properly mounted
+            match self.init_by_song(song) {
+                Ok(()) => {}
+                Err(e) => self.mount_error_popup(e),
             }
         }
     }

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -329,6 +329,7 @@ impl Model {
                 song.set_genre(&genre);
             }
             song.save_tag()?;
+            self.tageditor.has_changed = true;
             // the unwrap should also never happen as all components should be properly mounted
             self.init_by_song(song).unwrap();
             self.playlist_update_library_delete();
@@ -397,6 +398,7 @@ impl Model {
     /// Followup function to [`te_load_lyric_and_photo`](Self::te_load_lyric_and_photo)
     /// that executes the remaining operations on `Done` message which require access to `Model` again.
     pub fn te_load_lyric_and_photo_done(&mut self, song: Box<TETrack>) {
+        self.tageditor.has_changed = true;
         let song = *song;
         // the unwrap should also never happen as all components should be properly mounted
         self.init_by_song(song).unwrap();

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -217,6 +217,7 @@ impl Model {
         self.te_set_results(table).unwrap();
     }
 
+    /// Run a search with the current data.
     pub fn te_songtag_search(&mut self) {
         let mut search_str = String::new();
         if let Ok(State::One(StateValue::String(artist))) =
@@ -264,6 +265,7 @@ impl Model {
         }
     }
 
+    /// Download the given index from the list.
     pub fn te_songtag_download(&mut self, index: usize) -> Result<()> {
         let song_tag = self
             .songtag_options
@@ -300,6 +302,8 @@ impl Model {
         }
         Ok(())
     }
+
+    /// Save the current tag editor state to the track.
     pub fn te_rename_song_by_tag(&mut self) -> Result<()> {
         if let Some(mut song) = self.tageditor_song.clone() {
             if let Ok(State::One(StateValue::String(artist))) =

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -304,7 +304,7 @@ impl Model {
     }
 
     /// Save the current tag editor state to the track.
-    pub fn te_rename_song_by_tag(&mut self) -> Result<()> {
+    pub fn te_save_tag(&mut self) -> Result<()> {
         if let Some(mut song) = self.tageditor_song.clone() {
             if let Ok(State::One(StateValue::String(artist))) =
                 self.app.state(&Id::TagEditor(IdTagEditor::InputArtist))

--- a/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
+++ b/tui/src/ui/components/tag_editor/te_table_lyric_options.rs
@@ -150,7 +150,7 @@ impl Model {
         {
             return;
         }
-        self.songtag_options = items;
+        self.tageditor.songtag_results = items;
         self.te_sync_songtag_options();
         assert!(
             self.app
@@ -169,7 +169,7 @@ impl Model {
             .theme
             .library_highlight();
 
-        for (idx, record) in self.songtag_options.iter().enumerate() {
+        for (idx, record) in self.tageditor.songtag_results.iter().enumerate() {
             if idx > 0 {
                 table.add_row();
             }
@@ -233,7 +233,7 @@ impl Model {
         }
 
         if search_str.len() < 4
-            && let Some(song) = &self.tageditor_song
+            && let Some(song) = &self.tageditor.song
             && let Some(stem) = song.path().file_stem()
         {
             search_str = stem.to_string_lossy().to_string();
@@ -268,11 +268,12 @@ impl Model {
     /// Download the given index from the list.
     pub fn te_songtag_download(&mut self, index: usize) -> Result<()> {
         let song_tag = self
-            .songtag_options
+            .tageditor
+            .songtag_results
             .get(index)
             .cloned()
             .with_context(|| format!("no song_tag with index {index} found"))?;
-        if let Some(current_track) = &self.tageditor_song {
+        if let Some(current_track) = &self.tageditor.song {
             let file = current_track.path().to_path_buf();
             // this needs to be wrapped as this is not running another thread but some main-runtime thread and so needs to inform the runtime to hand-off other tasks
             // though i am not fully sure if that is 100% the case, this avoid the panic though
@@ -305,7 +306,7 @@ impl Model {
 
     /// Save the current tag editor state to the track.
     pub fn te_save_tag(&mut self) -> Result<()> {
-        if let Some(mut song) = self.tageditor_song.clone() {
+        if let Some(mut song) = self.tageditor.song.clone() {
             if let Ok(State::One(StateValue::String(artist))) =
                 self.app.state(&Id::TagEditor(IdTagEditor::InputArtist))
             {
@@ -339,12 +340,13 @@ impl Model {
     ///
     /// Will send a message once its done.
     pub fn te_load_lyric_and_photo(&mut self, index: usize) -> Result<()> {
-        if self.songtag_options.is_empty() {
+        if self.tageditor.songtag_results.is_empty() {
             return Ok(());
         }
-        if let Some(mut song) = self.tageditor_song.clone() {
+        if let Some(mut song) = self.tageditor.song.clone() {
             let song_tag = self
-                .songtag_options
+                .tageditor
+                .songtag_results
                 .get(index)
                 .cloned()
                 .ok_or_else(|| anyhow!("cannot get songtag"))?;

--- a/tui/src/ui/components/tag_editor/te_track.rs
+++ b/tui/src/ui/components/tag_editor/te_track.rs
@@ -232,7 +232,7 @@ impl TETrack {
     }
 
     /// Save selected lyric to lrc file in the same directory
-    ///  of track, with same name but different extension
+    ///  of track, with same name but different extension.
     pub fn save_lrc_selected(&mut self) -> Result<()> {
         if self.lyric_frames.is_empty() {
             return Ok(());

--- a/tui/src/ui/components/tag_editor/te_track.rs
+++ b/tui/src/ui/components/tag_editor/te_track.rs
@@ -233,7 +233,7 @@ impl TETrack {
 
     /// Save selected lyric to lrc file in the same directory
     ///  of track, with same name but different extension.
-    pub fn save_lrc_selected(&mut self) -> Result<()> {
+    pub fn export_lrc_selected(&mut self) -> Result<()> {
         if self.lyric_frames.is_empty() {
             return Ok(());
         }

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -24,7 +24,7 @@ impl Model {
                 self.te_delete_lyric();
             }
             TEMsg::CounterSaveOk => {
-                if let Err(e) = self.te_save_lyric() {
+                if let Err(e) = self.te_export_lyric() {
                     self.mount_error_popup(e.context("save lrc selected"));
                 }
             }
@@ -55,7 +55,7 @@ impl Model {
                 self.mount_error_popup(anyhow!(err));
             }
             TEMsg::Save => {
-                if let Err(e) = self.te_rename_song_by_tag() {
+                if let Err(e) = self.te_save_tag() {
                     self.mount_error_popup(e.context("rename song by tag"));
                 }
             }

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -15,6 +15,18 @@ impl Model {
             }
             TEMsg::Close => {
                 if let Some(s) = self.tageditor.song.take() {
+                    // force a reload of lyrics if the tag editor changed the track, and the loaded lyrics are for this path
+                    if self.tageditor.has_changed
+                        && self
+                            .current_track_lyric
+                            .as_ref()
+                            .is_some_and(|v| v.for_track == s.path())
+                    {
+                        self.lyric_reload_from_file();
+                    }
+                    // reset value for next time tag editor gets opened
+                    self.tageditor.has_changed = false;
+
                     self.new_library_reload_and_focus(s.into_path());
                 }
                 self.umount_tageditor();

--- a/tui/src/ui/components/tag_editor/update.rs
+++ b/tui/src/ui/components/tag_editor/update.rs
@@ -14,7 +14,7 @@ impl Model {
                 self.mount_tageditor(&path);
             }
             TEMsg::Close => {
-                if let Some(s) = self.tageditor_song.clone() {
+                if let Some(s) = self.tageditor.song.take() {
                     self.new_library_reload_and_focus(s.into_path());
                 }
                 self.umount_tageditor();
@@ -29,7 +29,7 @@ impl Model {
                 }
             }
             TEMsg::SelectLyricOk(index) => {
-                if let Some(mut song) = self.tageditor_song.take() {
+                if let Some(mut song) = self.tageditor.song.take() {
                     song.set_lyric_selected_index(index);
                     // the unwrap should also never happen as all components should be properly mounted
                     self.init_by_song(song).unwrap();

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -266,7 +266,7 @@ impl Model {
 
     /// Set the Lyric section of the tag-editor to the Lyrics based on the provided Track
     pub fn init_by_song(&mut self, track: TETrack) -> Result<()> {
-        self.tageditor_song = Some(track);
+        self.tageditor.song = Some(track);
 
         self.init_metadata()?;
 
@@ -277,7 +277,7 @@ impl Model {
     ///
     /// Expects a current `tageditor_song` to be set.
     fn init_metadata(&mut self) -> Result<()> {
-        let Some(track) = self.tageditor_song.as_ref() else {
+        let Some(track) = self.tageditor.song.as_ref() else {
             // No Metadata to change.
             return Ok(());
         };
@@ -318,7 +318,7 @@ impl Model {
 
     /// Extract the lyric data from the current track and set it in the Tag Editor fields.
     fn init_lyric_data(&mut self) -> Result<()> {
-        let track = self.tageditor_song.as_ref().unwrap();
+        let track = self.tageditor.song.as_ref().unwrap();
         let lyric_frames = track.lyric_frames();
 
         if lyric_frames.is_empty() {

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -305,8 +305,7 @@ impl Model {
         let lyric_frames = s.lyric_frames();
 
         if lyric_frames.is_empty() {
-            self.init_by_song_no_lyric();
-            return Ok(());
+            return self.init_by_song_no_lyric();
         }
 
         let vec_lang: Vec<PropValue> = lyric_frames
@@ -331,8 +330,7 @@ impl Model {
             (s.lyric_selected(), vec_lang.get(selected_index))
         else {
             // this should not happen as if it is Some above, there should be at least one entry in the vec.
-            self.init_by_song_no_lyric();
-            return Ok(());
+            return self.init_by_song_no_lyric();
         };
         let selected_desc = selected_desc
             .as_str()
@@ -377,50 +375,36 @@ impl Model {
     }
 
     /// Set the Lyric section of the tag-editor to "No Lyrics" (ie clear state)
-    fn init_by_song_no_lyric(&mut self) {
-        assert!(
-            self.app
-                .attr(
-                    &Id::TagEditor(IdTagEditor::SelectLyric),
-                    Attribute::Content,
-                    AttrValue::Payload(PropPayload::Vec(
-                        ["Empty"]
-                            .iter()
-                            .map(|x| PropValue::Str((*x).to_string()))
-                            .collect(),
-                    )),
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .attr(
-                    &Id::TagEditor(IdTagEditor::CounterDelete),
-                    Attribute::Value,
-                    AttrValue::Payload(PropPayload::None),
-                )
-                .is_ok()
-        );
+    fn init_by_song_no_lyric(&mut self) -> Result<()> {
+        self.app.attr(
+            &Id::TagEditor(IdTagEditor::SelectLyric),
+            Attribute::Content,
+            AttrValue::Payload(PropPayload::Vec(
+                ["Empty"]
+                    .iter()
+                    .map(|x| PropValue::Str((*x).to_string()))
+                    .collect(),
+            )),
+        )?;
+        self.app.attr(
+            &Id::TagEditor(IdTagEditor::CounterDelete),
+            Attribute::Value,
+            AttrValue::Payload(PropPayload::None),
+        )?;
 
-        assert!(
-            self.app
-                .attr(
-                    &Id::TagEditor(IdTagEditor::TextareaLyric),
-                    Attribute::Title,
-                    AttrValue::Title(("Empty Lyrics".to_string(), Alignment::Left))
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .attr(
-                    &Id::TagEditor(IdTagEditor::TextareaLyric),
-                    Attribute::Text,
-                    AttrValue::Payload(PropPayload::Vec(vec![PropValue::TextSpan(
-                        TextSpan::from("No Lyrics.")
-                    ),]))
-                )
-                .is_ok()
-        );
+        self.app.attr(
+            &Id::TagEditor(IdTagEditor::TextareaLyric),
+            Attribute::Title,
+            AttrValue::Title(("Empty Lyrics".to_string(), Alignment::Left)),
+        )?;
+        self.app.attr(
+            &Id::TagEditor(IdTagEditor::TextareaLyric),
+            Attribute::Text,
+            AttrValue::Payload(PropPayload::Vec(vec![PropValue::TextSpan(TextSpan::from(
+                "No Lyrics.",
+            ))])),
+        )?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -265,12 +265,23 @@ impl Model {
     }
 
     /// Set the Lyric section of the tag-editor to the Lyrics based on the provided Track
-    #[allow(clippy::too_many_lines)]
-    pub fn init_by_song(&mut self, s: TETrack) -> Result<()> {
-        self.tageditor_song = Some(s);
-        // Unwrap safe as we literally just assigned it
-        let s = self.tageditor_song.as_ref().unwrap();
-        if let Some(artist) = s.artist() {
+    pub fn init_by_song(&mut self, track: TETrack) -> Result<()> {
+        self.tageditor_song = Some(track);
+
+        self.init_metadata()?;
+
+        self.init_lyric_data()
+    }
+
+    /// Read the metadata from the current track and set it to the Tag Editor fields.
+    ///
+    /// Expects a current `tageditor_song` to be set.
+    fn init_metadata(&mut self) -> Result<()> {
+        let Some(track) = self.tageditor_song.as_ref() else {
+            // No Metadata to change.
+            return Ok(());
+        };
+        if let Some(artist) = track.artist() {
             self.app.attr(
                 &Id::TagEditor(IdTagEditor::InputArtist),
                 Attribute::Value,
@@ -278,7 +289,7 @@ impl Model {
             )?;
         }
 
-        if let Some(title) = s.title() {
+        if let Some(title) = track.title() {
             self.app.attr(
                 &Id::TagEditor(IdTagEditor::InputTitle),
                 Attribute::Value,
@@ -286,7 +297,7 @@ impl Model {
             )?;
         }
 
-        if let Some(album) = s.album() {
+        if let Some(album) = track.album() {
             self.app.attr(
                 &Id::TagEditor(IdTagEditor::InputAlbum),
                 Attribute::Value,
@@ -294,7 +305,7 @@ impl Model {
             )?;
         }
 
-        if let Some(genre) = s.genre() {
+        if let Some(genre) = track.genre() {
             self.app.attr(
                 &Id::TagEditor(IdTagEditor::InputGenre),
                 Attribute::Value,
@@ -302,10 +313,16 @@ impl Model {
             )?;
         }
 
-        let lyric_frames = s.lyric_frames();
+        Ok(())
+    }
+
+    /// Extract the lyric data from the current track and set it in the Tag Editor fields.
+    fn init_lyric_data(&mut self) -> Result<()> {
+        let track = self.tageditor_song.as_ref().unwrap();
+        let lyric_frames = track.lyric_frames();
 
         if lyric_frames.is_empty() {
-            return self.init_by_song_no_lyric();
+            return self.init_lyric_data_empty();
         }
 
         let vec_lang: Vec<PropValue> = lyric_frames
@@ -324,13 +341,13 @@ impl Model {
             .map(PropValue::Str)
             .collect();
 
-        let selected_index = s.lyric_selected_index();
+        let selected_index = track.lyric_selected_index();
         // get access to "Lyric" instance for text and modified description for display
         let (Some(vec_lang_selected), Some(selected_desc)) =
-            (s.lyric_selected(), vec_lang.get(selected_index))
+            (track.lyric_selected(), vec_lang.get(selected_index))
         else {
             // this should not happen as if it is Some above, there should be at least one entry in the vec.
-            return self.init_by_song_no_lyric();
+            return self.init_lyric_data_empty();
         };
         let selected_desc = selected_desc
             .as_str()
@@ -375,16 +392,11 @@ impl Model {
     }
 
     /// Set the Lyric section of the tag-editor to "No Lyrics" (ie clear state)
-    fn init_by_song_no_lyric(&mut self) -> Result<()> {
+    fn init_lyric_data_empty(&mut self) -> Result<()> {
         self.app.attr(
             &Id::TagEditor(IdTagEditor::SelectLyric),
             Attribute::Content,
-            AttrValue::Payload(PropPayload::Vec(
-                ["Empty"]
-                    .iter()
-                    .map(|x| PropValue::Str((*x).to_string()))
-                    .collect(),
-            )),
+            AttrValue::Payload(PropPayload::Vec(vec![PropValue::Str("Empty".to_string())])),
         )?;
         self.app.attr(
             &Id::TagEditor(IdTagEditor::CounterDelete),

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -188,20 +188,12 @@ impl Model {
         )?;
         self.app.remount(
             Id::TagEditor(IdTagEditor::CounterDelete),
-            Box::new(TECounterDelete::new(
-                None,
-                "Delete Selected",
-                self.config_tui.clone(),
-            )),
+            Box::new(TECounterDelete::new(None, self.config_tui.clone())),
             Vec::new(),
         )?;
         self.app.remount(
             Id::TagEditor(IdTagEditor::CounterSave),
-            Box::new(TECounterSave::new(
-                None,
-                "Save LRC",
-                self.config_tui.clone(),
-            )),
+            Box::new(TECounterSave::new(None, self.config_tui.clone())),
             Vec::new(),
         )?;
         self.app.remount(

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -18,6 +18,7 @@ use crate::ui::model::Model;
 use crate::ui::utils::{draw_area_in_absolute, draw_area_top_right_absolute};
 
 impl Model {
+    /// Draw the Tag Editor.
     #[allow(clippy::too_many_lines)]
     pub fn view_tag_editor(&mut self) {
         self.terminal
@@ -140,7 +141,7 @@ impl Model {
             .expect("Expected to draw without error");
     }
 
-    /// Mount / Remount the Tag Editor
+    /// Mount / Remount the Tag Editor.
     fn remount_tageditor(&mut self) -> Result<()> {
         self.app.remount(
             Id::Label,
@@ -243,7 +244,7 @@ impl Model {
         }
     }
 
-    /// Unmount the Tag Editor
+    /// Unmount the Tag Editor Components.
     fn umount_tageditor_inner(&mut self) -> Result<()> {
         self.app.umount(&Id::TagEditor(IdTagEditor::LabelHint))?;
         self.app.umount(&Id::TagEditor(IdTagEditor::InputArtist))?;
@@ -262,6 +263,7 @@ impl Model {
         Ok(())
     }
 
+    /// Unmount all tag editor components.
     pub fn umount_tageditor(&mut self) {
         self.mount_label_help();
         self.umount_tageditor_inner().unwrap();

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -268,8 +268,13 @@ impl ExtraLyricData {
 /// All data specific to the Tag Editor.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct TagEditor {
+    /// The current track open in the tag editor.
     pub song: Option<TETrack>,
+    /// Stores the result of the songtag fetching.
     pub songtag_results: Vec<SongTag>,
+    /// Track whether the Tag Editor modified the current track or not.
+    /// Used to force reload of metadata (currently only lyrics)
+    pub has_changed: bool,
 }
 
 pub type TxToMain = UnboundedSender<Msg>;

--- a/tui/src/ui/model/mod.rs
+++ b/tui/src/ui/model/mod.rs
@@ -265,6 +265,13 @@ impl ExtraLyricData {
     }
 }
 
+/// All data specific to the Tag Editor.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TagEditor {
+    pub song: Option<TETrack>,
+    pub songtag_results: Vec<SongTag>,
+}
+
 pub type TxToMain = UnboundedSender<Msg>;
 
 pub struct Model {
@@ -287,8 +294,8 @@ pub struct Model {
     pub dw: DatabaseWidgetData,
     pub podcast: PodcastWidgetData,
     pub config_editor: ConfigEditorData,
+    pub tageditor: TagEditor,
 
-    pub tageditor_song: Option<TETrack>,
     pub current_track_lyric: Option<ExtraLyricData>,
     pub playback: Playback,
 
@@ -298,7 +305,6 @@ pub struct Model {
     pub xywh: xywh::Xywh,
 
     youtube_options: YoutubeOptions,
-    pub songtag_options: Vec<SongTag>,
     pub download_tracker: DownloadTracker,
     /// Taskpool to limit number of active network requests
     ///
@@ -412,12 +418,11 @@ impl Model {
             terminal,
             config_server,
             config_tui,
-            tageditor_song: None,
 
+            tageditor: TagEditor::default(),
             youtube_options: YoutubeOptions::default(),
             #[cfg(all(feature = "cover-ueberzug", not(target_os = "windows")))]
             ueberzug_instance,
-            songtag_options: vec![],
             viuer_supported,
             db,
             layout: TermusicLayout::TreeView,

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -719,27 +719,40 @@ pub enum YSMsg {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TEMsg {
+    /// Open the Tag Editor with the given path.
     Open(PathBuf),
+    /// Close the Tag Editor without saving.
+    /// Also reload's the Music Library and focuses the current Tag Editor's path.
     Close,
+    /// Lyric Delete button has been pressed.
     CounterDeleteOk,
+    /// Lyric Save button has been pressed.
     CounterSaveOk,
-    Download(usize),
-    /// Request to embed the data from `param1` into the current track.
+    /// Embed the data from the given index from the search list into the current track.
     Embed(usize),
     /// Embedding has finished.
     // Box to not increase the size of this enum when not necessary.
     EmbedDone(Box<TETrack>),
-    /// Indicates that the embedding has failed.
+    /// Embedding has failed.
     ///
     /// `(ErrorAsString)`
     EmbedErr(String),
 
+    /// Focus change.
     Focus(TFMsg),
+    /// Save the current data into the current track.
     Save,
-    Search,
+    /// Change the selected lyric data index.
     SelectLyricOk(usize),
 
+    /// Run a search with the current data.
+    Search,
+    /// Search has finished.
     SearchLyricResult(SongtagSearchResult),
+
+    /// Download the given index from the search lsit.
+    Download(usize),
+    /// Track download messages.
     TrackDownloadResult(TrackDLMsg),
     /// Indicates that the preparation for the track download have failed
     ///


### PR DESCRIPTION
This PR refactors a little regarding the Tag Editor to read better and to band-aid fix #705.
In more details:
- refactors a bunch of code to be in their own structs / functions, so that it is easier to read
- dont immediately save when deleting a lyric (instead only on save action)
- change some strings (and function names) to make it more clear what they do (ex `Export LRC`)
- force reload of lyrics on tag editor exit, if the current track has been modified

This is not a full fix regarding metadata, but enough of a fix that it could be quickly done, fix #705 and be included in the next (hopefully soon) version.
This is not a replacement of refactoring the server side playlist / track handling and metadata updating.