### PR TITLE
Decouple Playlist and current playing track

### DIFF
--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -141,8 +141,6 @@ message UpdateGaplessChanged {
 message UpdateTrackChanged {
   // The index into the playlist of which track changed.
   uint64 current_track_index = 1;
-  // Indicates if this update is a change to a new track (not just metadata change)
-  bool current_track_updated = 2;
 
   // all values below should be moved into their own "Track" message at some point
   // instead of having the TUI fetch everything from the file itself

--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -118,8 +118,6 @@ impl From<PlayerProgress> for protobuf::UpdateProgress {
 pub struct TrackChangedInfo {
     /// Current track index in the playlist
     pub current_track_index: u64,
-    /// Indicate if the track changed to another track
-    pub current_track_updated: bool,
     /// Title of the current track / radio
     pub title: Option<String>,
     /// Current progress of the track
@@ -167,7 +165,6 @@ impl From<UpdateEvents> for protobuf::StreamUpdates {
             }
             UpdateEvents::TrackChanged(info) => StreamTypes::TrackChanged(UpdateTrackChanged {
                 current_track_index: info.current_track_index,
-                current_track_updated: info.current_track_updated,
                 optional_title: info
                     .title
                     .map(protobuf::update_track_changed::OptionalTitle::Title),
@@ -208,7 +205,6 @@ impl TryFrom<protobuf::StreamUpdates> for UpdateEvents {
             StreamTypes::MissedEvents(ev) => Self::MissedEvents { amount: ev.amount },
             StreamTypes::TrackChanged(ev) => Self::TrackChanged(TrackChangedInfo {
                 current_track_index: ev.current_track_index,
-                current_track_updated: ev.current_track_updated,
                 title: ev.optional_title.map(|v| {
                     let protobuf::update_track_changed::OptionalTitle::Title(v) = v;
                     v

--- a/playback/src/backends/rusty/mod.rs
+++ b/playback/src/backends/rusty/mod.rs
@@ -627,6 +627,9 @@ async fn player_thread(mut args: PlayerThreadArgs) {
         let builder = DeviceSinkBuilder::from_default_device().unwrap();
         builder
             .with_sample_rate(args.output_sample_rate)
+            .with_error_callback(|err| {
+                error!("CPAL Audio Error: {err:#?}");
+            })
             .open_sink_or_fallback()
             .unwrap()
     };

--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -38,7 +38,7 @@ impl Default for Rpc {
 
 impl Rpc {
     /// Update the discord status track information
-    pub fn update(&self, track: &Track) {
+    pub fn set_track(&self, track: &Track) {
         let artist = track.artist().unwrap_or(UNKNOWN_ARTIST).to_string();
         let title = track.title().unwrap_or(UNKNOWN_TITLE).to_string();
         self.tx.send(RpcCommand::Update(artist, title)).ok();

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -166,8 +166,6 @@ pub struct GeneralPlayer {
     pub playlist: SharedPlaylist,
     /// A reference to the server config.
     pub config: SharedServerSettings,
-    /// Simple flag to check in a tick to update some extra information.
-    pub current_track_updated: bool,
 
     /// Media Control (mpris) instance.
     pub mpris: Option<mpris::Mpris>,
@@ -239,7 +237,6 @@ impl GeneralPlayer {
             db_podcast,
             cmd_tx,
             stream_tx,
-            current_track_updated: false,
 
             errors_since_last_progress: 0,
         })
@@ -362,7 +359,6 @@ impl GeneralPlayer {
             if playlist.has_next_track() {
                 playlist.set_next_track(None);
                 drop(playlist);
-                self.current_track_updated = true;
                 info!("gapless next track played");
                 self.add_and_play_mpris_discord();
 
@@ -372,7 +368,6 @@ impl GeneralPlayer {
             }
             drop(playlist);
 
-            self.current_track_updated = true;
             let wait = async {
                 self.add_and_play(&track).await;
             };
@@ -395,7 +390,6 @@ impl GeneralPlayer {
         self.send_stream_ev(UpdateEvents::TrackChanged(TrackChangedInfo {
             current_track_index: u64::try_from(self.playlist.read().get_current_track_index())
                 .unwrap(),
-            current_track_updated: self.current_track_updated,
             title: self.media_info().media_title,
             progress: self.get_progress(),
         }));

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -171,6 +171,10 @@ pub struct RunInfo {
     ///
     /// This may or may not be present in any playlist.
     current_track: Option<Track>,
+    /// The track that has been enqueued.
+    ///
+    /// This is used to know whether something had been enqueued and if something changed in-between.
+    enqueued: Option<Track>,
 }
 
 impl Default for RunInfo {
@@ -178,6 +182,7 @@ impl Default for RunInfo {
         Self {
             status: RunningStatus::Stopped,
             current_track: None,
+            enqueued: None,
         }
     }
 }
@@ -251,6 +256,16 @@ impl RunInfo {
         let _ = self.current_track.take();
     }
 
+    /// Set the track that has been enqueued for seamless playback
+    pub fn set_enqueued(&mut self, track: Track) {
+        self.enqueued = Some(track);
+    }
+
+    /// Get the current enqueued Track value and reset it.
+    pub fn take_enqueued(&mut self) -> Option<Track> {
+        self.enqueued.take()
+    }
+
     /// Send stream events with consistent error handling.
     fn send_stream_ev(ev: UpdateEvents, tx: &StreamTX) {
         // there is only one error case: no receivers
@@ -289,6 +304,8 @@ pub struct GeneralPlayer {
 
     /// Keep track of continues backend errors (like `NotFound`) to not keep trying infinitely.
     pub errors_since_last_progress: usize,
+    /// Track whether the current track is being skipped.
+    pub in_skip: bool, // TODO: evaluate if this option can be omitted somehow
 }
 
 impl GeneralPlayer {
@@ -350,6 +367,7 @@ impl GeneralPlayer {
             stream_tx,
 
             errors_since_last_progress: 0,
+            in_skip: false,
         })
     }
 
@@ -429,48 +447,67 @@ impl GeneralPlayer {
     /// # Panics
     ///
     /// if `current_track_index` in playlist is above u32
-    pub fn start_play(&mut self) {
-        let mut run_info_w = self.run_info.write();
-        let original_state = run_info_w.status();
-        if run_info_w.is_stopped() | run_info_w.is_paused() {
-            run_info_w.play(&self.stream_tx);
+    pub fn start_play(&mut self, from_eos: bool) {
+        let mut run_info = self.run_info.write();
+        if run_info.is_stopped() | run_info.is_paused() {
+            run_info.play(&self.stream_tx);
         }
-        drop(run_info_w);
 
         let mut playlist = self.playlist.write();
 
-        if playlist.proceed(original_state) {
-            drop(playlist);
-            info!("Stopping playback due to \"proceed\" saying so");
-            self.stop();
-            return;
-        }
+        let next_track = if self.in_skip || !from_eos {
+            // When in-skip or not from EOS, get the current track, as "next" or "previous" has already set it (in_skip), or we want to play the current one as we just loaded the playlist
+            self.in_skip = false;
+            playlist.get_current_track()
+        } else {
+            // When from EOS, we want to respect the LoopMode decision, so no force here.
+            // Force should only be done in Skip / Next.
+            playlist.next(false)
+        };
 
-        if let Some(track) = playlist.get_current_track().cloned() {
-            info!("Starting Track {track:#?}");
-            self.run_info.write().set_current_track(track.clone());
-
-            if playlist.has_next_track() {
-                playlist.set_next_track(None);
+        if let Some(enqueued_track) = run_info.take_enqueued() {
+            let Some(track) = next_track else {
+                error!("Desync: enqueue flag set, but playlist did not have a next anymore!");
                 drop(playlist);
-                info!("gapless next track played");
+                drop(run_info);
+                self.stop();
+                return;
+            };
+            if enqueued_track.as_track_source() == track.as_track_source() {
+                info!("Starting seamless Track {track:#?}");
+                run_info.set_current_track(track.clone());
+                drop(playlist);
+                drop(run_info);
                 self.set_track_mpris_discord();
 
                 self.send_track_changed();
 
                 return;
             }
+
+            info!("Enqueued Track did not match next track from playlist, skipping enqueued!");
+        }
+
+        if let Some(track) = next_track.cloned() {
             drop(playlist);
+            drop(run_info);
+            info!("Starting Track {track:#?}");
 
             let wait = async {
                 self.add_and_play(&track).await;
             };
             Handle::current().block_on(wait);
+            self.run_info.write().set_current_track(track);
 
             self.set_track_mpris_discord();
             self.player_restore_last_position();
 
             self.send_track_changed();
+        } else {
+            info!("Stopping due to not having a next track");
+            drop(playlist);
+            drop(run_info);
+            self.stop();
         }
     }
 
@@ -505,28 +542,25 @@ impl GeneralPlayer {
     /// Try to enqueue the next track to play, so that it can be seamlessly played.
     pub fn enqueue_next_from_playlist(&mut self) {
         let mut playlist = self.playlist.write();
-        if playlist.has_next_track() {
-            return;
-        }
-
-        let Some(track) = playlist.fetch_next_track().cloned() else {
+        let Some(next_track) = playlist.fetch_next().cloned() else {
+            debug!("No next track, not enqueuing!");
             return;
         };
         drop(playlist);
 
-        self.enqueue_next(&track);
+        self.enqueue_next(&next_track);
 
-        info!("Next track enqueued: {track:#?}");
+        info!("Next track enqueued: {next_track:#?}");
     }
 
     /// Skip to the next track, if there is one
     pub fn next(&mut self) {
-        if self.playlist.read().get_current_track().is_some() {
-            debug!("next: playlist.current_track is some");
-            self.playlist.write().set_next_track(None);
+        let has_next = self.playlist.write().next(true).is_some();
+        debug!("next: has_next: {has_next:#?}");
+
+        if has_next {
             self.skip_one();
         } else {
-            info!("next: playlist is empty, stopping");
             self.stop();
         }
     }
@@ -534,10 +568,15 @@ impl GeneralPlayer {
     /// Switch & Play the previous track in the playlist
     pub fn previous(&mut self) {
         let mut playlist = self.playlist.write();
-        playlist.previous();
-        playlist.proceed_false();
+        let has_previous = playlist.previous().is_some();
         drop(playlist);
-        self.next();
+        debug!("previous: has_previous: {has_previous:#?}");
+
+        if has_previous {
+            self.skip_one();
+        } else {
+            self.stop();
+        }
     }
 
     /// Resume playback if paused, pause playback if running.
@@ -606,17 +645,11 @@ impl GeneralPlayer {
                 }
 
                 drop(playlist_read);
-                let mut playlist_write = self.playlist.write();
                 self.run_info.write().stop(&self.stream_tx);
-                playlist_write.proceed_false();
 
-                info!(
-                    "Resuming from stopped status. Next track: {:#?}",
-                    playlist_write.get_current_track()
-                );
-                drop(playlist_write);
+                info!("Resuming from stopped status");
 
-                self.start_play();
+                self.start_play(false);
             }
         }
     }
@@ -850,8 +883,8 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn stop(&mut self) {
+        self.in_skip = false;
         self.run_info.write().stop(&self.stream_tx);
-        self.playlist.write().stop();
         self.get_player_mut().stop();
     }
 
@@ -869,6 +902,7 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn skip_one(&mut self) {
+        self.in_skip = true;
         self.get_player_mut().skip_one();
     }
 
@@ -877,6 +911,7 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn enqueue_next(&mut self, track: &Track) {
+        self.run_info.write().set_enqueued(track.clone());
         self.get_player_mut().enqueue_next(track);
     }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -120,7 +120,6 @@ pub enum PlayerCmd {
 
     // Mainly called from outside sources (client, mpris)
     CycleLoop,
-    GetProgress,
     SkipPrevious,
     Pause,
     Play,

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -164,12 +164,20 @@ pub type SharedRunInfo = Arc<RwLock<RunInfo>>;
 pub struct RunInfo {
     /// The current running status that we are targeting, not fully representing what the backend is actually doing.
     status: RunningStatus,
+
+    /// The currently playing [`Track`], if there is one.
+    ///
+    /// This should only be UNSET if `status == RunningStatus::Stopped`.
+    ///
+    /// This may or may not be present in any playlist.
+    current_track: Option<Track>,
 }
 
 impl Default for RunInfo {
     fn default() -> Self {
         Self {
             status: RunningStatus::Stopped,
+            current_track: None,
         }
     }
 }
@@ -200,6 +208,7 @@ impl RunInfo {
     /// and finally, stop the currently playing track.
     pub fn stop(&mut self, tx: &StreamTX) {
         self.set_status(RunningStatus::Stopped, tx);
+        self.clear_current_track();
     }
 
     /// Get the current running status.
@@ -224,6 +233,22 @@ impl RunInfo {
     #[must_use]
     pub fn is_stopped(&self) -> bool {
         self.status == RunningStatus::Stopped
+    }
+
+    /// Set a new currently playing track.
+    pub fn set_current_track(&mut self, track: Track) {
+        self.current_track = Some(track);
+    }
+
+    /// Get the current track, if there is one.
+    #[must_use]
+    pub fn current_track(&self) -> Option<&Track> {
+        self.current_track.as_ref()
+    }
+
+    /// Clear the currently playing track.
+    fn clear_current_track(&mut self) {
+        let _ = self.current_track.take();
     }
 
     /// Send stream events with consistent error handling.
@@ -353,8 +378,8 @@ impl GeneralPlayer {
             // start mpris if new config has it enabled, but is not active yet
             let mut mpris = mpris::Mpris::new(self.cmd_tx.clone());
             // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
-            if let Some(track) = self.playlist.read().current_track() {
-                mpris.add_and_play(track);
+            if let Some(track) = self.run_info.read().current_track() {
+                mpris.set_track(track);
             }
             // the same for volume
             mpris.update_volume(self.volume());
@@ -369,8 +394,8 @@ impl GeneralPlayer {
             let discord = discord::Rpc::default();
 
             // actually set the metadata of the currently playing track, otherwise the controls will work but no title or coverart will be set until next track
-            if let Some(track) = self.playlist.read().current_track() {
-                discord.update(track);
+            if let Some(track) = self.run_info.read().current_track() {
+                discord.set_track(track);
             }
 
             self.discord.replace(discord);
@@ -421,14 +446,15 @@ impl GeneralPlayer {
             return;
         }
 
-        if let Some(track) = playlist.current_track().cloned() {
+        if let Some(track) = playlist.get_current_track().cloned() {
             info!("Starting Track {track:#?}");
+            self.run_info.write().set_current_track(track.clone());
 
             if playlist.has_next_track() {
                 playlist.set_next_track(None);
                 drop(playlist);
                 info!("gapless next track played");
-                self.add_and_play_mpris_discord();
+                self.set_track_mpris_discord();
 
                 self.send_track_changed();
 
@@ -441,7 +467,7 @@ impl GeneralPlayer {
             };
             Handle::current().block_on(wait);
 
-            self.add_and_play_mpris_discord();
+            self.set_track_mpris_discord();
             self.player_restore_last_position();
 
             self.send_track_changed();
@@ -463,17 +489,20 @@ impl GeneralPlayer {
         }));
     }
 
-    fn add_and_play_mpris_discord(&mut self) {
-        if let Some(track) = self.playlist.read().current_track() {
+    /// Set the current track for extra services like Media Control or discord.
+    fn set_track_mpris_discord(&mut self) {
+        if let Some(track) = self.run_info.read().current_track() {
             if let Some(ref mut mpris) = self.mpris {
-                mpris.add_and_play(track);
+                mpris.set_track(track);
             }
 
             if let Some(ref discord) = self.discord {
-                discord.update(track);
+                discord.set_track(track);
             }
         }
     }
+
+    /// Try to enqueue the next track to play, so that it can be seamlessly played.
     pub fn enqueue_next_from_playlist(&mut self) {
         let mut playlist = self.playlist.write();
         if playlist.has_next_track() {
@@ -492,8 +521,8 @@ impl GeneralPlayer {
 
     /// Skip to the next track, if there is one
     pub fn next(&mut self) {
-        if self.playlist.read().current_track().is_some() {
-            debug!("next: current_track is some");
+        if self.playlist.read().get_current_track().is_some() {
+            debug!("next: playlist.current_track is some");
             self.playlist.write().set_next_track(None);
             self.skip_one();
         } else {
@@ -583,7 +612,7 @@ impl GeneralPlayer {
 
                 info!(
                     "Resuming from stopped status. Next track: {:#?}",
-                    playlist_write.current_track()
+                    playlist_write.get_current_track()
                 );
                 drop(playlist_write);
 
@@ -598,7 +627,7 @@ impl GeneralPlayer {
     pub fn seek_relative(&mut self, forward: bool) {
         // fallback to 5 instead of not seeking at all
         let track_len = self
-            .playlist
+            .run_info
             .read()
             .current_track()
             .and_then(Track::duration)
@@ -638,10 +667,11 @@ impl GeneralPlayer {
         Ok(())
     }
 
+    /// Save the current track position to the database.
     #[allow(clippy::cast_sign_loss)]
     pub fn player_save_last_position(&mut self) {
-        let playlist = self.playlist.read();
-        let Some(track) = playlist.current_track() else {
+        let run_info = self.run_info.read();
+        let Some(track) = run_info.current_track() else {
             info!("Not saving Last position as there is no current track");
             return;
         };
@@ -674,13 +704,14 @@ impl GeneralPlayer {
         }
     }
 
+    /// Restore the last known track position for the current track.
     pub fn player_restore_last_position(&mut self) {
-        let playlist = self.playlist.read();
-        let Some(track) = playlist.current_track().cloned() else {
+        let run_info = self.run_info.read();
+        let Some(track) = run_info.current_track().cloned() else {
             info!("Not restoring Last position as there is no current track");
             return;
         };
-        drop(playlist);
+        drop(run_info);
 
         let mut restored = false;
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -157,15 +157,95 @@ pub mod quit_sources {
 
 pub type StreamTX = broadcast::Sender<UpdateEvents>;
 pub type SharedPlaylist = Arc<RwLock<Playlist>>;
+pub type SharedRunInfo = Arc<RwLock<RunInfo>>;
+
+/// Contains all the status for the current playback, which is not backend dependent.
+#[derive(Debug)]
+pub struct RunInfo {
+    /// The current running status that we are targeting, not fully representing what the backend is actually doing.
+    status: RunningStatus,
+}
+
+impl Default for RunInfo {
+    fn default() -> Self {
+        Self {
+            status: RunningStatus::Stopped,
+        }
+    }
+}
+
+impl RunInfo {
+    /// Set the [`RunningStatus`] of the playlist, also sends a stream event.
+    fn set_status(&mut self, status: RunningStatus, tx: &StreamTX) {
+        self.status = status;
+        Self::send_stream_ev(
+            UpdateEvents::PlayStateChanged {
+                playing: status.as_u32(),
+            },
+            tx,
+        );
+    }
+
+    /// Start playing, if not already.
+    pub fn play(&mut self, tx: &StreamTX) {
+        self.set_status(RunningStatus::Running, tx);
+    }
+
+    /// Pause playback.
+    pub fn pause(&mut self, tx: &StreamTX) {
+        self.set_status(RunningStatus::Paused, tx);
+    }
+
+    /// Stop the current playback by setting [`RunningStatus::Stopped`], preventing going to the next track
+    /// and finally, stop the currently playing track.
+    pub fn stop(&mut self, tx: &StreamTX) {
+        self.set_status(RunningStatus::Stopped, tx);
+    }
+
+    /// Get the current running status.
+    #[must_use]
+    pub fn status(&self) -> RunningStatus {
+        self.status
+    }
+
+    /// Get whether the current running status is playing or not.
+    #[must_use]
+    pub fn is_playing(&self) -> bool {
+        self.status == RunningStatus::Running
+    }
+
+    /// Get whether the current running status is paused or not.
+    #[must_use]
+    pub fn is_paused(&self) -> bool {
+        self.status == RunningStatus::Paused
+    }
+
+    /// Get wether the current running status is stopped or not.
+    #[must_use]
+    pub fn is_stopped(&self) -> bool {
+        self.status == RunningStatus::Stopped
+    }
+
+    /// Send stream events with consistent error handling.
+    fn send_stream_ev(ev: UpdateEvents, tx: &StreamTX) {
+        // there is only one error case: no receivers
+        if tx.send(ev).is_err() {
+            debug!("Stream Event not send: No Receivers");
+        }
+    }
+}
 
 #[allow(clippy::module_name_repetitions)]
 pub struct GeneralPlayer {
     /// The backend in use where audio will be output to.
     pub backend: Backend,
-    /// The playlist (currently handles current track info too).
-    pub playlist: SharedPlaylist,
     /// A reference to the server config.
     pub config: SharedServerSettings,
+
+    /// The playlist.
+    pub playlist: SharedPlaylist,
+    /// The information for the current playback.
+    pub run_info: SharedRunInfo,
 
     /// Media Control (mpris) instance.
     pub mpris: Option<mpris::Mpris>,
@@ -199,6 +279,7 @@ impl GeneralPlayer {
         cmd_tx: PlayerCmdSender,
         stream_tx: StreamTX,
         playlist: SharedPlaylist,
+        run_info: SharedRunInfo,
     ) -> Result<Self> {
         let backend = Backend::new_select(backend, config.clone(), cmd_tx.clone());
 
@@ -229,12 +310,17 @@ impl GeneralPlayer {
 
         Ok(Self {
             backend,
-            playlist,
             config,
+
+            playlist,
+            run_info,
+
             mpris,
             discord,
+
             db,
             db_podcast,
+
             cmd_tx,
             stream_tx,
 
@@ -250,27 +336,6 @@ impl GeneralPlayer {
     /// Reset errors that happened back to 0
     pub fn reset_errors(&mut self) {
         self.errors_since_last_progress = 0;
-    }
-
-    /// Create a new [`GeneralPlayer`], with the default Backend ([`BackendSelect::Rusty`])
-    ///
-    /// # Errors
-    ///
-    /// - if connecting to the database fails
-    /// - if config path creation fails
-    pub fn new(
-        config: SharedServerSettings,
-        cmd_tx: PlayerCmdSender,
-        stream_tx: StreamTX,
-        playlist: SharedPlaylist,
-    ) -> Result<Self> {
-        Self::new_backend(
-            BackendSelect::default(),
-            config,
-            cmd_tx,
-            stream_tx,
-            playlist,
-        )
     }
 
     /// Reload the config from file, on fail continue to use the old
@@ -340,11 +405,14 @@ impl GeneralPlayer {
     ///
     /// if `current_track_index` in playlist is above u32
     pub fn start_play(&mut self) {
-        let mut playlist = self.playlist.write();
-        let original_state = playlist.status();
-        if playlist.is_stopped() | playlist.is_paused() {
-            playlist.set_status(RunningStatus::Running);
+        let mut run_info_w = self.run_info.write();
+        let original_state = run_info_w.status();
+        if run_info_w.is_stopped() | run_info_w.is_paused() {
+            run_info_w.play(&self.stream_tx);
         }
+        drop(run_info_w);
+
+        let mut playlist = self.playlist.write();
 
         if playlist.proceed(original_state) {
             drop(playlist);
@@ -449,7 +517,7 @@ impl GeneralPlayer {
     pub fn toggle_pause(&mut self) {
         // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
         // see https://github.com/rust-lang/rust/issues/93883
-        let status = self.playlist.read().status();
+        let status = self.run_info.read().status();
         match status {
             RunningStatus::Running => {
                 <Self as PlayerTrait>::pause(self);
@@ -467,7 +535,7 @@ impl GeneralPlayer {
     pub fn pause(&mut self) {
         // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
         // see https://github.com/rust-lang/rust/issues/93883
-        let status = self.playlist.read().status();
+        let status = self.run_info.read().status();
         match status {
             RunningStatus::Running => {
                 <Self as PlayerTrait>::pause(self);
@@ -480,7 +548,7 @@ impl GeneralPlayer {
     pub fn play(&mut self) {
         // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
         // see https://github.com/rust-lang/rust/issues/93883
-        let status = self.playlist.read().status();
+        let status = self.run_info.read().status();
         match status {
             RunningStatus::Running => {}
             RunningStatus::Stopped => {
@@ -499,7 +567,7 @@ impl GeneralPlayer {
         // NOTE: if this ".read()" call is in a match's statement, it will not be unlocked until the end of the match
         // see https://github.com/rust-lang/rust/issues/93883
         let playlist_read = self.playlist.read();
-        let status = playlist_read.status();
+        let status = self.run_info.read().status();
         match status {
             RunningStatus::Running | RunningStatus::Paused => {}
             RunningStatus::Stopped => {
@@ -510,7 +578,7 @@ impl GeneralPlayer {
 
                 drop(playlist_read);
                 let mut playlist_write = self.playlist.write();
-                playlist_write.clear_current_track();
+                self.run_info.write().stop(&self.stream_tx);
                 playlist_write.proceed_false();
 
                 info!(
@@ -701,7 +769,7 @@ impl PlayerTrait for GeneralPlayer {
     }
     /// This function should not be used directly, use `GeneralPlayer::pause`
     fn pause(&mut self) {
-        self.playlist.write().set_status(RunningStatus::Paused);
+        self.run_info.write().pause(&self.stream_tx);
         self.get_player_mut().pause();
         if let Some(ref mut mpris) = self.mpris {
             mpris.pause();
@@ -712,7 +780,7 @@ impl PlayerTrait for GeneralPlayer {
     }
     /// This function should not be used directly, use `GeneralPlayer::play`
     fn resume(&mut self) {
-        self.playlist.write().set_status(RunningStatus::Running);
+        self.run_info.write().play(&self.stream_tx);
         self.get_player_mut().resume();
         if let Some(ref mut mpris) = self.mpris {
             mpris.resume();
@@ -751,6 +819,7 @@ impl PlayerTrait for GeneralPlayer {
     }
 
     fn stop(&mut self) {
+        self.run_info.write().stop(&self.stream_tx);
         self.playlist.write().stop();
         self.get_player_mut().stop();
     }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -161,15 +161,28 @@ pub type SharedPlaylist = Arc<RwLock<Playlist>>;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct GeneralPlayer {
+    /// The backend in use where audio will be output to.
     pub backend: Backend,
+    /// The playlist (currently handles current track info too).
     pub playlist: SharedPlaylist,
+    /// A reference to the server config.
     pub config: SharedServerSettings,
+    /// Simple flag to check in a tick to update some extra information.
     pub current_track_updated: bool,
+
+    /// Media Control (mpris) instance.
     pub mpris: Option<mpris::Mpris>,
+    /// Discord status display RPC.
     pub discord: Option<discord::Rpc>,
+
+    /// Track database.
     pub db: Database,
+    /// Podcast database.
     pub db_podcast: DBPod,
+
+    /// Sender for Player commands.
     pub cmd_tx: PlayerCmdSender,
+    /// Sender for the Streaming Updates.
     pub stream_tx: StreamTX,
 
     /// Keep track of continues backend errors (like `NotFound`) to not keep trying infinitely.

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -52,7 +52,7 @@ impl Mpris {
 }
 
 impl Mpris {
-    pub fn add_and_play(&mut self, track: &Track) {
+    pub fn set_track(&mut self, track: &Track) {
         // This is to fix a bug that the first track is not updated
         std::thread::sleep(std::time::Duration::from_millis(100));
         self.controls

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -247,7 +247,7 @@ impl GeneralPlayer {
     #[inline]
     pub fn mpris_update_progress(&mut self, progress: &PlayerProgress) {
         if let Some(ref mut mpris) = self.mpris {
-            mpris.update_progress(progress.position, self.playlist.read_recursive().status());
+            mpris.update_progress(progress.position, self.run_info.read().status());
         }
     }
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -488,34 +488,6 @@ impl Playlist {
         self.tracks.is_empty()
     }
 
-    /// Swap the `index` with the one below(+1) it, if there is one.
-    pub fn swap_down(&mut self, index: usize) {
-        if index < self.len().saturating_sub(1) {
-            self.tracks.swap(index, index + 1);
-            // handle index
-            if index == self.current_track_index {
-                self.current_track_index += 1;
-            } else if index == self.current_track_index - 1 {
-                self.current_track_index -= 1;
-            }
-            self.is_modified = true;
-        }
-    }
-
-    /// Swap the `index` with the one above(-1) it, if there is one.
-    pub fn swap_up(&mut self, index: usize) {
-        if index > 0 {
-            self.tracks.swap(index, index - 1);
-            // handle index
-            if index == self.current_track_index {
-                self.current_track_index -= 1;
-            } else if index == self.current_track_index + 1 {
-                self.current_track_index += 1;
-            }
-            self.is_modified = true;
-        }
-    }
-
     /// Swap specific indexes, sends swap event.
     ///
     /// # Errors

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -43,8 +43,6 @@ pub struct Playlist {
     next_track_index: Option<usize>,
     /// The currently playing [`Track`]. Does not need to be in `tracks`
     current_track: Option<Track>,
-    /// The current playing running status of the playlist
-    status: RunningStatus,
     /// The loop-/play-mode for the playlist
     loop_mode: LoopMode,
     /// Indexes into `tracks` that have been previously been played (for `previous`)
@@ -66,7 +64,6 @@ impl Playlist {
 
         Self {
             tracks: Vec::new(),
-            status: RunningStatus::Stopped,
             loop_mode,
             current_track_index: 0,
             current_track,
@@ -568,29 +565,6 @@ impl Playlist {
         let next_index = self.get_next_track_index(RunningStatus::Running)?;
         self.next_track_index = Some(next_index);
         self.tracks.get(next_index)
-    }
-
-    /// Set the [`RunningStatus`] of the playlist, also sends a stream event.
-    pub fn set_status(&mut self, status: RunningStatus) {
-        self.status = status;
-        self.send_stream_ev(UpdateEvents::PlayStateChanged {
-            playing: status.as_u32(),
-        });
-    }
-
-    #[must_use]
-    pub fn is_stopped(&self) -> bool {
-        self.status == RunningStatus::Stopped
-    }
-
-    #[must_use]
-    pub fn is_paused(&self) -> bool {
-        self.status == RunningStatus::Paused
-    }
-
-    #[must_use]
-    pub fn status(&self) -> RunningStatus {
-        self.status
     }
 
     /// Cycle through the loop modes and return the new mode.
@@ -1147,7 +1121,6 @@ impl Playlist {
     /// Stop the current playlist by setting [`RunningStatus::Stopped`], preventing going to the next track
     /// and finally, stop the currently playing track.
     pub fn stop(&mut self) {
-        self.set_status(RunningStatus::Stopped);
         self.set_next_track(None);
         self.clear_current_track();
     }
@@ -1200,14 +1173,6 @@ impl Playlist {
             .send(UpdateEvents::PlaylistChanged(ev))
             .is_err()
         {
-            debug!("Stream Event not send: No Receivers");
-        }
-    }
-
-    /// Send stream events with consistent error handling
-    fn send_stream_ev(&self, ev: UpdateEvents) {
-        // there is only one error case: no receivers
-        if self.stream_tx.send(ev).is_err() {
             debug!("Stream Event not send: No Receivers");
         }
     }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -12,6 +12,7 @@ use rand::RngExt;
 use rand::seq::SliceRandom;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::config::v2::server::LoopMode;
+use termusiclib::player;
 use termusiclib::player::PlaylistLoopModeInfo;
 use termusiclib::player::PlaylistShuffledInfo;
 use termusiclib::player::PlaylistSwapInfo;
@@ -22,7 +23,6 @@ use termusiclib::player::playlist_helpers::PlaylistPlaySpecific;
 use termusiclib::player::playlist_helpers::PlaylistSwapTrack;
 use termusiclib::player::playlist_helpers::PlaylistTrackSource;
 use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
-use termusiclib::player::{self, RunningStatus};
 use termusiclib::player::{PlaylistAddTrackInfo, PlaylistRemoveTrackInfo};
 use termusiclib::podcast::{db::Database as DBPod, episode::Episode};
 use termusiclib::track::{MediaTypes, Track, TrackData};
@@ -45,8 +45,7 @@ pub struct Playlist {
     loop_mode: LoopMode,
     /// Indexes into `tracks` that have been previously been played (for `previous`)
     played_index: Vec<usize>,
-    /// Indicator if the playlist should advance the `current_*` and `next_*` values
-    need_proceed_to_next: bool,
+    /// Sender for the Streaming Updates.
     stream_tx: StreamTX,
 
     /// Indicator if we need to save the playlist for interval saving
@@ -56,7 +55,6 @@ pub struct Playlist {
 impl Playlist {
     /// Create a new playlist instance with 0 tracks
     pub fn new(config: &SharedServerSettings, stream_tx: StreamTX) -> Self {
-        // TODO: shouldn't "loop_mode" be combined with the config ones?
         let loop_mode = config.read().settings.player.loop_mode;
 
         Self {
@@ -65,7 +63,6 @@ impl Playlist {
             current_track_index: 0,
             played_index: Vec::new(),
             next_track_index: None,
-            need_proceed_to_next: false,
             stream_tx,
             is_modified: false,
         }
@@ -86,23 +83,97 @@ impl Playlist {
         Ok(Arc::new(RwLock::new(playlist)))
     }
 
-    /// Advance the playlist to the next track.
+    /// Get the current track to play in this playlist.
     ///
-    /// Returns whether playback should be stopped.
-    pub fn proceed(&mut self, from_state: RunningStatus) -> bool {
-        debug!("need to proceed to next: {}", self.need_proceed_to_next);
-        self.is_modified = true;
-        if self.need_proceed_to_next {
-            self.next(from_state)
-        } else {
-            self.need_proceed_to_next = true;
-            false
-        }
+    /// Does not modify the playlist.
+    #[must_use]
+    pub fn get_current_track(&self) -> Option<&Track> {
+        self.tracks.get(self.current_track_index)
     }
 
-    /// Set `need_proceed_to_next` to `false`
-    pub fn proceed_false(&mut self) {
-        self.need_proceed_to_next = false;
+    /// Get the current track index to play in this playlist.
+    #[must_use]
+    pub fn get_current_track_index(&self) -> usize {
+        self.current_track_index
+    }
+
+    /// Set the state so that the next track is the current track.
+    ///
+    /// If [`None`] is returned, this playlist is done playing.
+    pub fn next(&mut self, force_next: bool) -> Option<&Track> {
+        debug!("Playlist next");
+        self.played_index.push(self.current_track_index);
+
+        // use next idx if present
+        if let Some(next_idx) = self.next_track_index.take() {
+            self.current_track_index = next_idx;
+            self.is_modified = true;
+
+            return self.get_current_track();
+        }
+        // otherwise, try to generate a new idx
+        self.current_track_index = self.next_index_loopmode(force_next)?;
+        self.is_modified = true;
+
+        self.get_current_track()
+    }
+
+    /// Try to fetch the next track for enqueuing.
+    pub fn fetch_next(&mut self) -> Option<&Track> {
+        if self.next_track_index.is_some() {
+            return self.get_next_track();
+        }
+
+        self.next_track_index = self.next_index_loopmode(false);
+
+        self.get_next_track()
+    }
+
+    /// Set the state so that the previous track is the current track.
+    ///
+    /// Uses `played_index` vec before generating a previous value.
+    pub fn previous(&mut self) -> Option<&Track> {
+        debug!("Playlist previous");
+
+        let previous = match self.played_index.pop() {
+            Some(v) => v,
+            None => self.previous_index_loopmode(),
+        };
+
+        self.current_track_index = previous;
+        self.is_modified = true;
+
+        self.get_current_track()
+    }
+
+    /// Skip to a specific track in the playlist.
+    ///
+    /// # Errors
+    ///
+    /// - if converting u64 to usize fails
+    /// - if the given info's tracks mismatch with the actual playlist
+    pub fn set_play_specific(&mut self, info: &PlaylistPlaySpecific) -> Result<Option<&Track>> {
+        debug!("Playlist specific");
+        let new_index =
+            usize::try_from(info.track_index).context("convert track_index(u64) to usize")?;
+
+        let Some(track_at_idx) = self.tracks.get(new_index) else {
+            bail!("Index {new_index} is out of bound {}", self.tracks.len())
+        };
+
+        Self::check_same_source(&info.id, track_at_idx.inner(), new_index)?;
+
+        self.next_track_index = Some(new_index);
+
+        Ok(self.next(true))
+    }
+
+    /// Get the next track to play in this playlist.
+    ///
+    /// Does not modify the playlist.
+    #[must_use]
+    pub fn get_next_track(&self) -> Option<&Track> {
+        self.next_track_index.and_then(|v| self.tracks.get(v))
     }
 
     /// Load the playlist from the file.
@@ -317,27 +388,6 @@ impl Playlist {
         Ok(false)
     }
 
-    /// Change to the next track.
-    ///
-    /// Returns whether playback should stop
-    pub fn next(&mut self, from_state: RunningStatus) -> bool {
-        self.played_index.push(self.current_track_index);
-        // Note: the next index is *not* taken here, as ".proceed/next" is called first,
-        // then "has_next_track" is later used to check if enqueuing has used.
-        if let Some(index) = self.next_track_index {
-            self.current_track_index = index;
-            return false;
-        }
-
-        let Some(next_track_idx) = self.get_next_track_index(from_state) else {
-            self.stop();
-            return true;
-        };
-        self.current_track_index = next_track_idx;
-
-        false
-    }
-
     /// Check that the given `info` track source matches the given `track_inner` types.
     ///
     /// # Errors
@@ -384,34 +434,8 @@ impl Playlist {
         Ok(())
     }
 
-    /// Skip to a specific track in the playlist
-    ///
-    /// # Errors
-    ///
-    /// - if converting u64 to usize fails
-    /// - if the given info's tracks mismatch with the actual playlist
-    pub fn play_specific(&mut self, info: &PlaylistPlaySpecific) -> Result<()> {
-        let new_index =
-            usize::try_from(info.track_index).context("convert track_index(u64) to usize")?;
-
-        let Some(track_at_idx) = self.tracks.get(new_index) else {
-            bail!("Index {new_index} is out of bound {}", self.tracks.len())
-        };
-
-        Self::check_same_source(&info.id, track_at_idx.inner(), new_index)?;
-
-        self.played_index.push(self.current_track_index);
-        self.set_next_track(None);
-        self.set_current_track_index(new_index);
-        self.proceed_false();
-        self.is_modified = true;
-
-        Ok(())
-    }
-
     /// Get the next track index based on the [`LoopMode`] used.
-    // TODO: i dont quite like having to rely on RunningStatus for this; maybe once playlist is refactored a better option would be available to indicate change reason (like user next, or last track EOS)
-    fn get_next_track_index(&self, from_state: RunningStatus) -> Option<usize> {
+    fn next_index_loopmode(&self, force_next: bool) -> Option<usize> {
         let mut next_track_index = self.current_track_index;
         match self.loop_mode {
             LoopMode::Track => {}
@@ -424,7 +448,7 @@ impl Playlist {
             LoopMode::PlaylistOnce => {
                 next_track_index += 1;
                 if next_track_index >= self.len() {
-                    if from_state == RunningStatus::Stopped {
+                    if force_next {
                         next_track_index = 0;
                     } else {
                         return None;
@@ -438,33 +462,20 @@ impl Playlist {
         Some(next_track_index)
     }
 
-    /// Change to the previous track played.
-    ///
-    /// This uses `played_index` vec, if available, otherwise uses [`LoopMode`].
-    pub fn previous(&mut self) {
-        // unset next track as we now want a previous track instead of the next enqueued
-        self.set_next_track(None);
-
-        if let Some(index) = self.played_index.pop() {
-            self.current_track_index = index;
-            self.is_modified = true;
-            return;
-        }
+    /// Get the previous track index based on the [`LoopMode`].
+    fn previous_index_loopmode(&self) -> usize {
         match self.loop_mode {
-            LoopMode::Track => {}
+            LoopMode::Track => self.current_track_index,
             // doing both with one impl is fine as long as we dont have a "reverse play" option
             LoopMode::Playlist | LoopMode::PlaylistOnce => {
                 if self.current_track_index == 0 {
-                    self.current_track_index = self.len() - 1;
+                    self.len() - 1
                 } else {
-                    self.current_track_index -= 1;
+                    self.current_track_index - 1
                 }
             }
-            LoopMode::Random => {
-                self.current_track_index = self.get_random_index();
-            }
+            LoopMode::Random => self.get_random_index(),
         }
-        self.is_modified = true;
     }
 
     #[must_use]
@@ -537,7 +548,7 @@ impl Playlist {
     /// Get the current track's Path/Url.
     // TODO: refactor this function to likely return either a consistent URI format or a enum
     // TODO: refactor to return a reference if possible
-    pub fn get_current_track_str(&mut self) -> Option<String> {
+    fn get_current_track_internal(&mut self) -> Option<String> {
         let mut result = None;
         if let Some(track) = self.get_current_track() {
             match track.inner() {
@@ -553,13 +564,6 @@ impl Playlist {
             }
         }
         result
-    }
-
-    /// Get the next track index and return a reference to it.
-    pub fn fetch_next_track(&mut self) -> Option<&Track> {
-        let next_index = self.get_next_track_index(RunningStatus::Running)?;
-        self.next_track_index = Some(next_index);
-        self.tracks.get(next_index)
     }
 
     /// Cycle through the loop modes and return the new mode.
@@ -978,7 +982,6 @@ impl Playlist {
         self.played_index.clear();
         self.next_track_index.take();
         self.current_track_index = 0;
-        self.need_proceed_to_next = false;
 
         self.send_stream_ev_pl(UpdatePlaylistEvents::PlaylistCleared);
     }
@@ -989,7 +992,7 @@ impl Playlist {
     ///
     /// see [`as_grpc_playlist_tracks#Errors`](Self::as_grpc_playlist_tracks)
     pub fn shuffle(&mut self) {
-        let current_track_file = self.get_current_track_str();
+        let current_track_file = self.get_current_track_internal();
 
         self.tracks.shuffle(&mut rand::rng());
 
@@ -1031,7 +1034,7 @@ impl Playlist {
             .collect::<Result<_>>()?;
 
         Ok(PlaylistTracks {
-            current_track_index: u64::try_from(self.get_current_track_index())
+            current_track_index: u64::try_from(self.current_track_index)
                 .context("current_track_index(usize) to u64")?,
             tracks,
         })
@@ -1074,7 +1077,7 @@ impl Playlist {
     ///
     /// if usize cannot be converted to u64
     pub fn remove_deleted_items(&mut self) {
-        if let Some(current_track_file) = self.get_current_track_str() {
+        if let Some(current_track_file) = self.get_current_track_internal() {
             let len = self.tracks.len();
             let old_tracks = std::mem::replace(&mut self.tracks, Vec::with_capacity(len));
 
@@ -1111,45 +1114,6 @@ impl Playlist {
                 None => self.current_track_index = 0,
             }
         }
-    }
-
-    /// Stop the current playlist by setting [`RunningStatus::Stopped`], preventing going to the next track
-    /// and finally, stop the currently playing track.
-    pub fn stop(&mut self) {
-        self.set_next_track(None);
-    }
-
-    #[must_use]
-    pub fn get_current_track(&self) -> Option<&Track> {
-        self.tracks.get(self.current_track_index)
-    }
-
-    pub fn current_track_as_mut(&mut self) -> Option<&mut Track> {
-        self.tracks.get_mut(self.current_track_index)
-    }
-
-    #[must_use]
-    pub fn get_current_track_index(&self) -> usize {
-        self.current_track_index
-    }
-
-    pub fn set_current_track_index(&mut self, index: usize) {
-        self.current_track_index = index;
-    }
-
-    #[must_use]
-    pub fn next_track(&self) -> Option<&Track> {
-        let index = self.next_track_index?;
-        self.tracks.get(index)
-    }
-
-    pub fn set_next_track(&mut self, track_idx: Option<usize>) {
-        self.next_track_index = track_idx;
-    }
-
-    #[must_use]
-    pub fn has_next_track(&self) -> bool {
-        self.next_track_index.is_some()
     }
 
     /// Send Playlist stream events with consistent error handling

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -505,6 +505,14 @@ impl Playlist {
 
         self.tracks.swap(index_a, index_b);
 
+        // Update current track index too if it is the currently playing track, so that we dont continue somewhere else.
+        // TODO: also update `played_index`vec after swapping
+        if self.current_track_index == index_a {
+            self.current_track_index = index_b;
+        } else if self.current_track_index == index_b {
+            self.current_track_index = index_a;
+        }
+
         let index_a = u64::try_from(index_a).unwrap();
         let index_b = u64::try_from(index_b).unwrap();
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -41,8 +41,6 @@ pub struct Playlist {
     ///
     /// Practically only used for pre-enqueue / pre-fetch / gapless.
     next_track_index: Option<usize>,
-    /// The currently playing [`Track`]. Does not need to be in `tracks`
-    current_track: Option<Track>,
     /// The loop-/play-mode for the playlist
     loop_mode: LoopMode,
     /// Indexes into `tracks` that have been previously been played (for `previous`)
@@ -60,13 +58,11 @@ impl Playlist {
     pub fn new(config: &SharedServerSettings, stream_tx: StreamTX) -> Self {
         // TODO: shouldn't "loop_mode" be combined with the config ones?
         let loop_mode = config.read().settings.player.loop_mode;
-        let current_track = None;
 
         Self {
             tracks: Vec::new(),
             loop_mode,
             current_track_index: 0,
-            current_track,
             played_index: Vec::new(),
             next_track_index: None,
             need_proceed_to_next: false,
@@ -334,7 +330,6 @@ impl Playlist {
         }
 
         let Some(next_track_idx) = self.get_next_track_index(from_state) else {
-            self.clear_current_track();
             self.stop();
             return true;
         };
@@ -542,9 +537,9 @@ impl Playlist {
     /// Get the current track's Path/Url.
     // TODO: refactor this function to likely return either a consistent URI format or a enum
     // TODO: refactor to return a reference if possible
-    pub fn get_current_track(&mut self) -> Option<String> {
+    pub fn get_current_track_str(&mut self) -> Option<String> {
         let mut result = None;
-        if let Some(track) = self.current_track() {
+        if let Some(track) = self.get_current_track() {
             match track.inner() {
                 MediaTypes::Track(track_data) => {
                     result = Some(track_data.path().to_string_lossy().to_string());
@@ -994,7 +989,7 @@ impl Playlist {
     ///
     /// see [`as_grpc_playlist_tracks#Errors`](Self::as_grpc_playlist_tracks)
     pub fn shuffle(&mut self) {
-        let current_track_file = self.get_current_track();
+        let current_track_file = self.get_current_track_str();
 
         self.tracks.shuffle(&mut rand::rng());
 
@@ -1079,7 +1074,7 @@ impl Playlist {
     ///
     /// if usize cannot be converted to u64
     pub fn remove_deleted_items(&mut self) {
-        if let Some(current_track_file) = self.get_current_track() {
+        if let Some(current_track_file) = self.get_current_track_str() {
             let len = self.tracks.len();
             let old_tracks = std::mem::replace(&mut self.tracks, Vec::with_capacity(len));
 
@@ -1122,23 +1117,15 @@ impl Playlist {
     /// and finally, stop the currently playing track.
     pub fn stop(&mut self) {
         self.set_next_track(None);
-        self.clear_current_track();
     }
 
     #[must_use]
-    pub fn current_track(&self) -> Option<&Track> {
-        if self.current_track.is_some() {
-            return self.current_track.as_ref();
-        }
+    pub fn get_current_track(&self) -> Option<&Track> {
         self.tracks.get(self.current_track_index)
     }
 
     pub fn current_track_as_mut(&mut self) -> Option<&mut Track> {
         self.tracks.get_mut(self.current_track_index)
-    }
-
-    pub fn clear_current_track(&mut self) {
-        self.current_track = None;
     }
 
     #[must_use]

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -37,7 +37,6 @@ impl MusicPlayerService {
         let mut player_stats = PlayerStats::new();
         let config_read = config.read();
         player_stats.gapless = config_read.settings.player.gapless;
-        player_stats.speed = config_read.settings.player.speed;
         drop(config_read);
 
         let player_stats = Arc::new(Mutex::new(player_stats));
@@ -163,8 +162,9 @@ impl MusicPlayer for MusicPlayerService {
         let rx = self.command_cb(PlayerCmd::SpeedDown)?;
         // wait until the event was processed
         let _ = rx.await;
-        let s = self.player_stats.lock();
-        let reply = SpeedReply { speed: s.speed };
+        let reply = SpeedReply {
+            speed: self.config.read().settings.player.speed,
+        };
 
         Ok(Response::new(reply))
     }
@@ -173,8 +173,9 @@ impl MusicPlayer for MusicPlayerService {
         let rx = self.command_cb(PlayerCmd::SpeedUp)?;
         // wait until the event was processed
         let _ = rx.await;
-        let s = self.player_stats.lock();
-        let reply = SpeedReply { speed: s.speed };
+        let reply = SpeedReply {
+            speed: self.config.read().settings.player.speed,
+        };
 
         Ok(Response::new(reply))
     }

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -10,7 +10,9 @@ use termusiclib::player::{
     PlaylistSwapTracks, PlaylistTracks, PlaylistTracksToAdd, PlaylistTracksToRemove, SpeedReply,
     StreamUpdates, UpdateMissedEvents, VolumeReply, stream_updates,
 };
-use termusicplayback::{PlayerCmd, PlayerCmdCallback, PlayerCmdSender, SharedPlaylist, StreamTX};
+use termusicplayback::{
+    PlayerCmd, PlayerCmdCallback, PlayerCmdSender, SharedPlaylist, SharedRunInfo, StreamTX,
+};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::{Stream, StreamExt};
@@ -24,6 +26,7 @@ pub struct MusicPlayerService {
     stream_tx: StreamTX,
     config: SharedServerSettings,
     playlist: SharedPlaylist,
+    run_info: SharedRunInfo,
     pub(crate) player_stats: Arc<Mutex<PlayerStats>>,
 }
 
@@ -33,6 +36,7 @@ impl MusicPlayerService {
         stream_tx: StreamTX,
         config: SharedServerSettings,
         playlist: SharedPlaylist,
+        run_info: SharedRunInfo,
     ) -> Self {
         let player_stats = PlayerStats::new();
         let config_read = config.read();
@@ -46,6 +50,7 @@ impl MusicPlayerService {
             stream_tx,
             playlist,
             config,
+            run_info,
         }
     }
 }
@@ -90,7 +95,7 @@ impl MusicPlayer for MusicPlayerService {
     ) -> Result<Response<GetProgressResponse>, Status> {
         let stats = self.player_stats.lock();
         let reply =
-            stats.as_getprogress_response(self.playlist.read().status(), &self.config.read());
+            stats.as_getprogress_response(self.run_info.read().status(), &self.config.read());
 
         Ok(Response::new(reply))
     }
@@ -198,7 +203,7 @@ impl MusicPlayer for MusicPlayerService {
         // wait until the event was processed
         let _ = rx.await;
         let reply = PlayState {
-            status: self.playlist.read().status().as_u32(),
+            status: self.run_info.read().status().as_u32(),
         };
 
         Ok(Response::new(reply))

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -36,7 +36,6 @@ impl MusicPlayerService {
     ) -> Self {
         let mut player_stats = PlayerStats::new();
         let config_read = config.read();
-        player_stats.volume = config_read.settings.player.volume;
         player_stats.gapless = config_read.settings.player.gapless;
         player_stats.speed = config_read.settings.player.speed;
         drop(config_read);
@@ -91,8 +90,9 @@ impl MusicPlayer for MusicPlayerService {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<GetProgressResponse>, Status> {
-        let r = self.player_stats.lock();
-        let reply = r.as_getprogress_response(self.playlist.read().status());
+        let stats = self.player_stats.lock();
+        let reply =
+            stats.as_getprogress_response(self.playlist.read().status(), &self.config.read());
 
         Ok(Response::new(reply))
     }
@@ -207,9 +207,8 @@ impl MusicPlayer for MusicPlayerService {
         let rx = self.command_cb(PlayerCmd::VolumeDown)?;
         // wait until the event was processed
         let _ = rx.await;
-        let r = self.player_stats.lock();
         let reply = VolumeReply {
-            volume: u32::from(r.volume),
+            volume: u32::from(self.config.read().settings.player.volume),
         };
 
         Ok(Response::new(reply))
@@ -219,9 +218,8 @@ impl MusicPlayer for MusicPlayerService {
         let rx = self.command_cb(PlayerCmd::VolumeUp)?;
         // wait until the event was processed
         let _ = rx.await;
-        let r = self.player_stats.lock();
         let reply = VolumeReply {
-            volume: u32::from(r.volume),
+            volume: u32::from(self.config.read().settings.player.volume),
         };
 
         Ok(Response::new(reply))

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -34,9 +34,8 @@ impl MusicPlayerService {
         config: SharedServerSettings,
         playlist: SharedPlaylist,
     ) -> Self {
-        let mut player_stats = PlayerStats::new();
+        let player_stats = PlayerStats::new();
         let config_read = config.read();
-        player_stats.gapless = config_read.settings.player.gapless;
         drop(config_read);
 
         let player_stats = Arc::new(Mutex::new(player_stats));
@@ -187,8 +186,9 @@ impl MusicPlayer for MusicPlayerService {
         let rx = self.command_cb(PlayerCmd::ToggleGapless)?;
         // wait until the event was processed
         let _ = rx.await;
-        let r = self.player_stats.lock();
-        let reply = GaplessState { gapless: r.gapless };
+        let reply = GaplessState {
+            gapless: self.config.read().settings.player.gapless,
+        };
 
         Ok(Response::new(reply))
     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -49,7 +49,6 @@ const BACKEND_ERROR_LIMIT: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 struct PlayerStats {
     pub progress: PlayerProgress,
     pub current_track_index: u64,
-    pub gapless: bool,
     pub radio_title: String,
 }
 
@@ -61,7 +60,6 @@ impl PlayerStats {
                 total_duration: None,
             },
             current_track_index: 0,
-            gapless: true,
             radio_title: String::new(),
         }
     }
@@ -75,10 +73,10 @@ impl PlayerStats {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: status.as_u32(),
-            gapless: self.gapless,
             radio_title: self.radio_title.clone(),
             volume: u32::from(config.settings.player.volume),
             speed: config.settings.player.speed,
+            gapless: config.settings.player.gapless,
         }
     }
 
@@ -465,8 +463,7 @@ fn player_loop(
             }
             PlayerCmd::ToggleGapless => {
                 let new_gapless = player.toggle_gapless();
-                let mut p_tick = playerstats.lock();
-                p_tick.gapless = new_gapless;
+                info!("after toggle gapless: {new_gapless}");
             }
             PlayerCmd::TogglePause => {
                 info!("player toggled pause");

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -16,7 +16,7 @@ use termusiclib::track::{MediaTypesSimple, Track};
 use termusiclib::{podcast, utils};
 use termusicplayback::{
     Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
-    PlayerErrorType, PlayerTrait, Playlist, SharedPlaylist, SpeedSigned, Volume, VolumeSigned,
+    PlayerErrorType, PlayerTrait, Playlist, SharedPlaylist, SpeedSigned, VolumeSigned,
     quit_sources,
 };
 use tokio::runtime::Handle;
@@ -49,7 +49,6 @@ const BACKEND_ERROR_LIMIT: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 struct PlayerStats {
     pub progress: PlayerProgress,
     pub current_track_index: u64,
-    pub volume: u16,
     pub speed: i32,
     pub gapless: bool,
     pub radio_title: String,
@@ -63,22 +62,25 @@ impl PlayerStats {
                 total_duration: None,
             },
             current_track_index: 0,
-            volume: 0,
             speed: 10,
             gapless: true,
             radio_title: String::new(),
         }
     }
 
-    pub fn as_getprogress_response(&self, status: RunningStatus) -> GetProgressResponse {
+    pub fn as_getprogress_response(
+        &self,
+        status: RunningStatus,
+        config: &ServerOverlay,
+    ) -> GetProgressResponse {
         GetProgressResponse {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: status.as_u32(),
-            volume: u32::from(self.volume),
             speed: self.speed,
             gapless: self.gapless,
             radio_title: self.radio_title.clone(),
+            volume: u32::from(config.settings.player.volume),
         }
     }
 
@@ -479,19 +481,19 @@ fn player_loop(
             PlayerCmd::VolumeDown => {
                 info!("before volumedown: {}", player.volume());
                 let new_volume = player.add_volume(-VOLUME_STEP);
-                set_volume(&player, &playerstats, new_volume);
+                player.config.write().settings.player.volume = new_volume;
                 info!("after volumedown: {new_volume}");
             }
             PlayerCmd::VolumeUp => {
                 info!("before volumeup: {}", player.volume());
                 let new_volume = player.add_volume(VOLUME_STEP);
-                set_volume(&player, &playerstats, new_volume);
+                player.config.write().settings.player.volume = new_volume;
                 info!("after volumeup: {new_volume}");
             }
             PlayerCmd::VolumeSet(volume) => {
                 info!("before volumeset: {}", player.volume());
                 let new_volume = player.set_volume(volume);
-                set_volume(&player, &playerstats, new_volume);
+                player.config.write().settings.player.volume = new_volume;
                 info!("after volumeset: {new_volume}");
             }
             PlayerCmd::Pause => {
@@ -703,11 +705,4 @@ async fn execute_action(action: cli::Action, config: &ServerOverlay) -> Result<(
     };
 
     Ok(())
-}
-
-/// Set the volume for the Config and the playerstats.
-fn set_volume(player: &GeneralPlayer, playerstats: &Arc<Mutex<PlayerStats>>, new_volume: Volume) {
-    player.config.write().settings.player.volume = new_volume;
-    let mut p_tick = playerstats.lock();
-    p_tick.volume = new_volume;
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -451,7 +451,7 @@ fn player_loop(
                 }
                 p_tick.current_track_index =
                     u64::try_from(playlist.get_current_track_index()).unwrap();
-                if let Some(track) = playlist.current_track() {
+                if let Some(track) = player.run_info.read().current_track() {
                     update_metadata_changed(&mut p_tick, &player, track);
                 }
             }
@@ -535,7 +535,7 @@ fn player_loop(
             }
             PlayerCmd::MetadataChanged => {
                 trace!("Metadata changed");
-                if let Some(track) = player.playlist.read().current_track() {
+                if let Some(track) = player.run_info.read().current_track() {
                     let mut p_tick = playerstats.lock();
                     update_metadata_changed(&mut p_tick, &player, track);
                 }
@@ -579,7 +579,7 @@ fn update_metadata_changed(p_tick: &mut PlayerStats, player: &GeneralPlayer, tra
 ///
 /// Use `use_skip` to skip the next track instead of trying to play it.
 fn player_eos(player: &mut GeneralPlayer, use_skip: bool) {
-    let mut playlist = player.playlist.write();
+    let playlist = player.playlist.read();
     if playlist.is_empty() {
         drop(playlist);
         player.stop();
@@ -599,7 +599,6 @@ fn player_eos(player: &mut GeneralPlayer, use_skip: bool) {
         "current track index: {:?}",
         playlist.get_current_track_index()
     );
-    playlist.clear_current_track();
     drop(playlist);
     // skip the next one as it had already errored via enqueuement, no need to try again
     if use_skip {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::{Context as _, Result, bail};
 use clap::Parser;
 use music_player_service::MusicPlayerService;
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use termusiclib::config::v2::server::config_extra::ServerConfigVersionedDefaulted;
 use termusiclib::config::v2::server::{ComProtocol, ScanDepth, StartupState};
 use termusiclib::config::{ServerOverlay, SharedServerSettings, new_shared_server_settings};
@@ -16,8 +16,8 @@ use termusiclib::track::{MediaTypesSimple, Track};
 use termusiclib::{podcast, utils};
 use termusicplayback::{
     Backend, BackendSelect, GeneralPlayer, PlayerCmd, PlayerCmdReciever, PlayerCmdSender,
-    PlayerErrorType, PlayerTrait, Playlist, SharedPlaylist, SpeedSigned, VolumeSigned,
-    quit_sources,
+    PlayerErrorType, PlayerTrait, Playlist, RunInfo, SharedPlaylist, SharedRunInfo, SpeedSigned,
+    VolumeSigned, quit_sources,
 };
 use tokio::runtime::Handle;
 use tokio::select;
@@ -139,11 +139,14 @@ async fn actual_main() -> Result<()> {
     let playlist =
         Playlist::new_shared(&config, stream_tx.clone()).context("Failed to load playlist")?;
 
+    let run_info = Arc::new(RwLock::new(RunInfo::default()));
+
     let music_player_service: MusicPlayerService = MusicPlayerService::new(
         cmd_tx.clone(),
         stream_tx.clone(),
         config.clone(),
         playlist.clone(),
+        run_info.clone(),
     );
     let playerstats = music_player_service.player_stats.clone();
 
@@ -181,6 +184,7 @@ async fn actual_main() -> Result<()> {
                 playerstats,
                 stream_tx,
                 playlist,
+                run_info,
                 active_connections_data,
             );
             let _ = player_handle_os_tx.send(res);
@@ -293,9 +297,11 @@ fn player_loop(
     playerstats: Arc<Mutex<PlayerStats>>,
     stream_tx: termusicplayback::StreamTX,
     playlist: SharedPlaylist,
+    run_info: SharedRunInfo,
     active_connections_data: ActiveConnections,
 ) -> Result<()> {
-    let mut player = GeneralPlayer::new_backend(backend, config, cmd_tx, stream_tx, playlist)?;
+    let mut player =
+        GeneralPlayer::new_backend(backend, config, cmd_tx, stream_tx, playlist, run_info)?;
 
     let mut had_enqueue_error = false;
     let mut should_quit = false;
@@ -426,7 +432,6 @@ fn player_loop(
                 let mut playlist = player.playlist.read();
 
                 if let Some(progress) = player.get_progress() {
-                    let pl_status = playlist.status();
                     p_tick.progress = progress;
 
                     // the following function is "mut", which does not like having the immutable borrow to "playlist"
@@ -435,7 +440,7 @@ fn player_loop(
                     player.update_progress(&p_tick.progress);
 
                     // only reset errors if position is either above 0 or total duration is available and is above 0
-                    if pl_status == RunningStatus::Running
+                    if player.run_info.read().is_playing()
                         && (progress.total_duration.is_some_and(|v| v > Duration::ZERO)
                             || progress.position.is_some_and(|v| v > Duration::ZERO))
                     {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -384,6 +384,7 @@ fn player_loop(
                 player.playlist.write().reload_tracks().ok();
             }
             PlayerCmd::SeekBackward => {
+                // TODO: do seek callback for faster progress updates?
                 player.seek_relative(false);
             }
             PlayerCmd::SeekForward => {
@@ -443,11 +444,8 @@ fn player_loop(
 
                     playlist = player.playlist.read();
                 }
-                if player.current_track_updated {
-                    p_tick.current_track_index =
-                        u64::try_from(playlist.get_current_track_index()).unwrap();
-                    player.current_track_updated = false;
-                }
+                p_tick.current_track_index =
+                    u64::try_from(playlist.get_current_track_index()).unwrap();
                 if let Some(track) = playlist.current_track() {
                     update_metadata_changed(&mut p_tick, &player, track);
                 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -369,7 +369,6 @@ fn player_loop(
                     had_enqueue_error = true;
                 }
             }
-            PlayerCmd::GetProgress => {}
             PlayerCmd::SkipPrevious => {
                 player.reset_errors();
                 info!("skip to previous track");

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -318,7 +318,7 @@ fn player_loop(
                 info!("about to finish signal received");
                 let playlist = player.playlist.read();
                 if !playlist.is_empty()
-                    && !playlist.has_next_track()
+                    && playlist.get_next_track().is_none()
                     && player.config.read().settings.player.gapless
                 {
                     drop(playlist);
@@ -495,7 +495,7 @@ fn player_loop(
                     info.track_index, info.id
                 );
                 player.player_save_last_position();
-                if let Err(err) = player.playlist.write().play_specific(&info) {
+                if let Err(err) = player.playlist.write().set_play_specific(&info) {
                     error!("Error setting specific track to play: {err}");
                 }
                 player.next();
@@ -604,7 +604,7 @@ fn player_eos(player: &mut GeneralPlayer, use_skip: bool) {
     if use_skip {
         player.next();
     } else {
-        player.start_play();
+        player.start_play(true);
     }
     debug!(
         "playing index is: {}",

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -49,7 +49,6 @@ const BACKEND_ERROR_LIMIT: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 struct PlayerStats {
     pub progress: PlayerProgress,
     pub current_track_index: u64,
-    pub speed: i32,
     pub gapless: bool,
     pub radio_title: String,
 }
@@ -62,7 +61,6 @@ impl PlayerStats {
                 total_duration: None,
             },
             current_track_index: 0,
-            speed: 10,
             gapless: true,
             radio_title: String::new(),
         }
@@ -77,10 +75,10 @@ impl PlayerStats {
             progress: Some(self.as_playertime()),
             current_track_index: self.current_track_index,
             status: status.as_u32(),
-            speed: self.speed,
             gapless: self.gapless,
             radio_title: self.radio_title.clone(),
             volume: u32::from(config.settings.player.volume),
+            speed: config.settings.player.speed,
         }
     }
 
@@ -412,16 +410,12 @@ fn player_loop(
                 let new_speed = player.add_speed(-SPEED_STEP);
                 info!("after speed down: {new_speed}");
                 player.config.write().settings.player.speed = new_speed;
-                let mut p_tick = playerstats.lock();
-                p_tick.speed = new_speed;
             }
 
             PlayerCmd::SpeedUp => {
                 let new_speed = player.add_speed(SPEED_STEP);
                 info!("after speed up: {new_speed}");
                 player.config.write().settings.player.speed = new_speed;
-                let mut p_tick = playerstats.lock();
-                p_tick.speed = new_speed;
             }
             PlayerCmd::Tick => {
                 // Quit once there are no more connections active and having had at least one connection.

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -386,17 +386,9 @@ fn player_loop(
             }
             PlayerCmd::SeekBackward => {
                 player.seek_relative(false);
-                let mut p_tick = playerstats.lock();
-                if let Some(progress) = player.get_progress() {
-                    p_tick.progress = progress
-                }
             }
             PlayerCmd::SeekForward => {
                 player.seek_relative(true);
-                let mut p_tick = playerstats.lock();
-                if let Some(progress) = player.get_progress() {
-                    p_tick.progress = progress
-                }
             }
             PlayerCmd::SkipNext => {
                 player.reset_errors();

--- a/tui/src/ui/components/playlist.rs
+++ b/tui/src/ui/components/playlist.rs
@@ -534,8 +534,6 @@ impl Model {
     }
 
     /// Handle setting the current track index in the TUI playlist and selecting the proper list item
-    ///
-    /// Note: currently this function is called twice per track change, once for `UpdateEvents::TrackChanged` and once for `run_playback::GetProgress`
     pub fn handle_current_track_index(&mut self, current_track_index: usize, force_relocate: bool) {
         let tui_old_current_index = self.playback.playlist.current_track_index();
         info!(

--- a/tui/src/ui/model/playlist.rs
+++ b/tui/src/ui/model/playlist.rs
@@ -57,6 +57,15 @@ impl TUIPlaylist {
             bail!("Index {} not within tracks bounds", index_a.max(index_b));
         }
 
+        // maintain the correct current track index after swap
+        if let Some(current_track_idx) = self.current_track_idx {
+            if current_track_idx == index_a {
+                self.current_track_idx = Some(index_b);
+            } else if current_track_idx == index_b {
+                self.current_track_idx = Some(index_a);
+            }
+        }
+
         self.tracks.swap(index_a, index_b);
 
         Ok(())

--- a/tui/src/ui/model/playlist.rs
+++ b/tui/src/ui/model/playlist.rs
@@ -74,6 +74,16 @@ impl TUIPlaylist {
 
         self.tracks.remove(index);
 
+        // Update the current playing track index.
+        // TODO: maybe this can be improved somehow? Maybe by providing the current track idx in each message?
+        if self.current_track_idx.is_some_and(|v| v == index) {
+            let _ = self.current_track_idx.take();
+        } else if let Some(old_current_idx) = self.current_track_idx
+            && index < old_current_idx
+        {
+            self.current_track_idx = Some(old_current_idx.saturating_sub(1));
+        }
+
         Ok(())
     }
 

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -1168,12 +1168,12 @@ impl Model {
                 // handle "no more tracks / stopped" in this
                 if self.playback.is_stopped() {
                     self.playback.clear_current_track();
-                    self.lyric_update_title();
                     self.lyric_update();
                     self.progress_update(Some(Duration::ZERO), Duration::ZERO);
                 }
 
                 self.progress_update_title();
+                self.lyric_update_title();
             }
             UpdateEvents::TrackChanged(track_changed_info) => {
                 if let Some(progress) = track_changed_info.progress {
@@ -1183,7 +1183,12 @@ impl Model {
                     );
                 }
 
-                if track_changed_info.current_track_updated {
+                let as_usize =
+                    usize::try_from(track_changed_info.current_track_index).unwrap_or(usize::MAX);
+
+                if Some(as_usize) != self.playback.playlist.current_track_index()
+                    || self.playback.current_track().is_none()
+                {
                     self.handle_current_track_index(
                         usize::try_from(track_changed_info.current_track_index).unwrap(),
                         false,

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -1183,17 +1183,10 @@ impl Model {
                     );
                 }
 
-                let as_usize =
-                    usize::try_from(track_changed_info.current_track_index).unwrap_or(usize::MAX);
-
-                if Some(as_usize) != self.playback.playlist.current_track_index()
-                    || self.playback.current_track().is_none()
-                {
-                    self.handle_current_track_index(
-                        usize::try_from(track_changed_info.current_track_index).unwrap(),
-                        false,
-                    );
-                }
+                self.handle_current_track_index(
+                    usize::try_from(track_changed_info.current_track_index).unwrap(),
+                    false,
+                );
 
                 if let Some(title) = track_changed_info.title {
                     self.lyric_update_for_radio(title);


### PR DESCRIPTION
This PR moves the "current playing track" information from the playlist to outside of it, as the playlist should not be concerned with more than what the current track inside the playlist is. (for future multi-playlist ability)
Additionally:
- fix cpal / rodio panic on resume-able error (ex `BufferUnderrun`)
- refactor Playlist next / previous / current handling to be easier to understand
- fix TUI showing a different track as "currently playing" if current one is deleted
- fix TUI not showing currently playing track correctly if swapped
- fix SERVER not continuing from the swapped position if the current track is swapped
- rename some function to be closer to what they actually do
- some misc cleanup

To say this differently, this is cleanup so that in the future we can easily support multiple playlists and playing things directly (not being in a playlist, see #144). This also makes #493 easier to fix by having easier to understand flow.

---

Somewhere since opening #189 it got fixed, so i will tentatively put it here:
fixes #189

~~EDIT: still known issue is that when deleting the currently playing entry in the playlist, the TUI will show the next in the list with the "currently playing" icon.~~