### PR TITLE
fix: allow mp4 files to play via filetype_supported

### DIFF
--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -49,6 +49,7 @@ pub fn filetype_supported(path: &Path) -> bool {
             | "aifc"
             | "flac"
             | "m4a"
+            | "mp4"
             | "aac"
             | "opus"
             | "ogg"
@@ -455,5 +456,22 @@ mod tests {
         assert_eq!(iter.next(), Some("hello there"));
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn filetype_supported_extensions() {
+        // mp4 (AAC-in-mp4 audio) is handled by the backend, so the extension
+        // allow-list should accept it. See issue #701.
+        assert!(filetype_supported(Path::new("song.mp4")));
+
+        // existing supported extensions still pass
+        assert!(filetype_supported(Path::new("song.mp3")));
+        assert!(filetype_supported(Path::new("song.m4a")));
+        assert!(filetype_supported(Path::new("song.aac")));
+        assert!(filetype_supported(Path::new("song.flac")));
+
+        // unsupported and extension-less paths are rejected
+        assert!(!filetype_supported(Path::new("notes.txt")));
+        assert!(!filetype_supported(Path::new("noextension")));
     }
 }


### PR DESCRIPTION
## Summary

`mp4` audio files can now be played. They were previously rejected by the
extension allow-list in `filetype_supported`, even though the backend decodes
the AAC-in-mp4 audio fine.

## Why this matters

As diagnosed in issue #701, `filetype_supported` in `lib/src/utils.rs` gates
playback on a file-extension allow-list. `mp3`, `m4a`, and `aac` were listed but
`mp4` was not, so pressing `l` on an mp4 did nothing while the same file plays in
mpv. Adding `mp4` to the existing `matches!` arm lets these files reach the
backend that already supports them. This stays consistent with the existing
`// TODO: decide filetype supported by backend instead of in library` note.

## Testing

Added a unit test in `lib/src/utils.rs` asserting `filetype_supported` returns
`true` for `song.mp4` (and existing `mp3`/`m4a`/`aac`/`flac`) and `false` for an
unsupported extension and an extension-less path.

- `cargo test -p termusic-lib utils::tests::filetype_supported_extensions` passes
- `cargo fmt --check` and `cargo clippy -p termusic-lib --lib` are clean

Fixes #701
