### PR TITLE
feat(playback): publish current track to mpris on startup

### DIFF
--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -539,6 +539,41 @@ impl GeneralPlayer {
         }
     }
 
+    /// Publish the playlist's current track to MPRIS (and Discord) as Stopped,
+    /// without starting actual playback or loading the backend.
+    ///
+    /// Used when the server starts with `startup_state != Playing` so that MPRIS
+    /// clients (e.g. noctalia, KDE-style media widgets) see real now-playing
+    /// metadata immediately, instead of an empty default snapshot. Some shells
+    /// (noctalia v5) evict players whose first metadata snapshot is empty and
+    /// never re-introspect, so without this they stay broken until the user
+    /// manually plays once.
+    ///
+    /// Crucially, this leaves `RunningStatus` as `Stopped`. That way when a
+    /// client sends MPRIS `Play`, [`Self::play`] dispatches to
+    /// [`Self::resume_from_stopped`] (which loads the file and starts the
+    /// backend), instead of [`PlayerTrait::resume`] (which would only un-pause
+    /// an already-loaded backend, producing silent "playback").
+    pub fn publish_current_track_stopped_to_mpris(&mut self) {
+        let Some(track) = self.playlist.read().get_current_track().cloned() else {
+            return; // empty playlist; nothing to publish
+        };
+
+        // Record the current track for run_info readers (set_track_mpris_discord,
+        // send_track_changed), but DO NOT call set_status — leave it as
+        // RunningStatus::Stopped.
+        self.run_info.write().set_current_track(track);
+        self.set_track_mpris_discord();
+
+        // `Mpris::set_track` hard-codes PlaybackStatus=Playing; correct it to
+        // Stopped because no backend is actually loaded yet.
+        if let Some(ref mut mpris) = self.mpris {
+            mpris.stop();
+        }
+
+        self.send_track_changed();
+    }
+
     /// Try to enqueue the next track to play, so that it can be seamlessly played.
     pub fn enqueue_next_from_playlist(&mut self) {
         let mut playlist = self.playlist.write();

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -102,6 +102,9 @@ impl Mpris {
             .set_playback(MediaPlayback::Playing { progress: None })
             .ok();
     }
+    pub fn stop(&mut self) {
+        self.controls.set_playback(MediaPlayback::Stopped).ok();
+    }
 
     /// Update Track position / progress, requires `playlist_status` because [`MediaControls`] only allows `set_playback`, not `set_position` or `get_playback`
     pub fn update_progress(

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -309,6 +309,13 @@ fn player_loop(
     // Start the playback, if wanted on startup
     if player.config.read().settings.player.startup_state == StartupState::Playing {
         player.resume_from_stopped();
+    } else {
+        // Publish the loaded playlist's current track to MPRIS (and Discord) as
+        // Stopped, so MPRIS clients see real now-playing metadata at startup
+        // instead of an empty default snapshot. See
+        // `publish_current_track_stopped_to_mpris` for why this must stay Stopped
+        // (not Paused).
+        player.publish_current_track_stopped_to_mpris();
     }
 
     while let Some((cmd, cb)) = cmd_rx.blocking_recv() {


### PR DESCRIPTION
When the server starts with startup_state != Playing, publish the loaded playlist's current track to MPRIS (and Discord) as Stopped, instead of leaving MPRIS clients with an empty default metadata snapshot.

Some MPRIS clients (e.g. noctalia v5) evict players whose first introspection returns empty metadata and never re-introspect them, so without this they show no now-playing info until the user manually starts playback.

The status is intentionally Stopped, not Paused: when a client sends MPRIS `Play`, `GeneralPlayer::play` routes Stopped to `resume_from_stopped` (loads the file and starts the backend), whereas Paused would route to `PlayerTrait::resume` (only un-pauses an already-loaded backend, producing silent "playback").

Add `Mpris::stop` to set PlaybackStatus=Stopped, correcting the Playing status that `Mpris::set_track` hard-codes.

- playback/src/mpris.rs: add `Mpris::stop`
- playback/src/lib.rs: add `GeneralPlayer::publish_current_track_stopped_to_mpris`
- server/src/server.rs: call it in player_loop's non-Playing startup branch