### PR TITLE
feat(cli): add podcast and playlist subcommands

### DIFF
--- a/lib/src/player.rs
+++ b/lib/src/player.rs
@@ -11,6 +11,17 @@ pub use protobuf::*;
 
 use crate::config::v2::server::LoopMode;
 
+impl SortDirection {
+    /// Swap between `Asc` and `Desc`.
+    #[must_use]
+    pub fn invert(self) -> Self {
+        match self {
+            Self::Asc => Self::Desc,
+            Self::Desc => Self::Asc,
+        }
+    }
+}
+
 // implement transform function for easy use
 impl From<protobuf::Duration> for std::time::Duration {
     fn from(value: protobuf::Duration) -> Self {

--- a/lib/src/podcast/mod.rs
+++ b/lib/src/podcast/mod.rs
@@ -84,6 +84,22 @@ pub enum PodcastSyncResult {
     Error(PodcastFeed),
 }
 
+/// Dispatches `check_feed` for each podcast in the provided list.
+///
+/// This is the shared core used by both the CLI `refresh_all_feeds` and the TUI's
+/// `podcast_refresh_feeds`. Each caller provides its own callback to handle sync results.
+pub fn dispatch_feed_checks(
+    feeds: Vec<PodcastFeed>,
+    max_retries: usize,
+    taskpool: &TaskPool,
+    callback: impl Fn(PodcastSyncResult) + Send + 'static + Clone,
+) {
+    for feed in feeds {
+        let cb = callback.clone();
+        check_feed(feed, max_retries, taskpool, cb);
+    }
+}
+
 /// Spawns a new task to check a feed and retrieve podcast data.
 ///
 /// If `tx_to_main` is closed, no errors will be throws and the task will continue
@@ -259,6 +275,82 @@ fn duration_to_int(duration: Option<&str>) -> Option<i32> {
         1 => times[0],
         _ => None,
     }
+}
+
+/// Refreshes all podcast feeds in the database by re-fetching their RSS data
+/// and updating existing entries with new episodes.
+pub async fn refresh_all_feeds(db_path: &Path, config: &PodcastSettings) -> Result<()> {
+    let db_inst = Database::new(db_path)?;
+    let podcasts = db_inst.get_podcasts()?;
+    let total = podcasts.len();
+
+    if total == 0 {
+        println!("No podcasts to refresh.");
+        return Ok(());
+    }
+
+    println!("Refreshing {total} podcasts...");
+
+    let taskpool = TaskPool::new(usize::from(config.concurrent_downloads_max.get()));
+    let feeds: Vec<PodcastFeed> = podcasts
+        .into_iter()
+        .map(|pod| PodcastFeed::new(Some(pod.id), pod.url.clone(), Some(pod.title.clone())))
+        .collect();
+
+    let (tx_to_main, mut rx_to_main) = unbounded_channel();
+
+    dispatch_feed_checks(
+        feeds,
+        usize::from(config.max_download_retries),
+        &taskpool,
+        move |msg| {
+            let _ = tx_to_main.send(msg);
+        },
+    );
+
+    let mut failure = false;
+    while let Some(message) = rx_to_main.recv().await {
+        match message {
+            PodcastSyncResult::FetchPodcastStart(_) => (),
+            PodcastSyncResult::SyncData((id, pod)) => {
+                let title = &pod.title;
+                match db_inst.update_podcast(id, &pod) {
+                    Ok(_) => {
+                        println!("Updated {title}");
+                    }
+                    Err(err) => {
+                        failure = true;
+                        error!("Error updating {title}, err: {err}");
+                    }
+                }
+            }
+            PodcastSyncResult::NewData(pod) => {
+                let title = &pod.title;
+                // new data for an existing podcast shouldn't normally happen,
+                // but handle it gracefully by inserting
+                match db_inst.insert_podcast(&pod) {
+                    Ok(_) => {
+                        println!("Added {title}");
+                    }
+                    Err(err) => {
+                        failure = true;
+                        error!("Error adding {title}, err: {err}");
+                    }
+                }
+            }
+            PodcastSyncResult::Error(feed) => {
+                failure = true;
+                error!("Error retrieving RSS feed: {}", feed.url);
+            }
+        }
+    }
+
+    if failure {
+        bail!("Process finished with errors.");
+    }
+    println!("Refresh successful.");
+
+    Ok(())
 }
 
 /// Imports a list of podcasts from OPML format, reading from a file. If the `replace` flag is set, this replaces all

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -69,6 +69,14 @@ impl std::fmt::Display for Backend {
 /// Subcommands for the binary
 #[derive(Subcommand, Debug)]
 pub enum Action {
+    /// Podcast management commands.
+    #[command(subcommand)]
+    Podcast(PodcastAction),
+}
+
+/// Podcast management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum PodcastAction {
     /// Export Podcast feeds to a opml file.
     Export {
         #[arg(value_name = "FILE")]
@@ -79,6 +87,8 @@ pub enum Action {
         #[arg(value_name = "FILE")]
         file: PathBuf,
     },
+    /// Refresh all podcast feeds.
+    Refresh,
 }
 
 const DEFAULT_LOGFILE_FILENAME: &str = "termusic-server.log";

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -678,24 +678,33 @@ fn get_path(dir: &Path) -> Result<PathBuf> {
 
 async fn execute_action(action: cli::Action, config: &ServerOverlay) -> Result<()> {
     match action {
-        cli::Action::Import { file } => {
-            println!("need to import from file {}", file.display());
+        cli::Action::Podcast(podcast_action) => match podcast_action {
+            cli::PodcastAction::Import { file } => {
+                println!("need to import from file {}", file.display());
 
-            let path = get_path(&file).context("import cli file-path")?;
-            let config_dir_path =
-                utils::get_app_config_path().context("getting app-config-path")?;
+                let path = get_path(&file).context("import cli file-path")?;
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
 
-            podcast::import_from_opml(&config_dir_path, &config.settings.podcast, &path)
-                .await
-                .context("import opml")?;
-        }
-        cli::Action::Export { file } => {
-            println!("need to export to file {}", file.display());
-            let path = utils::absolute_path(&file)?;
-            let config_dir_path =
-                utils::get_app_config_path().context("getting app-config-path")?;
-            podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
-        }
+                podcast::import_from_opml(&config_dir_path, &config.settings.podcast, &path)
+                    .await
+                    .context("import opml")?;
+            }
+            cli::PodcastAction::Export { file } => {
+                println!("need to export to file {}", file.display());
+                let path = utils::absolute_path(&file)?;
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
+                podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
+            }
+            cli::PodcastAction::Refresh => {
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
+                podcast::refresh_all_feeds(&config_dir_path, &config.settings.podcast)
+                    .await
+                    .context("refresh feeds")?;
+            }
+        },
     };
 
     Ok(())

--- a/tui/src/cli.rs
+++ b/tui/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::{ArgAction, Parser, Subcommand, ValueEnum, builder::ArgPredicate};
 use std::path::PathBuf;
 use termusiclib::config::v2::server::Backend as ConfigBackend;
+use termusiclib::player::{SortCriterion, SortDirection};
 
 #[derive(Parser, Debug)]
 // mostly read from `Cargo.toml`
@@ -66,16 +67,12 @@ impl std::fmt::Display for Backend {
 /// Subcommands for the binary
 #[derive(Subcommand, Debug)]
 pub enum Action {
-    /// Export Podcast feeds to a opml file.
-    Export {
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
-    },
-    /// Import Podcast feeds from a opml file.
-    Import {
-        #[arg(value_name = "FILE")]
-        file: PathBuf,
-    },
+    /// Podcast management commands.
+    #[command(subcommand)]
+    Podcast(PodcastAction),
+    /// Playlist management commands.
+    #[command(subcommand)]
+    Playlist(PlaylistAction),
     /// Skip to next track
     #[command(aliases = &["n"])]
     Next,
@@ -106,12 +103,80 @@ pub enum Action {
     SeekForward,
     /// Seek backward
     SeekBackward,
-    /// Cycle loop mode (list → track → one → list)
-    CycleLoop,
-    /// Shuffle the current playlist
-    Shuffle,
     /// Quit the server
     Quit,
+}
+
+/// Podcast management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum PodcastAction {
+    /// Export Podcast feeds to a opml file.
+    Export {
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+    },
+    /// Import Podcast feeds from a opml file.
+    Import {
+        #[arg(value_name = "FILE")]
+        file: PathBuf,
+    },
+    /// Refresh all podcast feeds.
+    Refresh,
+}
+
+/// Playlist management subcommands.
+#[derive(Subcommand, Debug)]
+pub enum PlaylistAction {
+    /// Shuffle the current playlist.
+    Shuffle,
+    /// Sort the current playlist.
+    Sort {
+        /// Sort criterion.
+        #[arg(value_enum)]
+        criterion: SortCli,
+        /// Invert the default sort direction.
+        #[arg(short, long)]
+        invert: bool,
+    },
+    /// Cycle loop mode (list -> track -> one -> list).
+    CycleLoop,
+}
+
+/// Sort criterion for playlist sorting.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum SortCli {
+    Alphanumeric,
+    #[value(name = "atoz")]
+    AtoZ,
+    #[value(name = "ztoa")]
+    ZtoA,
+    FirstAdded,
+    LastAdded,
+    Duration,
+    HighestDuration,
+    LowestDuration,
+    MostPlayed,
+    LeastPlayed,
+    Recency,
+    Frecency,
+}
+
+impl SortCli {
+    /// Returns the base sort criterion and the default sort direction.
+    pub fn into_criterion_and_direction(self) -> (SortCriterion, SortDirection) {
+        match self {
+            Self::Alphanumeric | Self::AtoZ => (SortCriterion::Alphanumeric, SortDirection::Asc),
+            Self::ZtoA => (SortCriterion::Alphanumeric, SortDirection::Desc),
+            Self::FirstAdded => (SortCriterion::FirstAdded, SortDirection::Asc),
+            Self::LastAdded => (SortCriterion::FirstAdded, SortDirection::Desc),
+            Self::Duration | Self::LowestDuration => (SortCriterion::Duration, SortDirection::Asc),
+            Self::HighestDuration => (SortCriterion::Duration, SortDirection::Desc),
+            Self::MostPlayed => (SortCriterion::MostPlayed, SortDirection::Desc),
+            Self::LeastPlayed => (SortCriterion::MostPlayed, SortDirection::Asc),
+            Self::Recency => (SortCriterion::Recency, SortDirection::Asc),
+            Self::Frecency => (SortCriterion::Frecency, SortDirection::Asc),
+        }
+    }
 }
 
 const DEFAULT_LOGFILE_FILENAME: &str = "termusic-tui.log";

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -532,28 +532,77 @@ fn get_path(dir: &Path) -> Result<PathBuf> {
 
 async fn execute_action(action: cli::Action, config: &CombinedSettings) -> Result<()> {
     match action {
-        cli::Action::Import { file } => {
-            println!("need to import from file {}", file.display());
+        cli::Action::Podcast(podcast_action) => match podcast_action {
+            cli::PodcastAction::Import { file } => {
+                println!("need to import from file {}", file.display());
 
-            let path = get_path(&file).context("import cli file-path")?;
-            let config_dir_path =
-                utils::get_app_config_path().context("getting app-config-path")?;
+                let path = get_path(&file).context("import cli file-path")?;
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
 
-            // to not hold a mutexguard across await points
-            let config_c = config.server.read().settings.podcast.clone();
+                // to not hold a mutexguard across await points
+                let config_c = config.server.read().settings.podcast.clone();
 
-            podcast::import_from_opml(&config_dir_path, &config_c, &path)
-                .await
-                .context("import opml")?;
-        }
-        cli::Action::Export { file } => {
-            println!("need to export to file {}", file.display());
-            let path = utils::absolute_path(&file)?;
-            let config_dir_path =
-                utils::get_app_config_path().context("getting app-config-path")?;
-            podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
+                podcast::import_from_opml(&config_dir_path, &config_c, &path)
+                    .await
+                    .context("import opml")?;
+            }
+            cli::PodcastAction::Export { file } => {
+                println!("need to export to file {}", file.display());
+                let path = utils::absolute_path(&file)?;
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
+                podcast::export_to_opml(&config_dir_path, &path).context("export opml")?;
+            }
+            cli::PodcastAction::Refresh => {
+                let config_dir_path =
+                    utils::get_app_config_path().context("getting app-config-path")?;
+                let config_c = config.server.read().settings.podcast.clone();
+                podcast::refresh_all_feeds(&config_dir_path, &config_c)
+                    .await
+                    .context("refresh feeds")?;
+            }
+        },
+        cli::Action::Playlist(playlist_action) => {
+            execute_playlist_action(playlist_action, config).await?;
         }
         action => execute_media_control(action, config).await?,
+    }
+
+    Ok(())
+}
+
+/// Execute a playlist subcommand by sending the corresponding gRPC
+/// command to the running server.
+async fn execute_playlist_action(
+    action: cli::PlaylistAction,
+    config: &CombinedSettings,
+) -> Result<()> {
+    let pid = find_active_server_process()
+        .context("No active server process found. Start the Server first.")?;
+
+    let (raw_client, _addr) = wait_till_connected(config, pid.as_u32()).await?;
+    let mut playback = ui::Playback::new(raw_client);
+
+    match action {
+        cli::PlaylistAction::Shuffle => {
+            playback.shuffle_playlist().await?;
+            println!("Shuffled playlist");
+        }
+        cli::PlaylistAction::Sort { criterion, invert } => {
+            let (criterion, direction) = criterion.into_criterion_and_direction();
+            let direction = if invert {
+                direction.invert()
+            } else {
+                direction
+            };
+            playback.sort_playlist(criterion, direction).await?;
+            println!("Sorted playlist");
+        }
+        cli::PlaylistAction::CycleLoop => {
+            let mode = playback.cycle_loop().await?;
+            println!("Loop: {}", mode.display(false));
+        }
     }
 
     Ok(())
@@ -626,14 +675,6 @@ async fn execute_media_control(action: Action, config: &CombinedSettings) -> Res
         Action::SeekBackward => {
             playback.seek_backward().await?;
             println!("Seeked backward");
-        }
-        Action::CycleLoop => {
-            let mode = playback.cycle_loop().await?;
-            println!("Loop: {}", mode.display(false));
-        }
-        Action::Shuffle => {
-            playback.shuffle_playlist().await?;
-            println!("Shuffled playlist");
         }
         Action::Quit => {
             playback.quit_server().await?;

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -6,7 +6,7 @@ use reqwest::ClientBuilder;
 use sanitize_filename::{Options, sanitize_with_options};
 use serde_json::Value;
 use termusiclib::config::SharedTuiSettings;
-use termusiclib::podcast::{EpData, PodcastFeed, PodcastNoId, download_list};
+use termusiclib::podcast::{EpData, PodcastFeed, PodcastNoId, dispatch_feed_checks, download_list};
 use tokio::runtime::Handle;
 use tui_realm_stdlib::components::List;
 use tui_realm_stdlib::prop_ext::CommonHighlight;
@@ -667,24 +667,17 @@ impl Model {
                     .collect();
             }
         }
-        for feed in pod_data {
-            let tx_to_main = self.tx_to_main.clone();
-
-            crate::podcast::check_feed(
-                feed,
-                usize::from(
-                    self.config_server
-                        .read()
-                        .settings
-                        .podcast
-                        .max_download_retries,
-                ),
-                &self.taskpool,
-                move |msg| {
-                    let _ = tx_to_main.send(Msg::Podcast(PCMsg::SyncResult(msg)));
-                },
-            );
-        }
+        let tx_to_main = self.tx_to_main.clone();
+        let max_retries = usize::from(
+            self.config_server
+                .read()
+                .settings
+                .podcast
+                .max_download_retries,
+        );
+        dispatch_feed_checks(pod_data, max_retries, &self.taskpool, move |msg| {
+            let _ = tx_to_main.send(Msg::Podcast(PCMsg::SyncResult(msg)));
+        });
         // self.update_tracker_notif();
         self.podcast_sync_feeds_and_episodes();
         Ok(())


### PR DESCRIPTION
## Summary

Adds CLI subcommands for podcast and playlist management:

**Podcast subcommand** (`termusic podcast`):
- `termusic podcast import <FILE>` — import feeds from OPML
- `termusic podcast export <FILE>` — export feeds to OPML
- `termusic podcast refresh` — refresh all podcast feeds

**Playlist subcommand** (`termusic podcast`):
- `termusic playlist shuffle` — shuffle the playlist
- `termusic playlist sort [criterion] [-d direction]` — sort by `alphanumeric` (default), `first-added`, `duration`, `most-played`, `recency`, or `frecency`
- `termusic playlist cycle-loop` — cycle loop mode (list → track → one → list)

## Changes

- **lib**: Added `refresh_all_feeds()` function to `lib/src/podcast/mod.rs`
- **server**: Restructured CLI with `PodcastAction` subcommand, wired `Refresh` in `execute_action()`
- **tui**: Restructured CLI with `PodcastAction` and `PlaylistAction` subcommands, wired both in `execute_action()` + added `execute_playlist_action()` via gRPC

## Notes

- Playlist commands (shuffle, sort, cycle-loop) require a running server — they connect via gRPC
- Podcast commands (import, export, refresh) run locally without a server
- This PR does NOT include the Invidious search fix (separate work)

re #304