### PR TITLE
Add RPC and configuration options for restarting songs

### DIFF
--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -14,6 +14,7 @@ service MusicPlayer {
   rpc SpeedDown(Empty) returns (SpeedReply);
   // Toggle the gapless mdoe, returns the new state.
   rpc ToggleGapless(Empty) returns (GaplessState);
+  rpc RestartTrack(Empty) returns (PlayerTime);
   rpc SeekForward(Empty) returns (PlayerTime);
   rpc SeekBackward(Empty) returns (PlayerTime);
 

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -340,6 +340,9 @@ pub struct KeysPlayer {
     ///
     /// Will only apply in specific widgets (like the Playlist, but not in Config)
     pub volume_down: KeyBinding,
+    /// Key to restart track
+    ///
+    pub restart_track: KeyBinding,
     /// Key to seek forwards (by a set amount)
     ///
     /// Will only apply in specific widgets (like the Playlist, but not in Config)
@@ -378,6 +381,7 @@ impl Default for KeysPlayer {
             .into(),
             volume_up: tuievents::Key::Char('+').into(),
             volume_down: tuievents::Key::Char('-').into(),
+            restart_track: tuievents::Key::Char('0').into(),
             seek_forward: tuievents::Key::Char('f').into(),
             seek_backward: tuievents::Key::Char('b').into(),
             speed_up: tuievents::KeyEvent::new(
@@ -1894,6 +1898,9 @@ mod v1_interop {
                 }
             };
 
+            // defining default key for restart track without relying on v1 legacy keybindings.
+            let player_restart_track_key = KeysPlayer::default().restart_track;
+
             Self {
                 escape: value.global_esc.into(),
                 quit: value.global_quit.into(),
@@ -1918,6 +1925,7 @@ mod v1_interop {
                     previous_track: value.global_player_previous.into(),
                     volume_up: value.global_player_volume_plus_2.into(),
                     volume_down: player_volume_down_key,
+                    restart_track: player_restart_track_key,
                     seek_forward: value.global_player_seek_forward.into(),
                     seek_backward: value.global_player_seek_backward.into(),
                     speed_up: value.global_player_speed_up.into(),
@@ -2050,6 +2058,7 @@ mod v1_interop {
                     tuievents::KeyModifiers::NONE,
                 )
                 .into(),
+                restart_track: tuievents::Key::Char('0').into(),
                 seek_forward: tuievents::Key::Char('f').into(),
                 seek_backward: tuievents::Key::Char('b').into(),
                 speed_up: tuievents::KeyEvent::new(
@@ -2287,6 +2296,7 @@ mod v1_interop {
                     tuievents::KeyModifiers::NONE,
                 )
                 .into(),
+                restart_track: tuievents::Key::Char('0').into(),
                 seek_forward: tuievents::Key::Char('f').into(),
                 seek_backward: tuievents::Key::Char('b').into(),
                 speed_up: tuievents::KeyEvent::new(

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -127,6 +127,7 @@ pub enum PlayerCmd {
     Quit(&'static str),
     ReloadConfig,
     ReloadPlaylist,
+    RestartTrack,
     SeekBackward,
     SeekForward,
     SkipNext,
@@ -671,6 +672,12 @@ impl GeneralPlayer {
                 self.start_play(false);
             }
         }
+    }
+
+    ///
+    /// Sets Player Position to 0
+    pub fn restart_track(&mut self) {
+        self.seek_to(Duration::from_secs(0));
     }
 
     /// # Panics

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -138,6 +138,20 @@ impl MusicPlayer for MusicPlayerService {
         Ok(Response::new(reply))
     }
 
+    async fn restart_track(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<PlayerTime>, Status> {
+        let rx = self.command_cb(PlayerCmd::RestartTrack)?;
+        // wait until the event was processed
+        let _ = rx.await;
+        let s = self.player_stats.lock();
+
+        let reply = s.as_playertime();
+
+        Ok(Response::new(reply))
+    }
+
     async fn seek_forward(&self, _request: Request<Empty>) -> Result<Response<PlayerTime>, Status> {
         let rx = self.command_cb(PlayerCmd::SeekForward)?;
         // wait until the event was processed

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -393,6 +393,9 @@ fn player_loop(
                 // TODO: do seek callback for faster progress updates?
                 player.seek_relative(false);
             }
+            PlayerCmd::RestartTrack => {
+                player.restart_track();
+            }
             PlayerCmd::SeekForward => {
                 player.seek_relative(true);
             }

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -967,6 +967,9 @@ impl KEModifierSelect {
             }
             IdKey::Global(IdKeyGlobal::PlayerNext) => keys.player_keys.next_track.mod_key(),
             IdKey::Global(IdKeyGlobal::PlayerPrevious) => keys.player_keys.previous_track.mod_key(),
+            IdKey::Global(IdKeyGlobal::PlayerRestartTrack) => {
+                keys.player_keys.restart_track.mod_key()
+            }
             IdKey::Global(IdKeyGlobal::PlayerSeekForward) => {
                 keys.player_keys.seek_forward.mod_key()
             }
@@ -1404,6 +1407,15 @@ fn key_global_player_volume_down(config: SharedTuiSettings) -> KEModifierSelect 
     KEModifierSelect::new(
         " Decrease Volume ",
         IdKey::Global(IdKeyGlobal::PlayerVolumeDown),
+        config,
+    )
+}
+
+#[inline]
+fn key_global_player_restart_track(config: SharedTuiSettings) -> KEModifierSelect {
+    KEModifierSelect::new(
+        " Restart Track ",
+        IdKey::Global(IdKeyGlobal::PlayerRestartTrack),
         config,
     )
 }
@@ -1910,6 +1922,11 @@ impl Model {
         self.app.remount(
             Id::ConfigEditor(IdConfigEditor::KeyGlobal(IdKeyGlobal::PlayerVolumeDown)),
             Box::new(key_global_player_volume_down(self.config_tui.clone())),
+            Vec::new(),
+        )?;
+        self.app.remount(
+            Id::ConfigEditor(IdConfigEditor::KeyGlobal(IdKeyGlobal::PlayerRestartTrack)),
+            Box::new(key_global_player_restart_track(self.config_tui.clone())),
             Vec::new(),
         )?;
         self.app.remount(

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -284,6 +284,9 @@ impl Model {
             IdKey::Global(IdKeyGlobal::PlayerPrevious) => {
                 keys.player_keys.previous_track = binding;
             }
+            IdKey::Global(IdKeyGlobal::PlayerRestartTrack) => {
+                keys.player_keys.restart_track = binding;
+            }
             IdKey::Global(IdKeyGlobal::PlayerSeekForward) => {
                 keys.player_keys.seek_forward = binding;
             }

--- a/tui/src/ui/components/global_listener.rs
+++ b/tui/src/ui/components/global_listener.rs
@@ -64,6 +64,9 @@ impl AppComponent<Msg, UserEvent> for GlobalListener {
             Event::Keyboard(keyevent) if keyevent == keys.select_view_keys.open_help.get() => {
                 Some(Msg::HelpPopup(HelpPopupMsg::Show))
             }
+            Event::Keyboard(keyevent) if keyevent == keys.player_keys.restart_track.get() => {
+                Some(Msg::Player(PlayerMsg::RestartTrack))
+            }
             Event::Keyboard(keyevent) if keyevent == keys.player_keys.seek_forward.get() => {
                 Some(Msg::Player(PlayerMsg::SeekForward))
             }
@@ -237,6 +240,10 @@ fn global_listener_subscriptions(keys: &Keys) -> Vec<Sub<Id, UserEvent>> {
         // ),
         Sub::new(
             EventClause::Keyboard(keys.select_view_keys.open_help.get_owned()),
+            no_popup_clause.clone(),
+        ),
+        Sub::new(
+            EventClause::Keyboard(keys.player_keys.restart_track.get_owned()),
             no_popup_clause.clone(),
         ),
         Sub::new(

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -122,6 +122,9 @@ impl HelpPopup {
                         ))
                         .add_col(Self::comment("Move cursor(vim style by default)"))
                         .add_row()
+                        .add_col(Self::key(&config, &[&keys.player_keys.restart_track]))
+                        .add_col(Self::comment("Restart current track"))
+                        .add_row()
                         .add_col(Self::key(
                             &config,
                             &[

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -179,6 +179,7 @@ pub enum IdKeyGlobal {
     PlayerTogglePause,
     PlayerNext,
     PlayerPrevious,
+    PlayerRestartTrack,
     PlayerSeekForward,
     PlayerSeekBackward,
     PlayerSpeedUp,

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -411,6 +411,18 @@ impl Model {
             PlayerMsg::TogglePause => {
                 self.player_toggle_pause();
             }
+            PlayerMsg::RestartTrack => {
+                if self.is_radio() {
+                    self.show_message_timeout_label_help(
+                        "seek is not available for live radio",
+                        None,
+                        None,
+                        None,
+                    );
+                    return;
+                }
+                self.command(TuiCmd::RestartTrack);
+            }
             PlayerMsg::SeekForward => {
                 if self.is_radio() {
                     self.show_message_timeout_label_help(

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -71,6 +71,7 @@ pub enum PlayerMsg {
     VolumeDown,
     SpeedUp,
     SpeedDown,
+    RestartTrack,
     SeekForward,
     SeekBackward,
 }

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -464,6 +464,7 @@ pub const KFGLOBAL_FOCUS_ORDER: &[IdKey] = &[
     IdKey::Global(IdKeyGlobal::PlayerTogglePause),
     IdKey::Global(IdKeyGlobal::PlayerNext),
     IdKey::Global(IdKeyGlobal::PlayerPrevious),
+    IdKey::Global(IdKeyGlobal::PlayerRestartTrack),
     IdKey::Global(IdKeyGlobal::PlayerSeekForward),
     IdKey::Global(IdKeyGlobal::PlayerSeekBackward),
     IdKey::Global(IdKeyGlobal::PlayerSpeedUp),

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -101,6 +101,14 @@ impl Playback {
         Ok(response.gapless)
     }
 
+    pub async fn restart_track(&mut self) -> Result<PlayerProgress> {
+        let request = tonic::Request::new(Empty {});
+        let response = self.client.restart_track(request).await?;
+        let response = response.into_inner();
+        info!("Got response from server: {response:?}");
+        Ok(response.into())
+    }
+
     pub async fn seek_forward(&mut self) -> Result<PlayerProgress> {
         let request = tonic::Request::new(Empty {});
         let response = self.client.seek_forward(request).await?;

--- a/tui/src/ui/server_req_actor.rs
+++ b/tui/src/ui/server_req_actor.rs
@@ -54,6 +54,10 @@ impl ServerRequestActor {
                 // result will be populated back via UpdateStream
                 let _ = self.client_handle.toggle_pause().await?;
             }
+            TuiCmd::RestartTrack => {
+                // result will be populated back via UpdateStream
+                let _ = self.client_handle.restart_track().await?;
+            }
             TuiCmd::SeekForward => {
                 // result will be populated back via UpdateStream
                 let _ = self.client_handle.seek_forward().await?;

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -10,6 +10,7 @@ pub enum TuiCmd {
     TogglePause,
     // Play,
     // Pause,
+    RestartTrack,
     SeekForward,
     SeekBackward,
     VolumeUp,


### PR DESCRIPTION
## Add Key Binding for Restarting current song as requested from issue #699 
- Added gRPC function definition
- Added following client and server side function
- Added 'Restart' enum and linked them to their keybinding.
- Set default value to '0'
- Added proper description and config editor option.