### PR TITLE
MPRIS: remove wrong potential `RunningStatus` set & reduce progress / position flicker on PAUSE & RESUME

### DIFF
--- a/playback/src/discord.rs
+++ b/playback/src/discord.rs
@@ -18,8 +18,9 @@ pub struct Rpc {
 
 enum RpcCommand {
     Update(String, String),
-    Pause,
     Resume(i64),
+    Pause,
+    Stop,
 }
 
 impl Default for Rpc {
@@ -37,19 +38,19 @@ impl Default for Rpc {
 }
 
 impl Rpc {
-    /// Update the discord status track information
+    /// Update the discord status track information.
     pub fn set_track(&self, track: &Track) {
         let artist = track.artist().unwrap_or(UNKNOWN_ARTIST).to_string();
         let title = track.title().unwrap_or(UNKNOWN_TITLE).to_string();
         self.tx.send(RpcCommand::Update(artist, title)).ok();
     }
 
-    /// Update the discord status to show that it is paused
+    /// Update the discord status to show that it is paused.
     pub fn pause(&self) {
         self.tx.send(RpcCommand::Pause).ok();
     }
 
-    /// Update the discord status to show that it is playing
+    /// Update the discord status to show that it is playing.
     pub fn resume(&self, time_pos: Option<PlayerTimeUnit>) {
         // ignore clippy here, this should not be a problem, maybe rich presence will support duration in the future
         #[allow(clippy::cast_possible_wrap)]
@@ -60,8 +61,13 @@ impl Rpc {
         }
     }
 
+    /// Update the discord status to show that it is stopped.
+    pub fn stop(&self) {
+        self.tx.send(RpcCommand::Stop).ok();
+    }
+
     /// This function actually communicates with the discord client and is meant to run in its own thread.
-    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
     fn thread_fn(mut client: DiscordIpcClient, rx: Receiver<RpcCommand>) {
         let mut artist = String::new();
         let mut title = String::new();
@@ -158,6 +164,23 @@ impl Rpc {
                                 .timestamps(timestamp)
                                 .state(&artist)
                                 .details(&title),
+                        )
+                        .ok();
+                }
+                RpcCommand::Stop => {
+                    title.clear();
+                    artist.clear();
+
+                    let assets = activity::Assets::new()
+                        .large_image("termusic")
+                        .large_text("terminal music player written in Rust");
+
+                    client
+                        .set_activity(
+                            activity::Activity::new()
+                                .assets(assets)
+                                .state(&artist)
+                                .details("Stopped"),
                         )
                         .ok();
                 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -865,10 +865,11 @@ impl PlayerTrait for GeneralPlayer {
     fn resume(&mut self) {
         self.run_info.write().play(&self.stream_tx);
         self.get_player_mut().resume();
-        if let Some(ref mut mpris) = self.mpris {
-            mpris.resume();
-        }
+
         let time_pos = self.get_player().position();
+        if let Some(ref mut mpris) = self.mpris {
+            mpris.resume(time_pos);
+        }
         if let Some(ref discord) = self.discord {
             discord.resume(time_pos);
         }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -854,8 +854,9 @@ impl PlayerTrait for GeneralPlayer {
     fn pause(&mut self) {
         self.run_info.write().pause(&self.stream_tx);
         self.get_player_mut().pause();
+        let time_pos = self.get_player().position();
         if let Some(ref mut mpris) = self.mpris {
-            mpris.pause();
+            mpris.pause(time_pos);
         }
         if let Some(ref discord) = self.discord {
             discord.pause();

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -907,6 +907,13 @@ impl PlayerTrait for GeneralPlayer {
         self.in_skip = false;
         self.run_info.write().stop(&self.stream_tx);
         self.get_player_mut().stop();
+
+        if let Some(ref mut mpris) = self.mpris {
+            mpris.stop();
+        }
+        if let Some(ref discord) = self.discord {
+            discord.stop();
+        }
     }
 
     fn get_progress(&self) -> Option<PlayerProgress> {

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -91,9 +91,11 @@ impl Mpris {
     }
 
     /// Set the MPRIS metadata to display that playback is paused.
-    pub fn pause(&mut self) {
+    pub fn pause(&mut self, position: Option<Duration>) {
         self.controls
-            .set_playback(MediaPlayback::Paused { progress: None })
+            .set_playback(MediaPlayback::Paused {
+                progress: position.map(souvlaki::MediaPosition),
+            })
             .ok();
     }
 

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -52,13 +52,8 @@ impl Mpris {
 }
 
 impl Mpris {
+    /// Set Mpris metadata based on the given track.
     pub fn set_track(&mut self, track: &Track) {
-        // This is to fix a bug that the first track is not updated
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        self.controls
-            .set_playback(MediaPlayback::Playing { progress: None })
-            .ok();
-
         let cover_art = match track.get_picture() {
             Ok(v) => v.map(|v| {
                 format!(
@@ -81,22 +76,25 @@ impl Mpris {
 
         let album = track.as_track().and_then(|v| v.album());
 
-        self.controls
-            .set_metadata(MediaMetadata {
-                title: Some(track.title().unwrap_or(UNKNOWN_TITLE)),
-                artist: Some(track.artist().unwrap_or(UNKNOWN_ARTIST)),
-                album: Some(album.unwrap_or("")),
-                cover_url: cover_art.as_deref(),
-                duration: track.duration(),
-            })
-            .ok();
+        if let Err(err) = self.controls.set_metadata(MediaMetadata {
+            title: Some(track.title().unwrap_or(UNKNOWN_TITLE)),
+            artist: Some(track.artist().unwrap_or(UNKNOWN_ARTIST)),
+            album: Some(album.unwrap_or("")),
+            cover_url: cover_art.as_deref(),
+            duration: track.duration(),
+        }) {
+            error!("Error setting MPRIS metadata: {err}");
+        }
     }
 
+    /// Set the MPRIS metadata to display that playback is paused.
     pub fn pause(&mut self) {
         self.controls
             .set_playback(MediaPlayback::Paused { progress: None })
             .ok();
     }
+
+    /// Set the MPRIS metadata to display that playback is playing.
     pub fn resume(&mut self) {
         self.controls
             .set_playback(MediaPlayback::Playing { progress: None })

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -1,4 +1,7 @@
-use std::sync::mpsc::{self, Receiver};
+use std::{
+    sync::mpsc::{self, Receiver},
+    time::Duration,
+};
 
 use base64::Engine;
 use souvlaki::{MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, PlatformConfig};
@@ -95,9 +98,11 @@ impl Mpris {
     }
 
     /// Set the MPRIS metadata to display that playback is playing.
-    pub fn resume(&mut self) {
+    pub fn resume(&mut self, position: Option<Duration>) {
         self.controls
-            .set_playback(MediaPlayback::Playing { progress: None })
+            .set_playback(MediaPlayback::Playing {
+                progress: position.map(souvlaki::MediaPosition),
+            })
             .ok();
     }
 

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -108,6 +108,11 @@ impl Mpris {
             .ok();
     }
 
+    /// Set the MPRIS metadata to display that playback is stopped.
+    pub fn stop(&mut self) {
+        self.controls.set_playback(MediaPlayback::Stopped).ok();
+    }
+
     /// Update Track position / progress, requires `playlist_status` because [`MediaControls`] only allows `set_playback`, not `set_position` or `get_playback`
     pub fn update_progress(
         &mut self,
@@ -122,12 +127,13 @@ impl Mpris {
                         progress: Some(souvlaki::MediaPosition(position)),
                     })
                     .ok(),
-                RunningStatus::Paused | RunningStatus::Stopped => self
+                RunningStatus::Paused => self
                     .controls
                     .set_playback(MediaPlayback::Paused {
                         progress: Some(souvlaki::MediaPosition(position)),
                     })
                     .ok(),
+                RunningStatus::Stopped => self.controls.set_playback(MediaPlayback::Stopped).ok(),
             };
         }
     }


### PR DESCRIPTION
This PR fixes a issue that was pointed out in https://github.com/tramhao/termusic/pull/716#issuecomment-4779083186, namely that in `Mpris::set_track` (called by `GeneralPlayer::start_play` & `GeneralPlayer::reload_config`) it would set `MediaPlayback::Running`, regardless of what state it actually was in `::reload_config`, until it gets fixed via a Tick via `::update_progress`.

Additionally:
- because souvlaki always requires the progress / position when setting `Running` or `Paused`, it is now passed along, resulting in no flicker to `0.0`.
- Properly show `Stopped` state in MPRIS and discord

@jenningsloy318 in case you want to review or see the changes