### PR TITLE
Add CLI media control commands

### DIFF
--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -82,6 +82,12 @@ pub enum Action {
     /// Skip to previous track
     #[command(aliases = &["p", "prev"])]
     Previous,
+    /// Resume playback
+    #[command(aliases = &["unpause", "resume"])]
+    Play,
+    /// Pause playback
+    #[command(aliases = &["stop"])]
+    Pause,
     /// Toggle play/pause
     #[command(aliases = &["t", "play-pause"])]
     TogglePause,
@@ -98,7 +104,6 @@ pub enum Action {
     /// Toggle gapless playback
     ToggleGapless,
     /// Restart current track
-    #[command(aliases = &["restart"])]
     RestartTrack,
     /// Seek forward
     SeekForward,
@@ -106,7 +111,7 @@ pub enum Action {
     SeekBackward,
     /// Cycle loop mode (list → track → one → list)
     CycleLoop,
-    /// Shuffle playlist
+    /// Shuffle the current playlist
     Shuffle,
     /// Quit the server
     Quit,

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -76,6 +76,40 @@ pub enum Action {
         #[arg(value_name = "FILE")]
         file: PathBuf,
     },
+    /// Skip to next track
+    #[command(aliases = &["n"])]
+    Next,
+    /// Skip to previous track
+    #[command(aliases = &["p", "prev"])]
+    Previous,
+    /// Toggle play/pause
+    #[command(aliases = &["t", "play-pause"])]
+    TogglePause,
+    /// Increase volume
+    #[command(aliases = &["v-up"])]
+    VolumeUp,
+    /// Decrease volume
+    #[command(aliases = &["v-down"])]
+    VolumeDown,
+    /// Increase playback speed
+    SpeedUp,
+    /// Decrease playback speed
+    SpeedDown,
+    /// Toggle gapless playback
+    ToggleGapless,
+    /// Restart current track
+    #[command(aliases = &["restart"])]
+    RestartTrack,
+    /// Seek forward
+    SeekForward,
+    /// Seek backward
+    SeekBackward,
+    /// Cycle loop mode (list → track → one → list)
+    CycleLoop,
+    /// Shuffle playlist
+    Shuffle,
+    /// Quit the server
+    Quit,
 }
 
 const DEFAULT_LOGFILE_FILENAME: &str = "termusic-tui.log";

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -86,7 +86,6 @@ pub enum Action {
     #[command(aliases = &["unpause", "resume"])]
     Play,
     /// Pause playback
-    #[command(aliases = &["stop"])]
     Pause,
     /// Toggle play/pause
     #[command(aliases = &["t", "play-pause"])]
@@ -101,8 +100,6 @@ pub enum Action {
     SpeedUp,
     /// Decrease playback speed
     SpeedDown,
-    /// Toggle gapless playback
-    ToggleGapless,
     /// Restart current track
     RestartTrack,
     /// Seek forward

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -86,10 +86,10 @@ pub enum Action {
     #[command(aliases = &["t", "play-pause"])]
     TogglePause,
     /// Increase volume
-    #[command(aliases = &["v-up"])]
+    #[command(aliases = &["v-up", "volumeup"])]
     VolumeUp,
     /// Decrease volume
-    #[command(aliases = &["v-down"])]
+    #[command(aliases = &["v-down", "volumedown"])]
     VolumeDown,
     /// Increase playback speed
     SpeedUp,

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -19,7 +19,6 @@ use termusiclib::config::{
     new_shared_tui_settings,
 };
 use termusiclib::player::music_player_client::MusicPlayerClient;
-use termusiclib::player::Empty;
 use termusiclib::{podcast, utils};
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
@@ -30,6 +29,7 @@ use tokio_util::sync::CancellationToken;
 use ui::UI;
 
 mod cli;
+use cli::Action;
 mod logger;
 mod ui;
 
@@ -556,87 +556,88 @@ async fn execute_action(action: cli::Action, config: &CombinedSettings) -> Resul
     Ok(())
 }
 
-async fn execute_media_control(action: cli::Action, config: &CombinedSettings) -> Result<()> {
-    let _pid = find_active_server_process()
-        .context("No active server process found. Start the TUI first.")?;
+/// Execute a media control [`Action`] by sending the corresponding gRPC
+/// command to the running server.
+async fn execute_media_control(action: Action, config: &CombinedSettings) -> Result<()> {
+    let pid = find_active_server_process()
+        .context("No active server process found. Start the Server first.")?;
 
-    let addr = {
-        let config_read = config.tui.read();
-        let com = config_read
-            .settings
-            .get_com()
-            .ok_or(anyhow::anyhow!("Expected tui-com settings to be resolved"))?;
-        match com.protocol {
-            ComProtocol::HTTP => {
-                let sock_addr = SocketAddr::from(com);
-                format!("http://{sock_addr}")
-            }
-            ComProtocol::UDS => {
-                let path = &com.socket_path;
-                format!("unix://{}", path.display())
-            }
-        }
-    };
-
-    let mut client = MusicPlayerClient::connect(addr.clone())
-        .await
-        .with_context(|| format!("Could not connect to server at {addr}"))?;
+    let (raw_client, _addr) = wait_till_connected(config, pid.as_u32()).await?;
+    let mut playback = ui::Playback::new(raw_client);
 
     match action {
-        cli::Action::Next => {
-            client.skip_next(Empty {}).await?;
+        Action::Next => {
+            playback.skip_next().await?;
             println!("Next track");
         }
-        cli::Action::Previous => {
-            client.skip_previous(Empty {}).await?;
+        Action::Previous => {
+            playback.skip_previous().await?;
             println!("Previous track");
         }
-        cli::Action::TogglePause => {
-            client.toggle_pause(Empty {}).await?;
+        Action::Play => {
+            let status = playback.get_progress().await?.status;
+            if status != 1 {
+                playback.toggle_pause().await?;
+                println!("Playing");
+            } else {
+                println!("Already playing");
+            }
+        }
+        Action::Pause => {
+            let status = playback.get_progress().await?.status;
+            if status == 1 {
+                playback.toggle_pause().await?;
+                println!("Paused");
+            } else {
+                println!("Already paused");
+            }
+        }
+        Action::TogglePause => {
+            playback.toggle_pause().await?;
             println!("Toggled play/pause");
         }
-        cli::Action::VolumeUp => {
-            client.volume_up(Empty {}).await?;
+        Action::VolumeUp => {
+            playback.volume_up().await?;
             println!("Volume up");
         }
-        cli::Action::VolumeDown => {
-            client.volume_down(Empty {}).await?;
+        Action::VolumeDown => {
+            playback.volume_down().await?;
             println!("Volume down");
         }
-        cli::Action::SpeedUp => {
-            client.speed_up(Empty {}).await?;
+        Action::SpeedUp => {
+            playback.speed_up().await?;
             println!("Speed up");
         }
-        cli::Action::SpeedDown => {
-            client.speed_down(Empty {}).await?;
+        Action::SpeedDown => {
+            playback.speed_down().await?;
             println!("Speed down");
         }
-        cli::Action::ToggleGapless => {
-            client.toggle_gapless(Empty {}).await?;
+        Action::ToggleGapless => {
+            playback.toggle_gapless().await?;
             println!("Toggled gapless");
         }
-        cli::Action::RestartTrack => {
-            client.restart_track(Empty {}).await?;
+        Action::RestartTrack => {
+            playback.restart_track().await?;
             println!("Restarted track");
         }
-        cli::Action::SeekForward => {
-            client.seek_forward(Empty {}).await?;
+        Action::SeekForward => {
+            playback.seek_forward().await?;
             println!("Seeked forward");
         }
-        cli::Action::SeekBackward => {
-            client.seek_backward(Empty {}).await?;
+        Action::SeekBackward => {
+            playback.seek_backward().await?;
             println!("Seeked backward");
         }
-        cli::Action::CycleLoop => {
-            client.cycle_loop(Empty {}).await?;
+        Action::CycleLoop => {
+            playback.cycle_loop().await?;
             println!("Cycled loop mode");
         }
-        cli::Action::Shuffle => {
-            client.shuffle_playlist(Empty {}).await?;
+        Action::Shuffle => {
+            playback.shuffle_playlist().await?;
             println!("Shuffled playlist");
         }
-        cli::Action::Quit => {
-            client.quit_server(Empty {}).await?;
+        Action::Quit => {
+            playback.quit_server().await?;
             println!("Quit server");
         }
         _ => unreachable!(),

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -18,6 +18,7 @@ use termusiclib::config::{
     ServerOverlay, SharedServerSettings, SharedTuiSettings, TuiOverlay, new_shared_server_settings,
     new_shared_tui_settings,
 };
+use termusiclib::player::RunningStatus;
 use termusiclib::player::music_player_client::MusicPlayerClient;
 use termusiclib::{podcast, utils};
 use tokio::io::AsyncReadExt;
@@ -576,7 +577,7 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
         }
         Action::Play => {
             let status = playback.get_progress().await?.status;
-            if status == 1 {
+            if RunningStatus::from_u32(status) == RunningStatus::Running {
                 println!("Already playing");
             } else {
                 playback.toggle_pause().await?;
@@ -585,7 +586,7 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
         }
         Action::Pause => {
             let status = playback.get_progress().await?.status;
-            if status == 1 {
+            if RunningStatus::from_u32(status) == RunningStatus::Running {
                 playback.toggle_pause().await?;
                 println!("Paused");
             } else {
@@ -593,28 +594,24 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
             }
         }
         Action::TogglePause => {
-            playback.toggle_pause().await?;
-            println!("Toggled play/pause");
+            let status = playback.toggle_pause().await?;
+            println!("{status}");
         }
         Action::VolumeUp => {
-            playback.volume_up().await?;
-            println!("Volume up");
+            let volume = playback.volume_up().await?;
+            println!("Volume: {volume}");
         }
         Action::VolumeDown => {
-            playback.volume_down().await?;
-            println!("Volume down");
+            let volume = playback.volume_down().await?;
+            println!("Volume: {volume}");
         }
         Action::SpeedUp => {
-            playback.speed_up().await?;
-            println!("Speed up");
+            let speed = playback.speed_up().await?;
+            println!("Speed: {speed}x");
         }
         Action::SpeedDown => {
-            playback.speed_down().await?;
-            println!("Speed down");
-        }
-        Action::ToggleGapless => {
-            playback.toggle_gapless().await?;
-            println!("Toggled gapless");
+            let speed = playback.speed_down().await?;
+            println!("Speed: {speed}x");
         }
         Action::RestartTrack => {
             playback.restart_track().await?;
@@ -629,8 +626,8 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
             println!("Seeked backward");
         }
         Action::CycleLoop => {
-            playback.cycle_loop().await?;
-            println!("Cycled loop mode");
+            let mode = playback.cycle_loop().await?;
+            println!("Loop: {}", mode.display(false));
         }
         Action::Shuffle => {
             playback.shuffle_playlist().await?;

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -19,6 +19,7 @@ use termusiclib::config::{
     new_shared_tui_settings,
 };
 use termusiclib::player::music_player_client::MusicPlayerClient;
+use termusiclib::player::Empty;
 use termusiclib::{podcast, utils};
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
@@ -549,6 +550,96 @@ async fn execute_action(action: cli::Action, config: &CombinedSettings) -> Resul
                 utils::get_app_config_path().context("getting app-config-path")?;
             podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
         }
+        action => execute_media_control(action, config).await?,
+    }
+
+    Ok(())
+}
+
+async fn execute_media_control(action: cli::Action, config: &CombinedSettings) -> Result<()> {
+    let _pid = find_active_server_process()
+        .context("No active server process found. Start the TUI first.")?;
+
+    let addr = {
+        let config_read = config.tui.read();
+        let com = config_read
+            .settings
+            .get_com()
+            .ok_or(anyhow::anyhow!("Expected tui-com settings to be resolved"))?;
+        match com.protocol {
+            ComProtocol::HTTP => {
+                let sock_addr = SocketAddr::from(com);
+                format!("http://{sock_addr}")
+            }
+            ComProtocol::UDS => {
+                let path = &com.socket_path;
+                format!("unix://{}", path.display())
+            }
+        }
+    };
+
+    let mut client = MusicPlayerClient::connect(addr.clone())
+        .await
+        .with_context(|| format!("Could not connect to server at {addr}"))?;
+
+    match action {
+        cli::Action::Next => {
+            client.skip_next(Empty {}).await?;
+            println!("Next track");
+        }
+        cli::Action::Previous => {
+            client.skip_previous(Empty {}).await?;
+            println!("Previous track");
+        }
+        cli::Action::TogglePause => {
+            client.toggle_pause(Empty {}).await?;
+            println!("Toggled play/pause");
+        }
+        cli::Action::VolumeUp => {
+            client.volume_up(Empty {}).await?;
+            println!("Volume up");
+        }
+        cli::Action::VolumeDown => {
+            client.volume_down(Empty {}).await?;
+            println!("Volume down");
+        }
+        cli::Action::SpeedUp => {
+            client.speed_up(Empty {}).await?;
+            println!("Speed up");
+        }
+        cli::Action::SpeedDown => {
+            client.speed_down(Empty {}).await?;
+            println!("Speed down");
+        }
+        cli::Action::ToggleGapless => {
+            client.toggle_gapless(Empty {}).await?;
+            println!("Toggled gapless");
+        }
+        cli::Action::RestartTrack => {
+            client.restart_track(Empty {}).await?;
+            println!("Restarted track");
+        }
+        cli::Action::SeekForward => {
+            client.seek_forward(Empty {}).await?;
+            println!("Seeked forward");
+        }
+        cli::Action::SeekBackward => {
+            client.seek_backward(Empty {}).await?;
+            println!("Seeked backward");
+        }
+        cli::Action::CycleLoop => {
+            client.cycle_loop(Empty {}).await?;
+            println!("Cycled loop mode");
+        }
+        cli::Action::Shuffle => {
+            client.shuffle_playlist(Empty {}).await?;
+            println!("Shuffled playlist");
+        }
+        cli::Action::Quit => {
+            client.quit_server(Empty {}).await?;
+            println!("Quit server");
+        }
+        _ => unreachable!(),
     }
 
     Ok(())

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -576,11 +576,11 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
         }
         Action::Play => {
             let status = playback.get_progress().await?.status;
-            if status != 1 {
+            if status == 1 {
+                println!("Already playing");
+            } else {
                 playback.toggle_pause().await?;
                 println!("Playing");
-            } else {
-                println!("Already playing");
             }
         }
         Action::Pause => {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -8,7 +8,7 @@ use tuirealm::application::PollStrategy;
 use crate::CombinedSettings;
 use crate::ui::server_req_actor::ServerRequestActor;
 use model::Model;
-use music_player_client::Playback;
+pub use music_player_client::Playback;
 use tui_cmd::PlaylistCmd;
 use tui_cmd::TuiCmd;
 


### PR DESCRIPTION
Adds subcommands for media control via CLI: `termusic next`, `termusic toggle-pause`, `termusic volume-up`, etc.

Connects to an already-running server process via gRPC, sends the command, and exits. Useful for WM keybindings and scripts.

Closes #101