### PR TITLE
feat(playback): restart current track on SkipPrevious when past configurable threshold

### DIFF
--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -77,6 +77,61 @@ pub enum ScanDepth {
 /// What determines a long track length in seconds, 10 minutes
 const LONG_TRACK_TIME: u64 = 600; // 60 * 10
 
+/// How many seconds into a track before Command "Previous Track" restarts the current track vs going to the previous track.
+/// Range: 0-10, where 0 disables the feature (always goes to previous track).
+/// Default: 5 seconds.
+///
+/// If the current track position is past this threshold, pressing "Previous Track" will restart the current track.
+/// If before the threshold, it goes to the previous track.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
+pub struct PreviousTrackThreshold(u8);
+
+impl PreviousTrackThreshold {
+    /// Create a new `PreviousTrackThreshold`, clamping the value to 0-10.
+    #[must_use]
+    pub fn new(v: u8) -> Self {
+        Self(v.clamp(0, 10))
+    }
+
+    #[must_use]
+    pub fn get(&self) -> u64 {
+        u64::from(self.0)
+    }
+
+    /// Returns `true` if the threshold feature is enabled (value > 0).
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.0 > 0
+    }
+}
+
+impl Default for PreviousTrackThreshold {
+    fn default() -> Self {
+        Self(0)
+    }
+}
+
+impl TryFrom<u8> for PreviousTrackThreshold {
+    type Error = String;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        if v > 10 {
+            Err(format!(
+                "previous_track_threshold must be between 0 and 10, got {v}"
+            ))
+        } else {
+            Ok(Self(v))
+        }
+    }
+}
+
+impl From<PreviousTrackThreshold> for u8 {
+    fn from(v: PreviousTrackThreshold) -> Self {
+        v.0
+    }
+}
+
 /// Seek amount maybe depending on track length
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
@@ -283,6 +338,11 @@ pub struct PlayerSettings {
     pub gapless: bool,
     /// How much to seek on a seek event
     pub seek_step: SeekStep,
+    /// Threshold for Previous Track behavior, in seconds (0-10).
+    ///
+    /// If the current track position is past this threshold, pressing "Previous Track" restarts the current track.
+    /// If before the threshold, it goes to the previous track. Set to 0 to disable (always goes to previous track).
+    pub previous_track_threshold: PreviousTrackThreshold,
 
     /// Controls if support via Media-Controls (like mpris on linux) is enabled
     pub use_mediacontrols: bool,
@@ -321,6 +381,7 @@ impl Default for PlayerSettings {
             speed: 10,
             gapless: true,
             seek_step: SeekStep::default(),
+            previous_track_threshold: PreviousTrackThreshold::default(),
 
             use_mediacontrols: true,
             set_discord_status: true,
@@ -519,8 +580,8 @@ mod v1_interop {
 
     use super::{
         Backend, ComSettings, LoopMode, NonZeroU8, NonZeroU32, PlayerSettings, PodcastSettings,
-        PositionYesNo, PositionYesNoLower, RememberLastPosition, ScanDepth, SeekStep,
-        ServerSettings, backends::BackendSettings,
+        PositionYesNo, PositionYesNoLower, PreviousTrackThreshold, RememberLastPosition, ScanDepth,
+        SeekStep, ServerSettings, backends::BackendSettings,
     };
     use crate::config::{
         v1,
@@ -618,6 +679,7 @@ mod v1_interop {
                 speed: value.player_speed,
                 gapless: value.player_gapless,
                 seek_step: value.player_seek_step.into(),
+                previous_track_threshold: PreviousTrackThreshold::default(),
 
                 use_mediacontrols: value.player_use_mpris,
                 set_discord_status: value.player_use_discord,
@@ -718,6 +780,7 @@ mod v1_interop {
                         short_tracks: NonZeroU32::new(5).unwrap(),
                         long_tracks: NonZeroU32::new(30).unwrap(),
                     },
+                    previous_track_threshold: PreviousTrackThreshold::default(),
                     use_mediacontrols: true,
                     set_discord_status: true,
                     random_track_quantity: NonZeroU32::new(20).unwrap(),

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -587,8 +587,21 @@ impl GeneralPlayer {
         }
     }
 
-    /// Switch & Play the previous track in the playlist
+    /// Switch & Play the previous track in the playlist.
+    ///
+    /// If the current track position is past the configured `previous_track_threshold`,
+    /// the current track is restarted instead of switching to the previous track.
+    /// Set `previous_track_threshold` to 0 in the config to disable this behavior,
+    /// which will then always go to the previous track.
     pub fn previous(&mut self) {
+        let threshold = self.config.read().settings.player.previous_track_threshold;
+        if threshold.is_enabled() && self.position().is_some_and(|pos| pos.as_secs() > threshold.get())
+        {
+            info!("restarting current track (position > {}s threshold)", threshold.get());
+            self.restart_track();
+            return;
+        }
+        self.player_save_last_position();
         let mut playlist = self.playlist.write();
         let has_previous = playlist.previous().is_some();
         drop(playlist);

--- a/playback/src/mpris.rs
+++ b/playback/src/mpris.rs
@@ -431,7 +431,7 @@ pub mod macos {
         unsafe {
             let cls = AnyClass::get(c"NSApplication").expect("NSApplication class not found");
             let app: *mut AnyObject = msg_send![cls, sharedApplication];
-            let _: () =
+            let _: bool =
                 msg_send![app, setActivationPolicy: NS_APPLICATION_ACTIVATION_POLICY_ACCESSORY];
         }
     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -380,7 +380,6 @@ fn player_loop(
             PlayerCmd::SkipPrevious => {
                 player.reset_errors();
                 info!("skip to previous track");
-                player.player_save_last_position();
                 player.previous();
             }
             PlayerCmd::ReloadConfig => {

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -1019,6 +1019,85 @@ impl AppComponent<Msg, UserEvent> for PlayerBackend {
     }
 }
 
+/// Validates the full `previous_track_threshold` input (must be 0–10).
+fn threshold_valid(s: &str) -> bool {
+    if let Ok(v) = s.parse::<u8>() {
+        v <= 10
+    } else {
+        false
+    }
+}
+
+/// Validates each character typed into the `previous_track_threshold` input.
+///
+/// The allowed sequences are:
+/// - empty → any digit (0–9) to start typing
+/// - `"0"` → nothing further (prevents `"00"`, `"01"`, etc.)
+/// - `"1"` → only `'0'` allowed (to reach `"10"`)
+/// - anything else → blocked
+fn threshold_char_valid(s: &str, c: char) -> bool {
+    if s.is_empty() {
+        c.is_ascii_digit()
+    } else if s == "0" {
+        false
+    } else if s.len() == 1 && s == "1" {
+        c == '0'
+    } else {
+        false
+    }
+}
+
+#[derive(Component)]
+pub struct ConfigPreviousTrackThreshold {
+    component: Input,
+    config: SharedTuiSettings,
+}
+
+impl ConfigPreviousTrackThreshold {
+    pub fn new(config: CombinedSettings) -> Self {
+        let component = {
+            let config_tui = config.tui.read();
+            common_input_comp(&config_tui, " Previous Track Threshold (0-10s, 0=disabled): ")
+                .input_type(InputType::Custom(threshold_valid, threshold_char_valid))
+                .input_len(2)
+                .placeholder(LineStatic::styled(
+                    "0-10s, 0=disabled",
+                    Style::default().fg(config_tui
+                        .settings
+                        .theme
+                        .get_color_from_theme(ColorTermusic::LightBlack)),
+                ))
+                .value(
+                    config
+                        .server
+                        .read()
+                        .settings
+                        .player
+                        .previous_track_threshold
+                        .get()
+                        .to_string(),
+                )
+        };
+
+        Self {
+            component,
+            config: config.tui,
+        }
+    }
+}
+
+impl AppComponent<Msg, UserEvent> for ConfigPreviousTrackThreshold {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
+        handle_input_ev(
+            &mut self.component,
+            ev,
+            &self.config.read().settings.keys,
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Next)),
+            Msg::ConfigEditor(ConfigEditorMsg::General(KFMsg::Previous)),
+        )
+    }
+}
+
 #[derive(Component)]
 pub struct ExtraYtdlpArgs {
     component: Input,
@@ -1126,6 +1205,12 @@ impl Model {
         )?;
 
         self.app.remount(
+            Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PreviousTrackThreshold)),
+            Box::new(ConfigPreviousTrackThreshold::new(self.get_combined_settings())),
+            Vec::new(),
+        )?;
+
+        self.app.remount(
             Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)),
             Box::new(KillDaemon::new(self.config_tui.clone())),
             Vec::new(),
@@ -1222,6 +1307,10 @@ impl Model {
 
         self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
             IdCEGeneral::SeekStep,
+        )))?;
+
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(
+            IdCEGeneral::PreviousTrackThreshold,
         )))?;
 
         self.app.umount(&Id::ConfigEditor(IdConfigEditor::General(

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -29,7 +29,8 @@ use anyhow::{Result, bail};
 use include_dir::DirEntry;
 use termusiclib::THEME_DIR;
 use termusiclib::config::v2::server::{
-    Backend, ComProtocol, PositionYesNo, PositionYesNoLower, RememberLastPosition,
+    Backend, ComProtocol, PositionYesNo, PositionYesNoLower, PreviousTrackThreshold,
+    RememberLastPosition,
 };
 use termusiclib::config::v2::tui::Alignment as XywhAlign;
 use termusiclib::config::v2::tui::theme::ThemeColors;
@@ -196,22 +197,23 @@ impl Model {
                         IdCEGeneral::AlbumPhotoAlign => 8,
                         IdCEGeneral::SaveLastPosition => 9,
                         IdCEGeneral::SeekStep => 10,
-                        IdCEGeneral::KillDamon => 11,
-                        IdCEGeneral::PlayerUseMpris => 12,
-                        IdCEGeneral::PlayerUseDiscord => 13,
-                        IdCEGeneral::PlayerPort => 14,
-                        IdCEGeneral::PlayerAddress => 15,
-                        IdCEGeneral::PlayerProtocol => 16,
-                        IdCEGeneral::PlayerUDSPath => 17,
-                        IdCEGeneral::PlayerBackend => 18,
-                        IdCEGeneral::ExtraYtdlpArgs => 19,
+                        IdCEGeneral::PreviousTrackThreshold => 11,
+                        IdCEGeneral::KillDamon => 12,
+                        IdCEGeneral::PlayerUseMpris => 13,
+                        IdCEGeneral::PlayerUseDiscord => 14,
+                        IdCEGeneral::PlayerPort => 15,
+                        IdCEGeneral::PlayerAddress => 16,
+                        IdCEGeneral::PlayerProtocol => 17,
+                        IdCEGeneral::PlayerUDSPath => 18,
+                        IdCEGeneral::PlayerBackend => 19,
+                        IdCEGeneral::ExtraYtdlpArgs => 20,
                     })
                 } else {
                     None
                 }
             });
 
