### PR TITLE
fix(playback::mpris): use correct return type for setActivationPolicy msg_send

### DIFF
--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -431,7 +431,7 @@ pub mod macos {
         unsafe {
             let cls = AnyClass::get(c"NSApplication").expect("NSApplication class not found");
             let app: *mut AnyObject = msg_send![cls, sharedApplication];
-            let _: () =
+            let _: bool =
                 msg_send![app, setActivationPolicy: NS_APPLICATION_ACTIVATION_POLICY_ACCESSORY];
         }
     }


### PR DESCRIPTION
Fixes a runtime panic on macOS where `setActivationPolicy:` was declared with return type `()` (void) but the Objective-C method returns `BOOL`. The Objective-C runtime detects the type mismatch and panics on startup.

The fix changes the return type annotation from `()` to `bool` to match the actual Objective-C method signature.