### PR TITLE
Add common `CODE_OF_CONDUCT` and update `CONTRIBUTING`

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,91 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **contact a maintainer either via `@tag` in the issue itself, or via email (which can be found in commits).**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+****
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,78 @@
 # Contributing
 
-## Open an issue
+## Issue reports
 
 Open an issue when:
 
-- You have questions or concerns regarding the project or the application itself.
 - You have a bug to report.
-- You have a feature or a suggestion to improve Termusic to submit.
+- You have a suggestion on how to improve the project. (Consider opening a discussion instead)
 
-## Preferred contributions
+## Discussions
 
-Any contribution are welcome and I'll try my best to merge any PRs.
-Please commit to master branch and it's usually the most stable branch. dev branch is not stable, and probably crazy things can happen, for example, cannot build at all. I'll manage the difference between these two branches and you don't need to modify your PRs.
+Open a discussion if:
 
-Thank you for any contribution!
-Larry Hao
+- You have questions or concerns regarding the project or the application itself. (Use Category `Q&A`)
+- You have a idea to extend the project or a new feature idea. (Use Categroy `Ideas`)
+
+## Contribuing code
+
+### Commits
+
+For a commit, we expect the code:
+
+- Builds should not fail with the default features. (or the features this code touches)
+- Properly formatted code. (via `cargo +nightly fmt`)
+- No Clippy warnings. (via `cargo clippy`)
+- To follow the general coding style of surrounding code.
+- To not add code which would have a conflicting License.
+
+#### Size of the commits
+
+Commit should aim to be minimal and only a single feature related.
+
+Targeted / minimal commits help in:
+
+- review (PRs / `git blame`)
+- debugging (`git bisect`)
+- changelog generation
+- easier changes in case a PR needs to be rebased
+- revertion
+
+TL;DR: commit often, not all at once.
+
+### Commit messages
+
+Commit messages are expected to be [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Specifically, we use:
+
+1. For types:
+   - `feat`: Feature work, which would not fall into `refactor`, `fix` or `style`.
+   - `fix`: A minor fix, which does not change much overall.
+   - `refactor`: A Code refactor that does not change the observable behavior of the code.
+   - `style`: A style only change. (ex. `cargo clippy --fix`)
+   - `deps`: A Dependency update. (includes updates necessary for breaking dependency updates)
+   - `docs`: Documentation update. (ex. for `README`; code should use `style` instead)
+   - `chore`: Anything that does not touch the code itself and does not fall into any other category like `docs`.
+   - `revert`: A Revert commit. (may be excempt from following conventional commits)
+   - `merge`: A Merge commit. (may be excempt from following conventional commits)
+2. For Scope:
+   - for `deps`, use the dependency that is updated
+   - for `chore` and `docs`, use the basename of the file (ex. `CODE_OF_CONDUCT`), but include extension or a path if necesary. (ex. `Cargo.toml`; `workflows/release`)
+   - for code (`feat`, `fix`, `refactor`, `style`), use the common ancestor *module* path that is modified. (ex. on a single file `tui::ui::components::lyric`; many changes in a package `tui`) If there is no common ancestor (ex. changes across `lib` and `tui`), use `tui & lib` or dont use a scope.
+3. For description:
+   - include a simple summary for the changes; anything more extensive should use the body
+4. For footer:
+   - include `BREAKING CHANGE:` if the change is a observable breaking change (ex. removing support for a config version)
+   - include references to the issue / PR this commit handles (ex. `fixes #1`; `re #1`)
+
+Please keep in mind the project is `termusic` which is not meant to be consumed outside of `termusic`(TUI) and `termusic-server`, so any "observable" change is a change that the user would notice (ex. Changing the config; fixing TUI text).
+
+Note that for simple changes, squash merging may be used and the commit message reworded.
+
+### Pull requests
+
+Pull requests are expected to:
+
+- target the default (`master`) branch, unless specified otherwise.
+- pass *all* github CI actions, which indlues all things from [Commits](#commits) and passing of all tests.


### PR DESCRIPTION
This PR add a common `CODE_OF_CONDUCT`(`Contributor Covenant`) that should be common knowledge, but would still be good to have as a reference, and updates the `CONTRIBUTING` guidelines to be more strict.

For `CONTRIBUTING` i have gone with the common conventional-commits style and adapted it to what i had practically used until now for this project.
This should allow us to add tools like [`git-cliff`](https://crates.io/crates/git-cliff) at a later date for automatic CHANGELOG generation, and then maybe even upgrade to use [`release-plz`](https://release-plz.ieni.dev/) ([blog post](https://blog.orhun.dev/automated-rust-releases/)) for automated releases (this tool actually makes use of `git-cliff`).

fixes #693 