### PR TITLE
fix: cycle up/down focus within color pane items instead of wrapping into the theme select table

### DIFF
--- a/tui/src/ui/components/config_editor/color.rs
+++ b/tui/src/ui/components/config_editor/color.rs
@@ -351,21 +351,27 @@ impl AppComponent<Msg, UserEvent> for CEColorSelect {
 
             Event::Keyboard(key) if key == keys.navigation_keys.up.get() => match self.state() {
                 State::Single(_) => {
-                    return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)));
+                    return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeColorItem(
+                        KFMsg::Previous,
+                    )));
                 }
                 _ => self.perform(Cmd::Move(Direction::Up)),
             },
 
             Event::Keyboard(key) if key == keys.navigation_keys.down.get() => match self.state() {
                 State::Single(_) => {
-                    return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)));
+                    return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeColorItem(
+                        KFMsg::Next,
+                    )));
                 }
                 _ => self.perform(Cmd::Move(Direction::Down)),
             },
 
             Event::Keyboard(KeyEvent { code: Key::Up, .. }) => match self.state() {
                 State::Single(_) => {
-                    return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)));
+                    return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeColorItem(
+                        KFMsg::Previous,
+                    )));
                 }
                 _ => self.perform(Cmd::Move(Direction::Up)),
             },
@@ -374,7 +380,9 @@ impl AppComponent<Msg, UserEvent> for CEColorSelect {
                 code: Key::Down, ..
             }) => match self.state() {
                 State::Single(_) => {
-                    return Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next)));
+                    return Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeColorItem(
+                        KFMsg::Next,
+                    )));
                 }
                 _ => self.perform(Cmd::Move(Direction::Down)),
             },
