### PR TITLE
Add Catppuccin themes (latte, frappe, macchiato, mocha)

### DIFF
--- a/lib/themes/Catppuccin-Frappe.yml
+++ b/lib/themes/Catppuccin-Frappe.yml
@@ -1,0 +1,27 @@
+# Catppuccin Frappe
+colors:
+  name: Catppuccin Frappe
+  author: Catppuccin
+  primary:
+    background: '#303446'
+    foreground: '#c6d0f5'
+
+  normal:
+    black:   '#51576d'
+    red:     '#e78284'
+    green:   '#a6d189'
+    yellow:  '#e5c890'
+    blue:    '#8caaee'
+    magenta: '#f4b8e4'
+    cyan:    '#81c8be'
+    white:   '#b5bfe2'
+
+  bright:
+    black:   '#626880'
+    red:     '#e78284'
+    green:   '#a6d189'
+    yellow:  '#e5c890'
+    blue:    '#8caaee'
+    magenta: '#f4b8e4'
+    cyan:    '#81c8be'
+    white:   '#a5adce'

--- a/lib/themes/Catppuccin-Latte.yml
+++ b/lib/themes/Catppuccin-Latte.yml
@@ -1,0 +1,27 @@
+# Catppuccin Latte
+colors:
+  name: Catppuccin Latte
+  author: Catppuccin
+  primary:
+    background: '#eff1f5'
+    foreground: '#4c4f69'
+
+  normal:
+    black:   '#bcc0cc'
+    red:     '#d20f39'
+    green:   '#40a02b'
+    yellow:  '#df8e1d'
+    blue:    '#1e66f5'
+    magenta: '#ea76cb'
+    cyan:    '#179299'
+    white:   '#5c5f77'
+
+  bright:
+    black:   '#acb0be'
+    red:     '#d20f39'
+    green:   '#40a02b'
+    yellow:  '#df8e1d'
+    blue:    '#1e66f5'
+    magenta: '#ea76cb'
+    cyan:    '#179299'
+    white:   '#6c6f85'

--- a/lib/themes/Catppuccin-Macchiato.yml
+++ b/lib/themes/Catppuccin-Macchiato.yml
@@ -1,0 +1,27 @@
+# Catppuccin Macchiato
+colors:
+  name: Catppuccin Macchiato
+  author: Catppuccin
+  primary:
+    background: '#24273a'
+    foreground: '#cad3f5'
+
+  normal:
+    black:   '#494d64'
+    red:     '#ed8796'
+    green:   '#a6da95'
+    yellow:  '#eed49f'
+    blue:    '#8aadf4'
+    magenta: '#f5bde6'
+    cyan:    '#8bd5ca'
+    white:   '#b8c0e0'
+
+  bright:
+    black:   '#5b6078'
+    red:     '#ed8796'
+    green:   '#a6da95'
+    yellow:  '#eed49f'
+    blue:    '#8aadf4'
+    magenta: '#f5bde6'
+    cyan:    '#8bd5ca'
+    white:   '#a5adcb'

--- a/lib/themes/Catppuccin-Mocha.yml
+++ b/lib/themes/Catppuccin-Mocha.yml
@@ -1,0 +1,27 @@
+# Catppuccin Mocha
+colors:
+  name: Catppuccin Mocha
+  author: Catppuccin
+  primary:
+    background: '#1e1e2e'
+    foreground: '#cdd6f4'
+
+  normal:
+    black:   '#45475a'
+    red:     '#f38ba8'
+    green:   '#a6e3a1'
+    yellow:  '#f9e2af'
+    blue:    '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan:    '#94e2d5'
+    white:   '#bac2de'
+
+  bright:
+    black:   '#585b70'
+    red:     '#f38ba8'
+    green:   '#a6e3a1'
+    yellow:  '#f9e2af'
+    blue:    '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan:    '#94e2d5'
+    white:   '#a6adc8'


### PR DESCRIPTION
Adds the 4 standard Catppuccin flavor themes as YAML theme files, following the existing theme format. Palettes match the official Catppuccin Alacritty theme values.

Closes https://github.com/tramhao/termusic/issues/399