-        let cells = UniformDynamicGrid::new(20, 3, 56 + 2)
+        let cells = UniformDynamicGrid::new(21, 3, 56 + 2)
             .draw_row_low_space()
             .distribute_row_space()
             .focus_node(focus_elem)
@@ -235,18 +237,19 @@ impl Model {
 
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SaveLastPosition)) => cells[9],
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SeekStep)) => cells[10],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PreviousTrackThreshold)) => cells[11],
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)) => cells[11],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)) => cells[12],
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)) => cells[12],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)) => cells[13],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[14],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerAddress)) => cells[15],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerProtocol)) => cells[16],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUDSPath)) => cells[17],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerBackend)) => cells[18],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)) => cells[13],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)) => cells[14],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[15],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerAddress)) => cells[16],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerProtocol)) => cells[17],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUDSPath)) => cells[18],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerBackend)) => cells[19],
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[19],
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[20],
         }
     }
 
@@ -788,6 +791,15 @@ impl Model {
             //     _ => bail!(" Unknown player step length provided."),
             // };
             // config_server.settings.player.seek_step = seek_step;
+        }
+
+        if let Ok(State::Single(StateValue::String(threshold_str))) = self.app.state(
+            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PreviousTrackThreshold)),
+        ) && let Ok(threshold) = threshold_str.parse::<u8>()
+        {
+            config_server.settings.player.previous_track_threshold =
+                PreviousTrackThreshold::try_from(threshold)
+                    .map_err(|_| anyhow::anyhow!("Previous track threshold must be between 0 and 10"))?;
         }
 
         if let Ok(State::Single(StateValue::Usize(kill_daemon))) = self.app.state(

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -125,6 +125,7 @@ pub enum IdCEGeneral {
     ExtraYtdlpArgs,
     SaveLastPosition,
     SeekStep,
+    PreviousTrackThreshold,
 
     PlayerPort,
     PlayerAddress,

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -402,6 +402,7 @@ pub const GENERAL_FOCUS_ORDER: &[IdCEGeneral] = &[
     IdCEGeneral::AlbumPhotoAlign,
     IdCEGeneral::SaveLastPosition,
     IdCEGeneral::SeekStep,
+    IdCEGeneral::PreviousTrackThreshold,
     IdCEGeneral::KillDamon,
     IdCEGeneral::PlayerUseMpris,
     IdCEGeneral::PlayerUseDiscord,


### PR DESCRIPTION
Adds a new config option previous_track_threshold (0-10s, default 5,
0=disabled). When the current track position exceeds the threshold,
pressing Previous restarts the current track instead of going to the
previous track.

The logic lives in player.previous() so it works seamlessly with all
inputs — macOS media keys, TUI keybindings, and any other caller.

Adds PreviousTrackThreshold newtype with serde support, v1 config
conversion, and TUI config editor option in the General tab.

re #699