@@ -592,10 +600,12 @@ impl AppComponent<Msg, UserEvent> for ConfigInputHighlight {
             }
             Event::Keyboard(KeyEvent {
                 code: Key::Down, ..
-            }) => Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Next))),
-            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
-                Some(Msg::ConfigEditor(ConfigEditorMsg::Theme(KFMsg::Previous)))
-            }
+            }) => Some(Msg::ConfigEditor(ConfigEditorMsg::ThemeColorItem(
+                KFMsg::Next,
+            ))),
+            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => Some(Msg::ConfigEditor(
+                ConfigEditorMsg::ThemeColorItem(KFMsg::Previous),
+            )),
 
             Event::Keyboard(KeyEvent {
                 code: Key::Enter, ..

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -116,6 +116,7 @@ impl Model {
             // Focus handling
             ConfigEditorMsg::General(msg) => self.update_general(msg),
             ConfigEditorMsg::Theme(msg) => self.update_theme(msg),
+            ConfigEditorMsg::ThemeColorItem(msg) => self.update_theme_color_item(msg),
             ConfigEditorMsg::KeyFocusGlobal(msg) => self.update_key_focus_global(msg),
             ConfigEditorMsg::KeyFocusOther(msg) => self.update_key_focus_other(msg),
             ConfigEditorMsg::ChangeLayout(msg) => self.change_layout(msg),
@@ -210,6 +211,17 @@ impl Model {
     /// Handle focus of the "Theme" tab
     fn update_theme(&mut self, msg: KFMsg) {
         set_next_in_focus_array(self, msg, THEME_FOCUS_ORDER, |id| {
+            if let IdConfigEditor::Theme(id) = id {
+                Some(id)
+            } else {
+                None
+            }
+        });
+    }
+
+    /// Handle focus inside the "Theme" tab's color-item pane
+    fn update_theme_color_item(&mut self, msg: KFMsg) {
+        set_next_in_focus_array(self, msg, &THEME_FOCUS_ORDER[1..], |id| {
             if let IdConfigEditor::Theme(id) = id {
                 Some(id)
             } else {
@@ -475,29 +487,126 @@ where
         }
     });
 
-    // fallback in case somehow the focus gets lost or is on a weird element, reset it to the first element
-    let Some(focus_elem) = focus_elem else {
-        let id = array[0].into();
-        let _ = model.app.active(&Id::ConfigEditor(id));
-        return Some(id);
-    };
+    let focus = next_in_focus_array(msg, array, focus_elem)?;
 
-    let focus = match msg {
-        KFMsg::Next => array
-            .iter()
-            .skip_while(|v| **v != focus_elem)
-            .nth(1)
-            .unwrap_or(&array[0]),
-        KFMsg::Previous => array
-            .iter()
-            .rev()
-            .skip_while(|v| **v != focus_elem)
-            .nth(1)
-            .unwrap_or(array.last().unwrap()),
-    };
-
-    let id = (*focus).into();
+    let id = focus.into();
     let _ = model.app.active(&Id::ConfigEditor(id));
 
     Some(id)
+}
+
+fn next_in_focus_array<T>(msg: KFMsg, array: &[T], focus_elem: Option<T>) -> Option<T>
+where
+    T: Copy + PartialEq,
+{
+    // simple protection as the code below assumes at least 1 element in the array
+    if array.is_empty() {
+        return None;
+    }
+
+    // fallback in case somehow the focus gets lost or is on a weird element, reset it to the first element
+    let Some(focus_elem) = focus_elem else {
+        return Some(array[0]);
+    };
+
+    let Some(position) = array.iter().position(|v| *v == focus_elem) else {
+        return Some(array[0]);
+    };
+
+    let position = match msg {
+        KFMsg::Next => (position + 1) % array.len(),
+        KFMsg::Previous => position.checked_sub(1).unwrap_or(array.len() - 1),
+    };
+
+    Some(array[position])
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::ui::ids::IdCETheme;
+    use crate::ui::msg::{KFMsg, THEME_FOCUS_ORDER};
+
+    use super::next_in_focus_array;
+
+    fn theme_color_item_focus_order() -> &'static [IdCETheme] {
+        &THEME_FOCUS_ORDER[1..]
+    }
+
+    #[test]
+    fn theme_color_items_next_wraps_to_first_item() {
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Next,
+                theme_color_item_focus_order(),
+                Some(IdCETheme::FallbackHighlight)
+            ),
+            Some(IdCETheme::LibraryForeground)
+        );
+    }
+
+    #[test]
+    fn theme_color_items_previous_wraps_to_last_item() {
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Previous,
+                theme_color_item_focus_order(),
+                Some(IdCETheme::LibraryForeground)
+            ),
+            Some(IdCETheme::FallbackHighlight)
+        );
+    }
+
+    #[test]
+    fn theme_full_order_still_crosses_table_boundary() {
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Next,
+                THEME_FOCUS_ORDER,
+                Some(IdCETheme::ThemeSelectTable)
+            ),
+            Some(IdCETheme::LibraryForeground)
+        );
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Previous,
+                THEME_FOCUS_ORDER,
+                Some(IdCETheme::LibraryForeground)
+            ),
+            Some(IdCETheme::ThemeSelectTable)
+        );
+    }
+
+    #[test]
+    fn theme_color_items_reset_to_first_item_when_focus_is_outside_slice() {
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Previous,
+                theme_color_item_focus_order(),
+                Some(IdCETheme::ThemeSelectTable)
+            ),
+            Some(IdCETheme::LibraryForeground)
+        );
+    }
+
+    #[test]
+    fn theme_color_items_reset_to_first_item_when_focus_is_lost() {
+        assert_eq!(
+            next_in_focus_array(KFMsg::Next, theme_color_item_focus_order(), None),
+            Some(IdCETheme::LibraryForeground)
+        );
+    }
+
+    #[test]
+    fn empty_focus_order_returns_none() {
+        assert_eq!(
+            next_in_focus_array(
+                KFMsg::Next,
+                &[] as &[IdCETheme],
+                Some(IdCETheme::LibraryForeground)
+            ),
+            None
+        );
+    }
 }

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -12,7 +12,8 @@ use crate::ui::components::CEHeader;
 use crate::ui::ids::{Id, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::msg::{
     CONFIG_EDITOR_TABS_ORDER, ConfigEditorLayout, ConfigEditorMsg, GENERAL_FOCUS_ORDER,
-    KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, THEME_FOCUS_ORDER,
+    KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, THEME_COLOR_ITEM_FOCUS_ORDER_START,
+    THEME_FOCUS_ORDER,
 };
 use crate::ui::tui_cmd::TuiCmd;
 
@@ -221,13 +222,18 @@ impl Model {
 
     /// Handle focus inside the "Theme" tab's color-item pane
     fn update_theme_color_item(&mut self, msg: KFMsg) {
-        set_next_in_focus_array(self, msg, &THEME_FOCUS_ORDER[1..], |id| {
-            if let IdConfigEditor::Theme(id) = id {
-                Some(id)
-            } else {
-                None
-            }
-        });
+        set_next_in_focus_array(
+            self,
+            msg,
+            &THEME_FOCUS_ORDER[THEME_COLOR_ITEM_FOCUS_ORDER_START..],
+            |id| {
+                if let IdConfigEditor::Theme(id) = id {
+                    Some(id)
+                } else {
+                    None
+                }
+            },
+        );
     }
 
     /// Handle focus of the "Key Global" tab
@@ -495,6 +501,10 @@ where
     Some(id)
 }
 
+/// Return the next focus target within `array`.
+///
+/// Callers may pass a subslice to keep focus cycling inside one pane. If focus
+/// is absent or outside that slice, the first item in the slice is selected.
 fn next_in_focus_array<T>(msg: KFMsg, array: &[T], focus_elem: Option<T>) -> Option<T>
 where
     T: Copy + PartialEq,
@@ -526,12 +536,12 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::ui::ids::IdCETheme;
-    use crate::ui::msg::{KFMsg, THEME_FOCUS_ORDER};
+    use crate::ui::msg::{KFMsg, THEME_COLOR_ITEM_FOCUS_ORDER_START, THEME_FOCUS_ORDER};
 
     use super::next_in_focus_array;
 
     fn theme_color_item_focus_order() -> &'static [IdCETheme] {
-        &THEME_FOCUS_ORDER[1..]
+        &THEME_FOCUS_ORDER[THEME_COLOR_ITEM_FOCUS_ORDER_START..]
     }
 
     #[test]

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -384,6 +384,7 @@ pub enum ConfigEditorMsg {
     KeyFocusOther(KFMsg),
     General(KFMsg),
     Theme(KFMsg),
+    ThemeColorItem(KFMsg),
 
     ThemeSelectLoad(usize),
 }

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -444,6 +444,11 @@ pub const THEME_FOCUS_ORDER: &[IdCETheme] = &[
     IdCETheme::FallbackHighlight,
 ];
 
