### PR TITLE
feat: playlist sort — base criteria (alphabetical, date-added, duration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .cargo
 # VSCode relation configuration
 .vscode
+.cortexkit/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,7 +5384,6 @@ dependencies = [
  "async-ringbuf",
  "async-trait",
  "base64",
- "chrono",
  "criterion",
  "discord-rich-presence",
  "glib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5379,10 +5379,12 @@ dependencies = [
 name = "termusic-playback"
 version = "0.13.2"
 dependencies = [
+ "alphanumeric-sort",
  "anyhow",
  "async-ringbuf",
  "async-trait",
  "base64",
+ "chrono",
  "criterion",
  "discord-rich-presence",
  "glib",

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -287,17 +287,20 @@ message TrackId {
   }
 }
 
+// A request to sort the Playlist.
 message SortPlaylistRequest {
   SortCriterion criterion = 1;
   SortDirection direction = 2;
 }
 
+// All the sort methods available.
 enum SortCriterion {
   ALPHANUMERIC = 0;
   FIRST_ADDED = 1;
   DURATION = 2;
 }
 
+// All the orderings a sort can take.
 enum SortDirection {
   ASC = 0;
   DESC = 1;

--- a/lib/proto/player.proto
+++ b/lib/proto/player.proto
@@ -34,6 +34,8 @@ service MusicPlayer {
   rpc GetPlaylist(Empty) returns (PlaylistTracks);
   // Shuffle the playlist, returns the new playlist tracks.
   rpc ShufflePlaylist(Empty) returns (Empty);
+  // Sort the playlist by criterion and direction, emits PlaylistShuffled event.
+  rpc SortPlaylist(SortPlaylistRequest) returns (Empty);
   // Check for and remove deleted items from the playlist.
   // Unlike shuffle, this will send Removal events
   rpc RemoveDeletedTracks(Empty) returns (Empty);
@@ -283,4 +285,20 @@ message TrackId {
     // A podcast episode
     string podcastUrl = 3;
   }
+}
+
+message SortPlaylistRequest {
+  SortCriterion criterion = 1;
+  SortDirection direction = 2;
+}
+
+enum SortCriterion {
+  ALPHANUMERIC = 0;
+  FIRST_ADDED = 1;
+  DURATION = 2;
+}
+
+enum SortDirection {
+  ASC = 0;
+  DESC = 1;
 }

--- a/lib/src/config/v2/tui/keys/mod.rs
+++ b/lib/src/config/v2/tui/keys/mod.rs
@@ -783,6 +783,9 @@ pub struct KeysPlaylist {
     /// previously known as `cmus_lqueue`
     // NOTE: currently this can be somewhat broken sometimes, cause unknown
     pub add_random_album: KeyBinding,
+
+    /// Open the sort popup menu to select a sort criterion and direction
+    pub sort: KeyBinding,
 }
 
 impl Default for KeysPlaylist {
@@ -814,6 +817,12 @@ impl Default for KeysPlaylist {
                 tuievents::KeyModifiers::SHIFT,
             )
             .into(),
+
+            sort: tuievents::KeyEvent::new(
+                tuievents::Key::Char(','),
+                tuievents::KeyModifiers::empty(),
+            )
+            .into(),
         }
     }
 }
@@ -832,6 +841,8 @@ impl CheckConflict for KeysPlaylist {
 
             (&self.add_random_songs, "add_random_songs"),
             (&self.add_random_album, "add_random_album"),
+
+            (&self.sort, "sort"),
         }
     }
 
@@ -1963,6 +1974,7 @@ mod v1_interop {
                     swap_down: value.playlist_swap_down.into(),
                     add_random_songs: value.playlist_add_random_tracks.into(),
                     add_random_album: value.playlist_add_random_album.into(),
+                    sort: KeysPlaylist::default().sort,
                 },
                 database_keys: KeysDatabase {
                     // this is weird, but the previous implementation used "global_right" as the loading key to not conflict
@@ -2153,6 +2165,7 @@ mod v1_interop {
                     tuievents::KeyModifiers::SHIFT,
                 )
                 .into(),
+                sort: KeysPlaylist::default().sort,
             };
             assert_eq!(converted.playlist_keys, expected_playlist_keys);
 

