### PR TITLE
fix(tui): wait until the last events are send to the server before exiting

### DIFF
--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -141,6 +141,8 @@ async fn actual_main() -> Result<()> {
     let mut ui = UI::new(config, client).await?;
     ui.run()?;
 
+    ui.wait_until_done().await;
+
     info!("Bye");
 
     Ok(())

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use futures_util::StreamExt;
 use termusiclib::player::music_player_client::MusicPlayerClient;
 use tokio::sync::mpsc::{self};
+use tokio::task::JoinHandle;
 use tonic::transport::Channel;
 use tuirealm::application::PollStrategy;
 
@@ -26,6 +27,8 @@ pub mod utils;
 /// The main TUI struct which handles message passing and the main-loop.
 pub struct UI {
     model: Model,
+
+    server_req_actor: JoinHandle<()>,
 }
 
 impl UI {
@@ -39,9 +42,12 @@ impl UI {
         let mut model = Model::new(config, cmd_tx, stream_updates.boxed());
         model.init();
 
-        ServerRequestActor::start_actor(playback, cmd_rx, model.tx_to_main.clone());
+        let jh = ServerRequestActor::start_actor(playback, cmd_rx, model.tx_to_main.clone());
 
-        Ok(Self { model })
+        Ok(Self {
+            model,
+            server_req_actor: jh,
+        })
     }
 
     /// Main Loop function.
@@ -88,5 +94,18 @@ impl UI {
         }
 
         Ok(())
+    }
+
+    /// Wait until all events are handled.
+    ///
+    /// Currently this only waits until the [`ServerRequestActor`] is done sending events.
+    pub async fn wait_until_done(self) {
+        // Explicitly drop first as Model stores a ServerRequestActor channel Tx
+        // and the ServerRequestActor only closes once the channel is closed and all events are handled.
+        drop(self.model);
+
+        if let Err(err) = self.server_req_actor.await {
+            error!("Server Request Actor exited with a error: {err:#?}");
+        }
     }
 }

--- a/tui/src/ui/server_req_actor.rs
+++ b/tui/src/ui/server_req_actor.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use termusiclib::player::playlist_helpers::PlaylistRemoveTrackType;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::{sync::mpsc::UnboundedReceiver, task::JoinHandle};
 
 use crate::ui::{
     model::TxToMain,
@@ -26,16 +26,14 @@ impl ServerRequestActor {
         client_handle: Playback,
         rx_cmd: UnboundedReceiver<TuiCmd>,
         tx_main: TxToMain,
-    ) {
+    ) -> JoinHandle<()> {
         let obj = Self {
             client_handle,
             rx_cmd,
             tx_main,
         };
 
-        // clippy suggests manually dropping instead of "let _ =" on a future, which "JoinHandle" is
-        let jh = tokio::spawn(Self::run(obj));
-        drop(jh);
+        tokio::spawn(Self::run(obj))
     }
 
     /// The actor loop.


### PR DESCRIPTION
As otherwise, sometimes the (TUI)process exit may happen too quickly before the Quit event can be send to the server.

Noticed while testing with a VM for #731.