+/// First [`THEME_FOCUS_ORDER`] index used by the color-item pane.
+///
+/// Cycling that pane starts after `ThemeSelectTable`, so the theme table is skipped.
+pub const THEME_COLOR_ITEM_FOCUS_ORDER_START: usize = 1;
+
 /// This array defines the order the IDs listed are displayed and which gains next / previous focus.
 pub const KFGLOBAL_FOCUS_ORDER: &[IdKey] = &[
     // main layouts

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -414,6 +414,8 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
 ];
 
 /// This array defines the order the IDs listed are displayed and which gains next / previous focus.
+/// Focus handlers may use a subslice when cycling inside one pane, so some entries
+/// may be skipped; for example, the color-item pane skips `ThemeSelectTable`.
 pub const THEME_FOCUS_ORDER: &[IdCETheme] = &[
     IdCETheme::ThemeSelectTable,
     IdCETheme::LibraryForeground,


### PR DESCRIPTION
## Summary
In the config editor's "Themes and Colors" tab, Up/Down now cycles within the right-hand color-item grid instead of throwing focus back to the theme-select table when you hit the first or last item. Tab/BackTab traversal of the full focus order is unchanged, so the deliberate table-to-grid entry points still work.

## Why this matters
The reporter's most concrete complaint on #671 was exactly this: Up from the first color item or Down from the last lands on the theme table in the other pane. Collaborator hasezoey confirmed the behavior is "not intuitive and inconsistent". The cause is that `THEME_FOCUS_ORDER` is one flat array whose element 0 is `ThemeSelectTable`, and `set_next_in_focus_array` wraps Next/Previous around the whole array, so arrow-driven moves cross the pane boundary. This scopes to the confirmed complaint and does not redesign Tab semantics or grid row-aware skipping, which the thread has not converged on.

## Changes
- New `ConfigEditorMsg::ThemeColorItem(KFMsg)` variant routes arrow-driven moves to a handler that cycles over the color-item sub-slice `&THEME_FOCUS_ORDER[1..]`, never landing on `ThemeSelectTable`.
- Only the Up/Down emitters in `CEColorSelect::on` (closed-select state) and `ConfigInputHighlight::on` switch to the new variant; Tab/BackTab arms keep emitting `Theme(KFMsg)`.

## Testing
Inline `#[cfg(test)]` tests in `update.rs` cover sub-slice cycling (Next from last color item wraps to first, Previous from first wraps to last, table never entered). `cargo clippy` and `cargo build` pass.

re #671