--- a/lib/src/new_database/track_ops.rs
+++ b/lib/src/new_database/track_ops.rs
@@ -60,6 +60,8 @@ pub struct TrackRead {
     // Direct data on `tracks`
     pub duration: Option<Duration>,
     pub last_position: Option<Duration>,
+    /// Date the track was first added to the library (used for the "first added" sort).
+    pub added_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Either a reference to a insertable to look-up or a direct integer to use as reference into `albums`.
     pub album: Option<AlbumRead>,
 
@@ -426,6 +428,7 @@ pub fn get_track_from_path(conn: &Connection, path: &Path) -> Result<TrackRead> 
     let mut stmt = conn.prepare(indoc! {"
         SELECT
             tracks.id AS track_id, tracks.file_dir, tracks.file_stem, tracks.file_ext, tracks.duration, tracks.last_position,
+            tracks.added_at,
             tracks_metadata.title AS track_title, tracks_metadata.artist_display, tracks_metadata.genre,
             albums.id AS album_id, albums.title AS album_title
         FROM tracks
@@ -497,6 +500,13 @@ fn common_row_to_trackread(conn: &Connection, row: &Row<'_>) -> TrackRead {
         }
     };
 
+    let added_at: Option<String> = row.get("added_at").unwrap_or(None);
+    let added_at = added_at.and_then(|s| {
+        chrono::DateTime::parse_from_rfc3339(&s)
+            .ok()
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+    });
+
     TrackRead {
         id,
         file_dir,
@@ -504,6 +514,7 @@ fn common_row_to_trackread(conn: &Connection, row: &Row<'_>) -> TrackRead {
         file_ext,
         duration,
         last_position,
+        added_at,
         album,
         title,
         genre,
@@ -735,6 +746,7 @@ mod tests {
                 file_ext: OsString::from("ext"),
                 duration: Some(Duration::from_secs(10)),
                 last_position: None,
+                added_at: None,
                 album: Some(AlbumRead {
                     id: 1,
                     title: "AlbumA".to_string()
@@ -1254,6 +1266,7 @@ mod tests {
             file_ext: OsString::from("ext"),
             duration: None,
             last_position: None,
+            added_at: None,
             album: None,
             title: None,
             genre: None,

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -22,7 +22,6 @@ doctest = false
 [dependencies]
 termusic-lib.workspace = true
 alphanumeric-sort.workspace = true
-chrono.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 async-ringbuf.workspace = true

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -21,6 +21,8 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 termusic-lib.workspace = true
+alphanumeric-sort.workspace = true
+chrono.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 async-ringbuf.workspace = true

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -12,7 +12,8 @@ use termusiclib::player::playlist_helpers::{
     PlaylistAddTrack, PlaylistPlaySpecific, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
 };
 use termusiclib::player::{
-    PlayerProgress, PlayerTimeUnit, RunningStatus, TrackChangedInfo, UpdateEvents,
+    PlayerProgress, PlayerTimeUnit, RunningStatus, SortCriterion, SortDirection, TrackChangedInfo,
+    UpdateEvents,
 };
 use termusiclib::podcast::db::Database as DBPod;
 use termusiclib::track::{MediaTypes, Track};
@@ -147,6 +148,7 @@ pub enum PlayerCmd {
     PlaylistClear,
     PlaylistSwapTrack(PlaylistSwapTrack),
     PlaylistShuffle,
+    PlaylistSort(SortCriterion, SortDirection),
     PlaylistRemoveDeletedTracks,
 }
 
@@ -500,8 +502,8 @@ impl GeneralPlayer {
                 self.add_and_play(&track).await;
             };
             Handle::current().block_on(wait);
-            self.run_info.write().set_current_track(track);
 
+            self.run_info.write().set_current_track(track);
             self.set_track_mpris_discord();
             self.player_restore_last_position();
 

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -3,6 +3,7 @@ use parking_lot::RwLock;
 use pathdiff::diff_paths;
 use rand::RngExt;
 use rand::seq::SliceRandom;
+use std::cmp::Ordering;
 use std::error::Error;
 use std::fmt::{Display, Write as _};
 use std::fs::File;
@@ -1178,34 +1179,38 @@ fn score_track(track: Track, criterion: SortCriterion, db: &Database) -> ScoredT
     ScoredTrack { track, key }
 }
 
+/// Apply the [`SortDirection`] to the given [`Ordering`].
+///
+/// Effectively this means it returns:
+/// - `initial` as-is if [`SortDirection::Asc`]
+/// - `initial` reversed if [`SortDirection::Desc`]
+fn apply_direction(initial: Ordering, dir: SortDirection) -> Ordering {
+    if dir == SortDirection::Desc {
+        initial.reverse()
+    } else {
+        initial
+    }
+}
+
 /// Sort a scored track list in-place according to `criterion` + `direction`.
 fn sort_scored(scored: &mut [ScoredTrack], criterion: SortCriterion, direction: SortDirection) {
     if criterion == SortCriterion::Alphanumeric {
-        match direction {
-            SortDirection::Asc => {
-                scored.sort_by(|a, b| {
-                    alphanumeric_sort::compare_str(
-                        a.track.title().unwrap_or_default(),
-                        b.track.title().unwrap_or_default(),
-                    )
-                });
-            }
-            SortDirection::Desc => {
-                scored.sort_by(|a, b| {
-                    alphanumeric_sort::compare_str(
-                        b.track.title().unwrap_or_default(),
-                        a.track.title().unwrap_or_default(),
-                    )
-                });
-            }
-        }
+        scored.sort_by(|a, b| {
+            apply_direction(
+                alphanumeric_sort::compare_str(
+                    a.track.title().unwrap_or_default(),
+                    b.track.title().unwrap_or_default(),
+                ),
+                direction,
+            )
+        });
     } else {
         scored.sort_by(|a, b| {
-            let ord = match direction {
-                SortDirection::Asc => a.key.partial_cmp(&b.key),
-                SortDirection::Desc => b.key.partial_cmp(&a.key),
-            };
-            ord.unwrap_or(std::cmp::Ordering::Equal).then_with(|| {
+            apply_direction(
+                a.key.partial_cmp(&b.key).unwrap_or(Ordering::Equal),
+                direction,
+            )
+            .then_with(|| {
                 alphanumeric_sort::compare_str(
                     a.track.title().unwrap_or_default(),
                     b.track.title().unwrap_or_default(),

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1018,6 +1018,7 @@ impl Playlist {
         sort_scored(&mut scored, criterion, direction);
 
         self.tracks = scored.into_iter().map(|s| s.track).collect();
+        self.is_modified = true;
 
         // Restore current track index
         if let Some(current_track_file) = current_track_file

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1006,12 +1006,14 @@ impl Playlist {
     ) {
         let current_track_file = self.get_current_track_internal();
 
-        // We collect into a separate Vec rather than using `sort_by_cached_key`
-        // because `score_track` borrows `db` and each track immutably, which
-        // conflicts with the mutable borrow `sort_by_cached_key` would need.
-        let mut scored: Vec<ScoredTrack> = self
-            .tracks
-            .iter()
+        // take the original vec as this allows us to use the existing "Track"s already without cloning
+        let orig_track = std::mem::take(&mut self.tracks);
+
+        // Another vec is necessary as "sort_by_*_key" require that the returned key
+        // is not tied to a lifetime, which it in this case it would require
+        // to match against the track's title.
+        let mut scored: Vec<ScoredTrack> = orig_track
+            .into_iter()
             .map(|t| score_track(t, criterion, db))
             .collect();
 
@@ -1165,7 +1167,7 @@ struct ScoredTrack {
 
 /// Compute the sort key for a single track against the given criterion.
 #[allow(clippy::cast_precision_loss)]
-fn score_track(track: &Track, criterion: SortCriterion, db: &Database) -> ScoredTrack {
+fn score_track(track: Track, criterion: SortCriterion, db: &Database) -> ScoredTrack {
     let title = track.title().unwrap_or_default().to_string();
     let key = match criterion {
         SortCriterion::Alphanumeric => f64::NEG_INFINITY,
@@ -1176,11 +1178,7 @@ fn score_track(track: &Track, criterion: SortCriterion, db: &Database) -> Scored
             .and_then(|x| x.added_at)
             .map_or(f64::MIN, |dt| dt.timestamp() as f64),
     };
-    ScoredTrack {
-        track: track.clone(),
-        key,
-        title,
-    }
+    ScoredTrack { track, key, title }
 }
 
 /// Sort a scored track list in-place according to `criterion` + `direction`.

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1161,14 +1161,11 @@ struct ScoredTrack {
     track: Track,
     /// Primary sort key (score, duration, etc.).
     key: f64,
-    /// Title used for natural-sort tie-breaking.
-    title: String,
 }
 
 /// Compute the sort key for a single track against the given criterion.
 #[allow(clippy::cast_precision_loss)]
 fn score_track(track: Track, criterion: SortCriterion, db: &Database) -> ScoredTrack {
-    let title = track.title().unwrap_or_default().to_string();
     let key = match criterion {
         SortCriterion::Alphanumeric => f64::NEG_INFINITY,
         SortCriterion::Duration => track.duration().map_or(0.0, |d| d.as_secs_f64()),
@@ -1178,7 +1175,7 @@ fn score_track(track: Track, criterion: SortCriterion, db: &Database) -> ScoredT
             .and_then(|x| x.added_at)
             .map_or(f64::MIN, |dt| dt.timestamp() as f64),
     };
-    ScoredTrack { track, key, title }
+    ScoredTrack { track, key }
 }
 
 /// Sort a scored track list in-place according to `criterion` + `direction`.
@@ -1186,10 +1183,20 @@ fn sort_scored(scored: &mut [ScoredTrack], criterion: SortCriterion, direction: 
     if criterion == SortCriterion::Alphanumeric {
         match direction {
             SortDirection::Asc => {
-                scored.sort_by(|a, b| alphanumeric_sort::compare_str(&a.title, &b.title));
+                scored.sort_by(|a, b| {
+                    alphanumeric_sort::compare_str(
+                        a.track.title().unwrap_or_default(),
+                        b.track.title().unwrap_or_default(),
+                    )
+                });
             }
             SortDirection::Desc => {
-                scored.sort_by(|a, b| alphanumeric_sort::compare_str(&b.title, &a.title));
+                scored.sort_by(|a, b| {
+                    alphanumeric_sort::compare_str(
+                        b.track.title().unwrap_or_default(),
+                        a.track.title().unwrap_or_default(),
+                    )
+                });
             }
         }
     } else {
@@ -1198,8 +1205,12 @@ fn sort_scored(scored: &mut [ScoredTrack], criterion: SortCriterion, direction: 
                 SortDirection::Asc => a.key.partial_cmp(&b.key),
                 SortDirection::Desc => b.key.partial_cmp(&a.key),
             };
-            ord.unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| alphanumeric_sort::compare_str(&a.title, &b.title))
+            ord.unwrap_or(std::cmp::Ordering::Equal).then_with(|| {
+                alphanumeric_sort::compare_str(
+                    a.track.title().unwrap_or_default(),
+                    b.track.title().unwrap_or_default(),
+                )
+            })
         });
     }
 }

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -977,6 +977,7 @@ impl Playlist {
         let current_track_file = self.get_current_track_internal();
 
         self.tracks.shuffle(&mut rand::rng());
+        self.is_modified = true;
 
         if let Some(current_track_file) = current_track_file
             && let Some(index) = self.find_index_from_file(&current_track_file)

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1,17 +1,17 @@
+use anyhow::{Context, Result, bail};
+use parking_lot::RwLock;
+use pathdiff::diff_paths;
+use rand::RngExt;
+use rand::seq::SliceRandom;
 use std::error::Error;
 use std::fmt::{Display, Write as _};
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-
-use anyhow::{Context, Result, bail};
-use parking_lot::RwLock;
-use pathdiff::diff_paths;
-use rand::RngExt;
-use rand::seq::SliceRandom;
 use termusiclib::config::SharedServerSettings;
 use termusiclib::config::v2::server::LoopMode;
+use termusiclib::new_database::{Database, track_ops};
 use termusiclib::player;
 use termusiclib::player::PlaylistLoopModeInfo;
 use termusiclib::player::PlaylistShuffledInfo;
@@ -24,6 +24,7 @@ use termusiclib::player::playlist_helpers::PlaylistSwapTrack;
 use termusiclib::player::playlist_helpers::PlaylistTrackSource;
 use termusiclib::player::playlist_helpers::{PlaylistAddTrack, PlaylistRemoveTrackIndexed};
 use termusiclib::player::{PlaylistAddTrackInfo, PlaylistRemoveTrackInfo};
+use termusiclib::player::{SortCriterion, SortDirection};
 use termusiclib::podcast::{db::Database as DBPod, episode::Episode};
 use termusiclib::track::{MediaTypes, Track, TrackData};
 use termusiclib::utils::{filetype_supported, get_app_config_path, get_parent_folder};
@@ -989,6 +990,49 @@ impl Playlist {
         ));
     }
 
+    /// Reorder the playlist by `criterion` + `direction` and emit `PlaylistShuffled`.
+    ///
+    /// Ties on non-alphanumeric criteria are broken by track title (natural sort).
+    /// Mirrors `shuffle()` but with deterministic ordering.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `as_grpc_playlist_tracks` fails (should not happen in practice).
+    pub fn sort_by_mode(
+        &mut self,
+        criterion: SortCriterion,
+        direction: SortDirection,
+        db: &Database,
+    ) {
+        let current_track_file = self.get_current_track_internal();
+
+        // We collect into a separate Vec rather than using `sort_by_cached_key`
+        // because `score_track` borrows `db` and each track immutably, which
+        // conflicts with the mutable borrow `sort_by_cached_key` would need.
+        let mut scored: Vec<ScoredTrack> = self
+            .tracks
+            .iter()
+            .map(|t| score_track(t, criterion, db))
+            .collect();
+
+        sort_scored(&mut scored, criterion, direction);
+
+        self.tracks = scored.into_iter().map(|s| s.track).collect();
+
+        // Restore current track index
+        if let Some(current_track_file) = current_track_file
+            && let Some(index) = self.find_index_from_file(&current_track_file)
+        {
+            self.current_track_index = index;
+        }
+
+        self.send_stream_ev_pl(UpdatePlaylistEvents::PlaylistShuffled(
+            PlaylistShuffledInfo {
+                tracks: self.as_grpc_playlist_tracks().unwrap(),
+            },
+        ));
+    }
+
     /// Get the current tracks and state as a GRPC [`PlaylistTracks`] object.
     ///
     /// # Errors
@@ -1106,6 +1150,58 @@ impl Playlist {
         {
             debug!("Stream Event not send: No Receivers");
         }
+    }
+}
+
+/// A track paired with its sort key and title for deterministic ordering.
+struct ScoredTrack {
+    track: Track,
+    /// Primary sort key (score, duration, etc.).
+    key: f64,
+    /// Title used for natural-sort tie-breaking.
+    title: String,
+}
+
+/// Compute the sort key for a single track against the given criterion.
+#[allow(clippy::cast_precision_loss)]
+fn score_track(track: &Track, criterion: SortCriterion, db: &Database) -> ScoredTrack {
+    let title = track.title().unwrap_or_default().to_string();
+    let key = match criterion {
+        SortCriterion::Alphanumeric => f64::NEG_INFINITY,
+        SortCriterion::Duration => track.duration().map_or(0.0, |d| d.as_secs_f64()),
+        SortCriterion::FirstAdded => track
+            .path()
+            .and_then(|p| track_ops::get_track_from_path(&db.get_connection(), p).ok())
+            .and_then(|x| x.added_at)
+            .map_or(f64::MIN, |dt| dt.timestamp() as f64),
+    };
+    ScoredTrack {
+        track: track.clone(),
+        key,
+        title,
+    }
+}
+
+/// Sort a scored track list in-place according to `criterion` + `direction`.
+fn sort_scored(scored: &mut [ScoredTrack], criterion: SortCriterion, direction: SortDirection) {
+    if criterion == SortCriterion::Alphanumeric {
+        match direction {
+            SortDirection::Asc => {
+                scored.sort_by(|a, b| alphanumeric_sort::compare_str(&a.title, &b.title));
+            }
+            SortDirection::Desc => {
+                scored.sort_by(|a, b| alphanumeric_sort::compare_str(&b.title, &a.title));
+            }
+        }
+    } else {
+        scored.sort_by(|a, b| {
+            let ord = match direction {
+                SortDirection::Asc => a.key.partial_cmp(&b.key),
+                SortDirection::Desc => b.key.partial_cmp(&a.key),
+            };
+            ord.unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| alphanumeric_sort::compare_str(&a.title, &b.title))
+        });
     }
 }
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -355,6 +355,7 @@ impl MusicPlayer for MusicPlayerService {
             .map_err(|e| Status::invalid_argument(format!("unknown sort criterion: {e}")))?;
         let direction = player::SortDirection::try_from(req.direction)
             .map_err(|e| Status::invalid_argument(format!("unknown sort direction: {e}")))?;
+        info!("Sort playlist: {criterion:?} {direction:?}");
         let rx = self.command_cb(PlayerCmd::PlaylistSort(criterion, direction))?;
         let _ = rx.await;
 

--- a/server/src/music_player_service.rs
+++ b/server/src/music_player_service.rs
@@ -7,8 +7,9 @@ use termusiclib::player::music_player_server::MusicPlayer;
 use termusiclib::player::playlist_helpers::{PlaylistPlaySpecific, PlaylistRemoveTrackType};
 use termusiclib::player::{
     self, Empty, GaplessState, GetProgressResponse, PlayState, PlayerTime, PlaylistLoopMode,
-    PlaylistSwapTracks, PlaylistTracks, PlaylistTracksToAdd, PlaylistTracksToRemove, SpeedReply,
-    StreamUpdates, UpdateMissedEvents, VolumeReply, stream_updates,
+    PlaylistSwapTracks, PlaylistTracks, PlaylistTracksToAdd, PlaylistTracksToRemove,
+    SortPlaylistRequest, SpeedReply, StreamUpdates, UpdateMissedEvents, VolumeReply,
+    stream_updates,
 };
 use termusicplayback::{
     PlayerCmd, PlayerCmdCallback, PlayerCmdSender, SharedPlaylist, SharedRunInfo, StreamTX,
@@ -338,6 +339,23 @@ impl MusicPlayer for MusicPlayerService {
         // this does not necessarily need to be done, but its better to have the service read-only
         let rx = self.command_cb(PlayerCmd::PlaylistShuffle)?;
         // wait until the event was processed
+        let _ = rx.await;
+
+        let reply = Empty {};
+
+        Ok(Response::new(reply))
+    }
+
+    async fn sort_playlist(
+        &self,
+        request: Request<SortPlaylistRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        let criterion = player::SortCriterion::try_from(req.criterion)
+            .map_err(|e| Status::invalid_argument(format!("unknown sort criterion: {e}")))?;
+        let direction = player::SortDirection::try_from(req.direction)
+            .map_err(|e| Status::invalid_argument(format!("unknown sort direction: {e}")))?;
+        let rx = self.command_cb(PlayerCmd::PlaylistSort(criterion, direction))?;
         let _ = rx.await;
 
         let reply = Empty {};

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -533,6 +533,12 @@ fn player_loop(
             PlayerCmd::PlaylistShuffle => {
                 player.playlist.write().shuffle();
             }
+            PlayerCmd::PlaylistSort(criterion, direction) => {
+                player
+                    .playlist
+                    .write()
+                    .sort_by_mode(criterion, direction, &player.db);
+            }
             PlayerCmd::PlaylistRemoveDeletedTracks => {
                 player.playlist.write().remove_deleted_items();
             }

--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -1013,6 +1013,7 @@ impl KEModifierSelect {
             IdKey::Other(IdKeyOther::PlaylistAddRandomTracks) => {
                 keys.playlist_keys.add_random_songs.mod_key()
             }
+            IdKey::Other(IdKeyOther::PlaylistSort) => keys.playlist_keys.sort.mod_key(),
             IdKey::Other(IdKeyOther::LibrarySwitchRoot) => keys.library_keys.cycle_root.mod_key(),
             IdKey::Other(IdKeyOther::LibraryAddRoot) => keys.library_keys.add_root.mod_key(),
             IdKey::Other(IdKeyOther::LibraryRemoveRoot) => keys.library_keys.remove_root.mod_key(),
@@ -1739,6 +1740,15 @@ fn key_playlist_add_random_tracks(config: SharedTuiSettings) -> KEModifierSelect
     )
 }
 
+#[inline]
+fn key_playlist_sort(config: SharedTuiSettings) -> KEModifierSelect {
+    KEModifierSelect::new(
+        " Playlist Sort Popup ",
+        IdKey::Other(IdKeyOther::PlaylistSort),
+        config,
+    )
+}
+
 // --- Section Database Keys ---
 
 #[inline]
@@ -2156,6 +2166,12 @@ impl Model {
             Vec::new(),
         )?;
 
+        self.app.remount(
+            Id::ConfigEditor(IdConfigEditor::KeyOther(IdKeyOther::PlaylistSort)),
+            Box::new(key_playlist_sort(self.config_tui.clone())),
+            Vec::new(),
+        )?;
+
         Ok(())
     }
 
@@ -2453,6 +2469,10 @@ impl Model {
 
         self.app.umount(&Id::ConfigEditor(IdConfigEditor::KeyOther(
             IdKeyOther::PlaylistAddRandomTracks,
+        )))?;
+
+        self.app.umount(&Id::ConfigEditor(IdConfigEditor::KeyOther(
+            IdKeyOther::PlaylistSort,
         )))?;
 
         Ok(())

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -356,6 +356,9 @@ impl Model {
             IdKey::Other(IdKeyOther::PlaylistAddRandomTracks) => {
                 keys.playlist_keys.add_random_songs = binding;
             }
+            IdKey::Other(IdKeyOther::PlaylistSort) => {
+                keys.playlist_keys.sort = binding;
+            }
             IdKey::Other(IdKeyOther::LibrarySwitchRoot) => keys.library_keys.cycle_root = binding,
             IdKey::Other(IdKeyOther::LibraryAddRoot) => keys.library_keys.add_root = binding,
             IdKey::Other(IdKeyOther::LibraryRemoveRoot) => keys.library_keys.remove_root = binding,

--- a/tui/src/ui/components/global_listener.rs
+++ b/tui/src/ui/components/global_listener.rs
@@ -399,10 +399,11 @@ fn delete_confirm_popups() -> [SubClause<Id>; 2] {
 ///
 /// The values returned are meant to be used in a [`SubClause::OrMany`].
 #[inline]
-fn everywhere_popups() -> [SubClause<Id>; 3] {
+fn everywhere_popups() -> [SubClause<Id>; 4] {
     [
         SubClause::IsMounted(Id::HelpPopup),
         SubClause::IsMounted(Id::ErrorPopup),
         SubClause::IsMounted(Id::QuitPopup),
+        SubClause::IsMounted(Id::SortPopup),
     ]
 }

--- a/tui/src/ui/components/playlist/playlist_comp.rs
+++ b/tui/src/ui/components/playlist/playlist_comp.rs
@@ -18,7 +18,7 @@ use termusiclib::player::playlist_helpers::{
 };
 use termusiclib::player::{
     PlaylistAddTrackInfo, PlaylistLoopModeInfo, PlaylistRemoveTrackInfo, PlaylistShuffledInfo,
-    PlaylistSwapInfo,
+    PlaylistSwapInfo, SortCriterion, SortDirection,
 };
 use termusiclib::track::DurationFmtShort;
 use termusiclib::track::Track;
@@ -48,7 +48,7 @@ use crate::ui::components::playlist::playlist_mock::{
 };
 use crate::ui::ids::Id;
 use crate::ui::model::{SharedPlaylist, TUIPlaylist, TermusicLayout, UserEvent};
-use crate::ui::msg::{GSMsg, Msg, PLMsg, SearchCriteria};
+use crate::ui::msg::{GSMsg, Msg, PLMsg, SearchCriteria, SortPopupMsg};
 use crate::ui::tui_cmd::{PlaylistCmd, TuiCmd};
 
 /// Holds the playlist reference.
@@ -319,6 +319,9 @@ impl AppComponent<Msg, UserEvent> for Playlist {
             }
             Event::Keyboard(key) if key == keys.playlist_keys.shuffle.get() => {
                 return Some(Msg::Playlist(PLMsg::Shuffle));
+            }
+            Event::Keyboard(key) if key == keys.playlist_keys.sort.get() => {
+                return Some(Msg::SortPopup(SortPopupMsg::Show));
             }
             Event::Keyboard(key) if key == keys.playlist_keys.cycle_loop_mode.get() => {
                 return Some(Msg::Playlist(PLMsg::LoopModeCycle));
@@ -762,6 +765,14 @@ impl Model {
     /// Shuffle the whole playlist
     pub fn playlist_shuffle(&mut self) {
         self.command(TuiCmd::Playlist(PlaylistCmd::Shuffle));
+    }
+
+    /// Sort the whole playlist by criterion and direction
+    pub fn playlist_sort(&mut self, criterion: SortCriterion, direction: SortDirection) {
+        self.command(TuiCmd::Playlist(PlaylistCmd::Sort {
+            criterion,
+            direction,
+        }));
     }
 
     /// Send command to swap 2 indexes. Does nothing if either index is out-of-bounds.

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -301,6 +301,9 @@ impl HelpPopup {
                         ))
                         .add_col(Self::comment("Select random tracks/albums to playlist"))
                         .add_row()
+                        .add_col(Self::key(&config, &[&keys.playlist_keys.sort]))
+                        .add_col(Self::comment("Open sort popup menu"))
+                        .add_row()
                         .add_col(Self::header(&config, "Database"))
                         .add_row()
                         .add_col(Self::key(

--- a/tui/src/ui/components/popups/mod.rs
+++ b/tui/src/ui/components/popups/mod.rs
@@ -9,6 +9,7 @@ mod mock_yn_confirm;
 mod podcast;
 mod quit;
 mod saveplaylist;
+mod sort;
 pub mod youtube_search;
 
 #[allow(unused_imports)]
@@ -26,3 +27,5 @@ pub use podcast::{FeedDeleteConfirmRadioPopup, PodcastAddPopup, PodcastSearchTab
 pub use quit::QuitPopup;
 #[allow(unused_imports)]
 pub use saveplaylist::{SavePlaylistConfirmPopup, SavePlaylistPopup};
+#[allow(unused_imports)]
+pub use sort::SortPopup;

--- a/tui/src/ui/components/popups/sort.rs
+++ b/tui/src/ui/components/popups/sort.rs
@@ -1,0 +1,256 @@
+use termusiclib::config::SharedTuiSettings;
+use termusiclib::player::{SortCriterion, SortDirection};
+use tui_realm_stdlib::components::Table;
+use tui_realm_stdlib::prop_ext::CommonHighlight;
+use tuirealm::command::{Cmd, Direction};
+use tuirealm::component::{AppComponent, Component};
+use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers};
+use tuirealm::props::{
+    AttrValue, BorderType, Borders, HorizontalAlignment, LineStatic, PropPayload, PropValue, Style,
+    TableBuilder, Title,
+};
+use tuirealm::state::{State, StateValue};
+
+use crate::ui::ids::Id;
+use crate::ui::model::{Model, UserEvent};
+use crate::ui::msg::{Msg, SortPopupMsg};
+
+/// Describes one sort criterion with its key bindings and display labels.
+struct SortHint {
+    ascending_key: char,
+    descending_key: char,
+    criterion: SortCriterion,
+    label: &'static str,
+    asc_description: &'static str,
+    desc_description: &'static str,
+}
+
+const SORT_HINTS: &[SortHint] = &[
+    SortHint {
+        ascending_key: 'a',
+        descending_key: 'A',
+        criterion: SortCriterion::Alphanumeric,
+        label: "Alphanumeric",
+        asc_description: "Filename A\u{2192}Z",
+        desc_description: "Filename Z\u{2192}A",
+    },
+    SortHint {
+        ascending_key: 't',
+        descending_key: 'T',
+        criterion: SortCriterion::FirstAdded,
+        label: "First Added",
+        asc_description: "Date added oldest\u{2192}newest",
+        desc_description: "Date added newest\u{2192}oldest",
+    },
+    SortHint {
+        ascending_key: 'd',
+        descending_key: 'D',
+        criterion: SortCriterion::Duration,
+        label: "Duration",
+        asc_description: "Length shortest\u{2192}longest",
+        desc_description: "Length longest\u{2192}shortest",
+    },
+];
+
+const TITLE_ASC: &str = " Sort (Ascending) \u{2014} Tab: toggle, Enter: select, q/Esc: cancel ";
+const TITLE_DESC: &str = " Sort (Descending) \u{2014} Tab: toggle, Enter: select, q/Esc: cancel ";
+
+/// Build the table content (rows) for the given sort direction.
+fn table_data(direction: SortDirection) -> tuirealm::props::Table {
+    let mut builder = TableBuilder::default();
+    for (idx, hint) in SORT_HINTS.iter().enumerate() {
+        let desc = match direction {
+            SortDirection::Asc => hint.asc_description,
+            SortDirection::Desc => hint.desc_description,
+        };
+        builder
+            .add_col(LineStatic::from(format!(
+                "  {} / {}",
+                hint.ascending_key, hint.descending_key
+            )))
+            .add_col(LineStatic::from(hint.label))
+            .add_col(LineStatic::from(desc));
+        if idx < SORT_HINTS.len() - 1 {
+            builder.add_row();
+        }
+    }
+    builder.build()
+}
+
+/// Build the full `Table` widget with borders, styling, and headers.
+fn build_table(config: &SharedTuiSettings, direction: SortDirection) -> Table {
+    let config = config.read();
+    let table = table_data(direction);
+    let title = match direction {
+        SortDirection::Asc => TITLE_ASC,
+        SortDirection::Desc => TITLE_DESC,
+    };
+
+    Table::default()
+        .borders(
+            Borders::default()
+                .modifiers(BorderType::Rounded)
+                .color(config.settings.theme.fallback_border()),
+        )
+        .inactive(Style::new().bg(config.settings.theme.fallback_background()))
+        .foreground(config.settings.theme.fallback_foreground())
+        .background(config.settings.theme.fallback_background())
+        .highlight_style(
+            CommonHighlight::default()
+                .style
+                .fg(config.settings.theme.fallback_highlight()),
+        )
+        .scroll(true)
+        .title(Title::from(title).alignment(HorizontalAlignment::Center))
+        .rewind(false)
+        .step(1)
+        .row_height(1)
+        .headers(["  Key", "Name", "Description"])
+        .column_spacing(3)
+        .widths(&[12, 20, 46])
+        .table(table)
+}
+
+/// Sort popup component — displays available sort criteria with key hints.
+#[derive(Component)]
+pub struct SortPopup {
+    component: Table,
+    direction: SortDirection,
+    config: SharedTuiSettings,
+}
+
+impl SortPopup {
+    /// Create a new sort popup with ascending direction selected.
+    pub fn new(config: &SharedTuiSettings) -> Self {
+        let component = build_table(config, SortDirection::Asc);
+        Self {
+            component,
+            direction: SortDirection::Asc,
+            config: config.clone(),
+        }
+    }
+
+    /// Match a character against the sort hint key bindings.
+    fn match_key(ch: char) -> Option<(SortCriterion, SortDirection)> {
+        for hint in SORT_HINTS {
+            if ch == hint.ascending_key {
+                return Some((hint.criterion, SortDirection::Asc));
+            }
+            if ch == hint.descending_key {
+                return Some((hint.criterion, SortDirection::Desc));
+            }
+        }
+        None
+    }
+
+    /// Update the table content in place, preserving the active row highlight.
+    ///
+    /// Replacing the whole component would drop the `is_active` flag,
+    /// making the selection highlight disappear.
+    fn rebuild(&mut self, direction: SortDirection) {
+        let idx = match self.component.state() {
+            State::Single(StateValue::Usize(i)) => Some(i),
+            _ => None,
+        };
+        let title = match direction {
+            SortDirection::Asc => TITLE_ASC,
+            SortDirection::Desc => TITLE_DESC,
+        };
+        self.component.attr(
+            tuirealm::props::Attribute::Content,
+            AttrValue::Table(table_data(direction)),
+        );
+        self.component.attr(
+            tuirealm::props::Attribute::Title,
+            AttrValue::Title(Title::from(title).alignment(HorizontalAlignment::Center)),
+        );
+        if let Some(i) = idx {
+            self.component.attr(
+                tuirealm::props::Attribute::Value,
+                AttrValue::Payload(PropPayload::Single(PropValue::Usize(i))),
+            );
+        }
+    }
+
+    /// Return the currently highlighted sort criterion and direction, if any.
+    fn selected_criterion(&self) -> Option<(SortCriterion, SortDirection)> {
+        let State::Single(StateValue::Usize(idx)) = self.component.state() else {
+            return None;
+        };
+        SORT_HINTS.get(idx).map(|h| (h.criterion, self.direction))
+    }
+}
+
+impl AppComponent<Msg, UserEvent> for SortPopup {
+    fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
+        let config = self.config.clone();
+        let keys = &config.read().settings.keys;
+        match ev {
+            Event::Keyboard(KeyEvent {
+                code: Key::Char(ch),
+                ..
+            }) => {
+                if let Some((criterion, direction)) = Self::match_key(*ch) {
+                    return Some(Msg::SortPopup(SortPopupMsg::Selected(criterion, direction)));
+                }
+                None
+            }
+            Event::Keyboard(key) if key == keys.quit.get() => {
+                Some(Msg::SortPopup(SortPopupMsg::Close))
+            }
+            Event::Keyboard(key) if key == keys.escape.get() => {
+                Some(Msg::SortPopup(SortPopupMsg::Close))
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Enter,
+                modifiers: KeyModifiers::NONE,
+            }) => self
+                .selected_criterion()
+                .map(|(c, d)| Msg::SortPopup(SortPopupMsg::Selected(c, d))),
+            Event::Keyboard(KeyEvent {
+                code: Key::Tab,
+                modifiers: KeyModifiers::NONE,
+            }) => {
+                self.direction = match self.direction {
+                    SortDirection::Asc => SortDirection::Desc,
+                    SortDirection::Desc => SortDirection::Asc,
+                };
+                self.rebuild(self.direction);
+                Some(Msg::ForceRedraw)
+            }
+            Event::Keyboard(KeyEvent { code: Key::Up, .. }) => {
+                self.perform(Cmd::Move(Direction::Up));
+                Some(Msg::ForceRedraw)
+            }
+            Event::Keyboard(KeyEvent {
+                code: Key::Down, ..
+            }) => {
+                self.perform(Cmd::Move(Direction::Down));
+                Some(Msg::ForceRedraw)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Model {
+    /// Mount the sort popup, hiding the album cover behind it.
+    pub fn mount_sort_popup(&mut self) {
+        assert!(
+            self.app
+                .remount(
+                    Id::SortPopup,
+                    Box::new(SortPopup::new(&self.config_tui)),
+                    vec![]
+                )
+                .is_ok()
+        );
+        self.update_photo().ok();
+        assert!(self.app.active(&Id::SortPopup).is_ok());
+    }
+
+    /// Unmount the sort popup.
+    pub fn umount_sort_popup(&mut self) {
+        self.app.umount(&Id::SortPopup).ok();
+    }
+}

--- a/tui/src/ui/components/popups/sort.rs
+++ b/tui/src/ui/components/popups/sort.rs
@@ -6,8 +6,8 @@ use tuirealm::command::{Cmd, Direction};
 use tuirealm::component::{AppComponent, Component};
 use tuirealm::event::{Event, Key, KeyEvent, KeyModifiers};
 use tuirealm::props::{
-    AttrValue, BorderType, Borders, HorizontalAlignment, LineStatic, PropPayload, PropValue, Style,
-    TableBuilder, Title,
+    AttrValue, Attribute, BorderType, Borders, HorizontalAlignment, LineStatic, PropPayload,
+    PropValue, Style, TableBuilder, Title,
 };
 use tuirealm::state::{State, StateValue};
 
@@ -52,8 +52,8 @@ const SORT_HINTS: &[SortHint] = &[
     },
 ];
 
-const TITLE_ASC: &str = " Sort (Ascending) \u{2014} Tab: toggle, Enter: select, q/Esc: cancel ";
-const TITLE_DESC: &str = " Sort (Descending) \u{2014} Tab: toggle, Enter: select, q/Esc: cancel ";
+const TITLE_ASC: &str = " Sort (Ascending) \u{2014} Tab: toggle, Enter: select, Esc: cancel ";
+const TITLE_DESC: &str = " Sort (Descending) \u{2014} Tab: toggle, Enter: select, Esc: cancel ";
 
 /// Build the table content (rows) for the given sort direction.
 fn table_data(direction: SortDirection) -> tuirealm::props::Table {
@@ -65,7 +65,7 @@ fn table_data(direction: SortDirection) -> tuirealm::props::Table {
         };
         builder
             .add_col(LineStatic::from(format!(
-                "  {} / {}",
+                "{} / {}",
                 hint.ascending_key, hint.descending_key
             )))
             .add_col(LineStatic::from(hint.label))
@@ -100,12 +100,13 @@ fn build_table(config: &SharedTuiSettings, direction: SortDirection) -> Table {
                 .style
                 .fg(config.settings.theme.fallback_highlight()),
         )
+        .highlight_str(config.settings.theme.style.library.highlight_symbol.clone())
         .scroll(true)
         .title(Title::from(title).alignment(HorizontalAlignment::Center))
         .rewind(false)
         .step(1)
         .row_height(1)
-        .headers(["  Key", "Name", "Description"])
+        .headers(["Key", "Name", "Description"])
         .column_spacing(3)
         .widths(&[12, 20, 46])
         .table(table)
@@ -156,17 +157,15 @@ impl SortPopup {
             SortDirection::Asc => TITLE_ASC,
             SortDirection::Desc => TITLE_DESC,
         };
+        self.component
+            .attr(Attribute::Content, AttrValue::Table(table_data(direction)));
         self.component.attr(
-            tuirealm::props::Attribute::Content,
-            AttrValue::Table(table_data(direction)),
-        );
-        self.component.attr(
-            tuirealm::props::Attribute::Title,
+            Attribute::Title,
             AttrValue::Title(Title::from(title).alignment(HorizontalAlignment::Center)),
         );
         if let Some(i) = idx {
             self.component.attr(
-                tuirealm::props::Attribute::Value,
+                Attribute::Value,
                 AttrValue::Payload(PropPayload::Single(PropValue::Usize(i))),
             );
         }

--- a/tui/src/ui/ids.rs
+++ b/tui/src/ui/ids.rs
@@ -30,6 +30,7 @@ pub enum Id {
     SavePlaylistPopup,
     SavePlaylistLabel,
     SavePlaylistConfirm,
+    SortPopup,
     TagEditor(IdTagEditor),
     YoutubeSearchInputPopup,
     YoutubeSearchTablePopup,
@@ -224,6 +225,7 @@ pub enum IdKeyOther {
     PlaylistDeleteAll,
     PlaylistAddRandomAlbum,
     PlaylistAddRandomTracks,
+    PlaylistSort,
 
     DatabaseAddAll,
     DatabaseAddSelected,

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -121,10 +121,12 @@ impl Model {
             }
             SortPopupMsg::Close => {
                 self.umount_sort_popup();
+                self.update_photo().ok();
             }
             SortPopupMsg::Selected(criterion, direction) => {
                 self.umount_sort_popup();
                 self.playlist_sort(criterion, direction);
+                self.update_photo().ok();
             }
         }
     }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -16,7 +16,7 @@ use crate::ui::model::youtube_options::YTDLMsg;
 use crate::ui::msg::{
     CoverDLResult, DBMsg, DeleteConfirmMsg, ErrorPopupMsg, GSMsg, HelpPopupMsg, LIMsg, LyricMsg,
     MainLayoutMsg, Msg, NotificationMsg, PCMsg, PLMsg, PlayerMsg, QuitPopupMsg, SavePlaylistMsg,
-    ServerReqResponse, XYWHMsg, YSMsg,
+    ServerReqResponse, SortPopupMsg, XYWHMsg, YSMsg,
 };
 use crate::ui::tui_cmd::TuiCmd;
 use crate::ui::{Model, model::TermusicLayout};
@@ -49,6 +49,7 @@ impl Model {
             Msg::Player(msg) => self.update_player(msg),
 
             Msg::HelpPopup(msg) => self.update_help_popup_msg(&msg),
+            Msg::SortPopup(msg) => self.update_sort_popup_msg(msg),
             Msg::YoutubeSearch(msg) => {
                 self.update_youtube_search(msg);
             }
@@ -108,6 +109,22 @@ impl Model {
                     self.app.umount(&Id::HelpPopup).ok();
                 }
                 self.update_photo().ok();
+            }
+        }
+    }
+
+    /// Handle all [`SortPopupMsg`] messages. Sub-function for [`update`](Self::update).
+    fn update_sort_popup_msg(&mut self, msg: SortPopupMsg) {
+        match msg {
+            SortPopupMsg::Show => {
+                self.mount_sort_popup();
+            }
+            SortPopupMsg::Close => {
+                self.umount_sort_popup();
+            }
+            SortPopupMsg::Selected(criterion, direction) => {
+                self.umount_sort_popup();
+                self.playlist_sort(criterion, direction);
             }
         }
     }

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -305,6 +305,10 @@ impl Model {
             let popup = draw_area_in_absolute(f.area(), 40, 3);
             f.render_widget(Clear, popup);
             app.view(&Id::SavePlaylistConfirm, f, popup);
+        } else if app.mounted(&Id::SortPopup) {
+            let popup = draw_area_in_absolute(f.area(), 70, 10);
+            f.render_widget(Clear, popup);
+            app.view(&Id::SortPopup, f, popup);
         } else if app.mounted(&Id::PodcastAddPopup) {
             let popup = draw_area_in_absolute(f.area(), 65, 3);
             f.render_widget(Clear, popup);

--- a/tui/src/ui/msg.rs
+++ b/tui/src/ui/msg.rs
@@ -3,6 +3,8 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
+use termusiclib::player::{SortCriterion, SortDirection};
+
 use image::DynamicImage;
 use termusiclib::config::v2::tui::{keys::KeyBinding, theme::styles::ColorTermusic};
 use termusiclib::player::{GetProgressResponse, PlaylistTracks, UpdateEvents};
@@ -35,6 +37,7 @@ pub enum Msg {
     DeleteConfirm(DeleteConfirmMsg),
     QuitPopup(QuitPopupMsg),
     HelpPopup(HelpPopupMsg),
+    SortPopup(SortPopupMsg),
     ErrorPopup(ErrorPopupMsg),
 
     /// Same as [`ForceRedraw`](Msg::ForceRedraw), but also updated the drawn cover.
@@ -168,6 +171,14 @@ pub enum QuitPopupMsg {
 pub enum HelpPopupMsg {
     Show,
     Close,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SortPopupMsg {
+    Show,
+    Close,
+    /// User selected a sort criterion + direction from the menu.
+    Selected(SortCriterion, SortDirection),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -518,6 +529,7 @@ pub const KFOTHER_FOCUS_ORDER: &[IdKey] = &[
     IdKey::Other(IdKeyOther::PlaylistDeleteAll),
     IdKey::Other(IdKeyOther::PlaylistAddRandomAlbum),
     IdKey::Other(IdKeyOther::PlaylistAddRandomTracks),
+    IdKey::Other(IdKeyOther::PlaylistSort),
     // database keys
     IdKey::Other(IdKeyOther::DatabaseAddAll),
     IdKey::Other(IdKeyOther::DatabaseAddSelected),

--- a/tui/src/ui/music_player_client.rs
+++ b/tui/src/ui/music_player_client.rs
@@ -6,7 +6,8 @@ use termusiclib::player::playlist_helpers::{
 };
 use termusiclib::player::{
     Empty, GetProgressResponse, PlayerProgress, PlaylistSwapTracks, PlaylistTracks,
-    PlaylistTracksToAdd, PlaylistTracksToRemove, RunningStatus,
+    PlaylistTracksToAdd, PlaylistTracksToRemove, RunningStatus, SortCriterion, SortDirection,
+    SortPlaylistRequest,
 };
 use tokio_stream::{Stream, StreamExt as _};
 use tonic::transport::Channel;
@@ -195,6 +196,21 @@ impl Playback {
     pub async fn shuffle_playlist(&mut self) -> Result<()> {
         let request = tonic::Request::new(Empty {});
         let response = self.client.shuffle_playlist(request).await?;
+        info!("Got response from server: {response:?}");
+
+        Ok(())
+    }
+
+    pub async fn sort_playlist(
+        &mut self,
+        criterion: SortCriterion,
+        direction: SortDirection,
+    ) -> Result<()> {
+        let request = tonic::Request::new(SortPlaylistRequest {
+            criterion: criterion.into(),
+            direction: direction.into(),
+        });
+        let response = self.client.sort_playlist(request).await?;
         info!("Got response from server: {response:?}");
 
         Ok(())

--- a/tui/src/ui/server_req_actor.rs
+++ b/tui/src/ui/server_req_actor.rs
@@ -150,6 +150,14 @@ impl ServerRequestActor {
                 // result will be populated back via UpdateStream
                 self.client_handle.shuffle_playlist().await?;
             }
+            PlaylistCmd::Sort {
+                criterion,
+                direction,
+            } => {
+                self.client_handle
+                    .sort_playlist(criterion, direction)
+                    .await?;
+            }
             PlaylistCmd::RemoveDeletedItems => {
                 // result will be populated back via UpdateStream
                 self.client_handle.remove_deleted_tracks().await?;

--- a/tui/src/ui/tui_cmd.rs
+++ b/tui/src/ui/tui_cmd.rs
@@ -1,6 +1,7 @@
 use termusiclib::player::playlist_helpers::{
     PlaylistAddTrack, PlaylistPlaySpecific, PlaylistRemoveTrackIndexed, PlaylistSwapTrack,
 };
+use termusiclib::player::{SortCriterion, SortDirection};
 
 #[allow(clippy::doc_link_with_quotes)]
 /// Enum for Commands to send to the [`MusicPlayerClient` "Actor"](crate::ui::music_player_client).
@@ -38,6 +39,10 @@ pub enum PlaylistCmd {
     Clear,
     SwapTrack(PlaylistSwapTrack),
     Shuffle,
+    Sort {
+        criterion: SortCriterion,
+        direction: SortDirection,
+    },
     RemoveDeletedItems,
 
     /// Re-Request the playlist tracks and state


### PR DESCRIPTION
This is **part 1 of 2** of the playlist sort feature. The DB-dependent criteria (most-played, recency, frecency) and their migration live in the follow-up PR #743.

Adds the ability to reorder the current playlist by a chosen criterion with ASC/DESC, via a new **Sort** popup. This PR covers the **base** criteria that need no database schema change:

- **Alphabetical** (`a` / `A`) — A–Z / Z–A, natural sort
- **Date-added** (`t` / `T`) — oldest / newest (`added_at`, read from its existing RFC 3339 value)
- **Duration** (`d` / `D`) — shortest / longest

### Implementation
- **Proto**: `SortCriterion` (Alphanumeric, FirstAdded, Duration) + `SortDirection` enums, `SortPlaylist` RPC
- **Server**: `sort_playlist` handler translates the request into a `PlayerCmd`; reuses the existing `PlaylistShuffled` event so the TUI reloads with no new plumbing
- **Playback**: `sort_by_mode()` scores tracks (duration as seconds; `added_at` RFC 3339 → epoch); ties fall back to title natural-sort
- **Lib**: `added_at` is already stored as RFC 3339 and is surfaced on `TrackRead` (no migration needed)
- **TUI**: Sort popup lists the criteria, maps keys to `SortCriterion`/`SortDirection`, sends `SortPlaylist`; keybinding + help + config-editor wiring

### Notes
- No DB migration in this PR — `added_at` is read as-is. The follow-up PR #743 adds the migration + DB-dependent criteria.
- Implements upstream issue #709.
