### PR TITLE
Reduce noise & duplication for drawing in config editor "General"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,15 @@ jobs:
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev
         # run: sudo apt-get update && sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavahi-compat-libdnssd-dev libgstreamer-plugins-bad1.0-dev gstreamer-player-1
       - uses: Swatinem/rust-cache@v2
+        id: cache
 
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      # run formatting after clippy, so that the CI does not exit early when formatting has issues (but still would compile)
       - name: Run cargo fmt
         run: cargo fmt --all --check
+        # Always run both "clippy" and "fmt", even if clippy fails, but not if any of the previous steps fail.
+        if: ${{ !cancelled() && steps.cache.conclusion == 'success' }}
 
   test_linux:
     name: Test Linux

--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -83,7 +83,7 @@ const LONG_TRACK_TIME: u64 = 600; // 60 * 10
 ///
 /// If the current track position is past this threshold, pressing "Previous Track" will restart the current track.
 /// If before the threshold, it goes to the previous track.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(try_from = "u8", into = "u8")]
 pub struct PreviousTrackThreshold(u8);
 
@@ -103,12 +103,6 @@ impl PreviousTrackThreshold {
     #[must_use]
     pub fn is_enabled(&self) -> bool {
         self.0 > 0
-    }
-}
-
-impl Default for PreviousTrackThreshold {
-    fn default() -> Self {
-        Self(0)
     }
 }
 

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -595,9 +595,15 @@ impl GeneralPlayer {
     /// which will then always go to the previous track.
     pub fn previous(&mut self) {
         let threshold = self.config.read().settings.player.previous_track_threshold;
-        if threshold.is_enabled() && self.position().is_some_and(|pos| pos.as_secs() > threshold.get())
+        if threshold.is_enabled()
+            && self
+                .position()
+                .is_some_and(|pos| pos.as_secs() > threshold.get())
         {
-            info!("restarting current track (position > {}s threshold)", threshold.get());
+            info!(
+                "restarting current track (position > {}s threshold)",
+                threshold.get()
+            );
             self.restart_track();
             return;
         }

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -1057,26 +1057,29 @@ impl ConfigPreviousTrackThreshold {
     pub fn new(config: CombinedSettings) -> Self {
         let component = {
             let config_tui = config.tui.read();
-            common_input_comp(&config_tui, " Previous Track Threshold (0-10s, 0=disabled): ")
-                .input_type(InputType::Custom(threshold_valid, threshold_char_valid))
-                .input_len(2)
-                .placeholder(LineStatic::styled(
-                    "0-10s, 0=disabled",
-                    Style::default().fg(config_tui
-                        .settings
-                        .theme
-                        .get_color_from_theme(ColorTermusic::LightBlack)),
-                ))
-                .value(
-                    config
-                        .server
-                        .read()
-                        .settings
-                        .player
-                        .previous_track_threshold
-                        .get()
-                        .to_string(),
-                )
+            common_input_comp(
+                &config_tui,
+                " Previous Track Threshold (0-10s, 0=disabled): ",
+            )
+            .input_type(InputType::Custom(threshold_valid, threshold_char_valid))
+            .input_len(2)
+            .placeholder(LineStatic::styled(
+                "0-10s, 0=disabled",
+                Style::default().fg(config_tui
+                    .settings
+                    .theme
+                    .get_color_from_theme(ColorTermusic::LightBlack)),
+            ))
+            .value(
+                config
+                    .server
+                    .read()
+                    .settings
+                    .player
+                    .previous_track_threshold
+                    .get()
+                    .to_string(),
+            )
         };
 
         Self {
@@ -1206,7 +1209,9 @@ impl Model {
 
         self.app.remount(
             Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PreviousTrackThreshold)),
-            Box::new(ConfigPreviousTrackThreshold::new(self.get_combined_settings())),
+            Box::new(ConfigPreviousTrackThreshold::new(
+                self.get_combined_settings(),
+            )),
             Vec::new(),
         )?;
 

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -51,7 +51,9 @@ use crate::ui::components::raw::dynamic_height_grid::DynamicHeightGrid;
 use crate::ui::components::raw::uniform_dynamic_grid::UniformDynamicGrid;
 use crate::ui::ids::{Id, IdCEGeneral, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
 use crate::ui::model::{Model, UserEvent};
-use crate::ui::msg::{ConfigEditorLayout, KFGLOBAL_FOCUS_ORDER, KFOTHER_FOCUS_ORDER, Msg};
+use crate::ui::msg::{
+    ConfigEditorLayout, GENERAL_FOCUS_ORDER, KFGLOBAL_FOCUS_ORDER, KFOTHER_FOCUS_ORDER, Msg,
+};
 use crate::ui::utils::draw_area_in_absolute;
 
 // NOTE: the macros either have to be in a different file OR be defined *before* they are used, otherwise they are not in scope
@@ -183,73 +185,34 @@ impl Model {
                     None
                 }
             })
-            .and_then(|v| {
-                if let IdConfigEditor::General(v) = v {
-                    Some(match v {
-                        IdCEGeneral::MusicDir => 0,
-                        IdCEGeneral::ExitConfirmation => 1,
-                        IdCEGeneral::PlaylistDisplaySymbol => 2,
-                        IdCEGeneral::PlaylistRandomTrack => 3,
-                        IdCEGeneral::PlaylistRandomAlbum => 4,
-                        IdCEGeneral::PodcastDir => 5,
-                        IdCEGeneral::PodcastSimulDownload => 6,
-                        IdCEGeneral::PodcastMaxRetries => 7,
-                        IdCEGeneral::AlbumPhotoAlign => 8,
-                        IdCEGeneral::SaveLastPosition => 9,
-                        IdCEGeneral::SeekStep => 10,
-                        IdCEGeneral::PreviousTrackThreshold => 11,
-                        IdCEGeneral::KillDamon => 12,
-                        IdCEGeneral::PlayerUseMpris => 13,
-                        IdCEGeneral::PlayerUseDiscord => 14,
-                        IdCEGeneral::PlayerPort => 15,
-                        IdCEGeneral::PlayerAddress => 16,
-                        IdCEGeneral::PlayerProtocol => 17,
-                        IdCEGeneral::PlayerUDSPath => 18,
-                        IdCEGeneral::PlayerBackend => 19,
-                        IdCEGeneral::ExtraYtdlpArgs => 20,
-                    })
+            .and_then(|id| {
+                if let IdConfigEditor::General(id) = id {
+                    Some(
+                        GENERAL_FOCUS_ORDER
+                            .iter()
+                            .position(|v| *v == id)
+                            .expect("Expected all Ids to be present in the list"),
+                    )
                 } else {
                     None
                 }
             });
 
-        let cells = UniformDynamicGrid::new(21, 3, 56 + 2)
+        let cells = UniformDynamicGrid::new(GENERAL_FOCUS_ORDER.len(), 3, 56 + 2)
             .draw_row_low_space()
             .distribute_row_space()
             .focus_node(focus_elem)
             .split(chunk_main);
 
-        app_view! {
-            app, f,
+        debug_assert_eq!(cells.len(), GENERAL_FOCUS_ORDER.len());
 
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::MusicDir)) => cells[0],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExitConfirmation)) => cells[1],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)) => cells[2],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomTrack)) => cells[3],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistRandomAlbum)) => cells[4],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastDir)) => cells[5],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastSimulDownload)) => cells[6],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PodcastMaxRetries)) => cells[7],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::AlbumPhotoAlign)) => cells[8],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SaveLastPosition)) => cells[9],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::SeekStep)) => cells[10],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PreviousTrackThreshold)) => cells[11],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::KillDamon)) => cells[12],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseMpris)) => cells[13],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUseDiscord)) => cells[14],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerPort)) => cells[15],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerAddress)) => cells[16],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerProtocol)) => cells[17],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerUDSPath)) => cells[18],
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlayerBackend)) => cells[19],
-
-            &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::ExtraYtdlpArgs)) => cells[20],
+        for (idx, id) in GENERAL_FOCUS_ORDER.iter().enumerate() {
+            // indexing into "cells" is guranteed to be matching "GENERAL_FOCUS_ORDER"
+            app.view(
+                &Id::ConfigEditor(IdConfigEditor::General(*id)),
+                f,
+                cells[idx],
+            );
         }
     }
 
@@ -798,8 +761,9 @@ impl Model {
         ) && let Ok(threshold) = threshold_str.parse::<u8>()
         {
             config_server.settings.player.previous_track_threshold =
-                PreviousTrackThreshold::try_from(threshold)
-                    .map_err(|_| anyhow::anyhow!("Previous track threshold must be between 0 and 10"))?;
+                PreviousTrackThreshold::try_from(threshold).map_err(|_| {
+                    anyhow::anyhow!("Previous track threshold must be between 0 and 10")
+                })?;
         }
 
         if let Ok(State::Single(StateValue::Usize(kill_daemon))) = self.app.state(


### PR DESCRIPTION
This PR changes the drawing order for config editor tab "General" to be based on the focus array, as for this case anything that is not in there should also not be drawn. Also reduces changing noise when adding / removing extra fields, as can be seen in #739.
Additionally, applies some style fixes that were missed in #739. To prevent this in the future, this also contains a workflow change to always run both "clippy" and "fmt" steps, even if one fails to report the status of both.