### PR TITLE
fix(playback,server): reset next_track_index after shuffle

### DIFF
--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -982,6 +982,8 @@ impl Playlist {
             self.current_track_index = index;
         }
 
+        self.next_track_index = None;
+
         self.send_stream_ev_pl(UpdatePlaylistEvents::PlaylistShuffled(
             PlaylistShuffledInfo {
                 tracks: self.as_grpc_playlist_tracks().unwrap(),

--- a/playback/src/playlist.rs
+++ b/playback/src/playlist.rs
@@ -1033,6 +1033,8 @@ impl Playlist {
             self.current_track_index = index;
         }
 
+        self.next_track_index = None;
+
         self.send_stream_ev_pl(UpdatePlaylistEvents::PlaylistShuffled(
             PlaylistShuffledInfo {
                 tracks: self.as_grpc_playlist_tracks().unwrap(),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -532,6 +532,7 @@ fn player_loop(
             }
             PlayerCmd::PlaylistShuffle => {
                 player.playlist.write().shuffle();
+                player.run_info.write().take_enqueued();
             }
             PlayerCmd::PlaylistRemoveDeletedTracks => {
                 player.playlist.write().remove_deleted_items();


### PR DESCRIPTION
After `shuffle()` (and later `sort_by_mode()`), `next_track_index` was left stale — pointing to the wrong track in the now-reordered vec. This caused the gapless pipeline to potentially enqueue the wrong next track.

Clearing `run_info.enqueued` alongside ensures the backend does not hold a stale pre-fetched track either.

Relevant discussion: https://github.com/tramhao/termusic/pull/746#issuecomment-5028150578