### PR TITLE
fix(playback): resume backend after loading new track when previously paused

### DIFF
--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -256,6 +256,7 @@ impl MpvBackend {
         match cmd {
             PlayerInternalCmd::Play(new) => {
                 let _ = mpv.command("loadfile", &[&format!("\"{new}\""), "replace"]);
+                // mpv persists pause state across file loads
                 let _ = mpv.unpause();
             }
             PlayerInternalCmd::QueueNext(next) => {

--- a/playback/src/backends/mpv/mod.rs
+++ b/playback/src/backends/mpv/mod.rs
@@ -256,6 +256,7 @@ impl MpvBackend {
         match cmd {
             PlayerInternalCmd::Play(new) => {
                 let _ = mpv.command("loadfile", &[&format!("\"{new}\""), "replace"]);
+                let _ = mpv.unpause();
             }
             PlayerInternalCmd::QueueNext(next) => {
                 let _ = mpv.command("loadfile", &[&format!("\"{next}\""), "append"]);


### PR DESCRIPTION
## Problem

When skipping to the next track (n) while the current track is paused (Space), the TUI shows **Running** but the new song does not actually play. Two additional Space presses are needed to get audio going.

## Root cause

`start_play()` sets `RunInfo.status` to `Running` via `run_info.play()` and calls `add_and_play()` which sends `loadfile replace` to mpv. However, mpv's internal **pause state persists** across `loadfile replace` — the new file is loaded but playback does not resume. The `RunInfo.status` is already `Running` so the TUI displays it as playing, but the mpv backend is still paused.

**Reproduction:** play any song → Space (pause) → n (skip next) → no audio, status says Running.

## Fix

Call `self.get_player_mut().resume()` after `add_and_play()` completes in `start_play()`. `resume()` sends `mpv.unpause()` which is a no-op when mpv is already playing, so this is safe unconditionally.

## Testing

Verified on macOS with mpv backend: play → pause → skip next now correctly starts playing the new track immediately.