### PR TITLE
feat(tui): add custom loop mode display with Nerd Font support

### DIFF
--- a/lib/src/config/v2/server/mod.rs
+++ b/lib/src/config/v2/server/mod.rs
@@ -435,22 +435,14 @@ pub enum LoopMode {
 }
 
 impl LoopMode {
+    /// Return the text name of this loop mode.
     #[must_use]
-    pub fn display(self, display_symbol: bool) -> &'static str {
-        if display_symbol {
-            match self {
-                Self::Track => "🔂",
-                Self::Playlist => "🔁",
-                Self::Random => "🔀",
-                Self::PlaylistOnce => "⮕",
-            }
-        } else {
-            match self {
-                Self::Track => "track",
-                Self::Playlist => "playlist",
-                Self::Random => "random",
-                Self::PlaylistOnce => "playlist once",
-            }
+    pub fn display_text(self) -> &'static str {
+        match self {
+            Self::Track => "track",
+            Self::Playlist => "playlist",
+            Self::Random => "random",
+            Self::PlaylistOnce => "playlist once",
         }
     }
 

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -264,6 +264,7 @@ pub struct StylePlaylist {
 }
 
 impl StylePlaylist {
+    // TODO: consider adding a migration trait similar to what "Keys" has as "CheckConflict"
     #[must_use]
     pub fn effective_loop_mode_display(&self) -> LoopModeDisplay {
         match self.use_loop_mode_symbol_deprecated {

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -23,29 +23,11 @@ pub enum LoopModeDisplay {
 }
 
 impl LoopModeDisplay {
+    /// Get the text to display for the given loopmode.
     #[must_use]
     pub fn display(&self, mode: LoopMode) -> &str {
         match self {
-            Self::Base(base) => match base {
-                LoopModeDisplayBase::Text => match mode {
-                    LoopMode::Track => "track",
-                    LoopMode::Playlist => "playlist",
-                    LoopMode::Random => "random",
-                    LoopMode::PlaylistOnce => "playlist once",
-                },
-                LoopModeDisplayBase::BaseSymbols => match mode {
-                    LoopMode::Track => "🔂",
-                    LoopMode::Playlist => "🔁",
-                    LoopMode::Random => "🔀",
-                    LoopMode::PlaylistOnce => "⮕",
-                },
-                LoopModeDisplayBase::NerdFont => match mode {
-                    LoopMode::Track => nf_loop_icons::TRACK,
-                    LoopMode::Playlist => nf_loop_icons::PLAYLIST,
-                    LoopMode::Random => nf_loop_icons::RANDOM,
-                    LoopMode::PlaylistOnce => nf_loop_icons::PLAYLIST_ONCE,
-                },
-            },
+            Self::Base(base) => base.display(mode),
             Self::Custom(symbols) => match mode {
                 LoopMode::Track => &symbols.track,
                 LoopMode::Playlist => &symbols.playlist,
@@ -78,27 +60,14 @@ impl Default for CustomLoopSymbols {
     }
 }
 
+/// Convert a existing [`LoopModeDisplayBase`] to a Custom one to customize individual fields.
 impl From<LoopModeDisplayBase> for CustomLoopSymbols {
     fn from(value: LoopModeDisplayBase) -> Self {
-        match value {
-            LoopModeDisplayBase::Text => Self {
-                track: "track".into(),
-                playlist: "playlist".into(),
-                random: "random".into(),
-                playlist_once: "playlist once".into(),
-            },
-            LoopModeDisplayBase::BaseSymbols => Self {
-                track: "🔂".into(),
-                playlist: "🔁".into(),
-                random: "🔀".into(),
-                playlist_once: "⮕".into(),
-            },
-            LoopModeDisplayBase::NerdFont => Self {
-                track: nf_loop_icons::TRACK.into(),
-                playlist: nf_loop_icons::PLAYLIST.into(),
-                random: nf_loop_icons::RANDOM.into(),
-                playlist_once: nf_loop_icons::PLAYLIST_ONCE.into(),
-            },
+        Self {
+            track: value.display(LoopMode::Track).to_string(),
+            playlist: value.display(LoopMode::Playlist).to_string(),
+            random: value.display(LoopMode::Random).to_string(),
+            playlist_once: value.display(LoopMode::PlaylistOnce).to_string(),
         }
     }
 }
@@ -110,6 +79,28 @@ pub enum LoopModeDisplayBase {
     Text,
     BaseSymbols,
     NerdFont,
+}
+
+impl LoopModeDisplayBase {
+    /// Get the text to display for the given loopmode.
+    #[must_use]
+    pub fn display(&self, mode: LoopMode) -> &'static str {
+        match self {
+            LoopModeDisplayBase::Text => mode.display_text(),
+            LoopModeDisplayBase::BaseSymbols => match mode {
+                LoopMode::Track => "🔂",
+                LoopMode::Playlist => "🔁",
+                LoopMode::Random => "🔀",
+                LoopMode::PlaylistOnce => "⮕",
+            },
+            LoopModeDisplayBase::NerdFont => match mode {
+                LoopMode::Track => nf_loop_icons::TRACK,
+                LoopMode::Playlist => nf_loop_icons::PLAYLIST,
+                LoopMode::Random => nf_loop_icons::RANDOM,
+                LoopMode::PlaylistOnce => nf_loop_icons::PLAYLIST_ONCE,
+            },
+        }
+    }
 }
 
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -1,7 +1,116 @@
 use serde::{Deserialize, Serialize};
 use tuirealm::props::Color;
 
-/// All values correspond to the Theme's selected color for that
+use crate::config::v2::server::LoopMode;
+
+/// Nerd Font icons for loop mode display (from the Nerd Font PUA range).
+mod nf_loop_icons {
+    pub const TRACK: &str = "\u{f0456}";
+    pub const PLAYLIST: &str = "\u{f0458}";
+    pub const RANDOM: &str = "\u{f049f}";
+    pub const PLAYLIST_ONCE: &str = "\u{f049e}";
+}
+
+/// Display mode for loop/shuffle icons in the playlist header.
+///
+/// Serialized as a string for built-in modes: `"text"`, `"base_symbols"`, `"nerd_font"`
+/// or as an object for custom: `{ "track": "...", "playlist": "...", "random": "...", "playlist_once": "..." }`
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum LoopModeDisplay {
+    Base(LoopModeDisplayBase),
+    Custom(CustomLoopSymbols),
+}
+
+/// User-defined symbols for each loop mode.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct CustomLoopSymbols {
+    pub track: String,
+    pub playlist: String,
+    pub random: String,
+    pub playlist_once: String,
+}
+
+impl Default for CustomLoopSymbols {
+    fn default() -> Self {
+        Self::from(LoopModeDisplayBase::BaseSymbols)
+    }
+}
+
+impl From<LoopModeDisplayBase> for CustomLoopSymbols {
+    fn from(value: LoopModeDisplayBase) -> Self {
+        match value {
+            LoopModeDisplayBase::Text => Self {
+                track: "track".into(),
+                playlist: "playlist".into(),
+                random: "random".into(),
+                playlist_once: "playlist once".into(),
+            },
+            LoopModeDisplayBase::BaseSymbols => Self {
+                track: "🔂".into(),
+                playlist: "🔁".into(),
+                random: "🔀".into(),
+                playlist_once: "⮕".into(),
+            },
+            LoopModeDisplayBase::NerdFont => Self {
+                track: nf_loop_icons::TRACK.into(),
+                playlist: nf_loop_icons::PLAYLIST.into(),
+                random: nf_loop_icons::RANDOM.into(),
+                playlist_once: nf_loop_icons::PLAYLIST_ONCE.into(),
+            },
+        }
+    }
+}
+
+/// Built-in loop mode display modes.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopModeDisplayBase {
+    Text,
+    BaseSymbols,
+    NerdFont,
+}
+
+impl LoopModeDisplay {
+    #[must_use]
+    pub fn display(&self, mode: LoopMode) -> &str {
+        match self {
+            Self::Base(base) => match base {
+                LoopModeDisplayBase::Text => match mode {
+                    LoopMode::Track => "track",
+                    LoopMode::Playlist => "playlist",
+                    LoopMode::Random => "random",
+                    LoopMode::PlaylistOnce => "playlist once",
+                },
+                LoopModeDisplayBase::BaseSymbols => match mode {
+                    LoopMode::Track => "🔂",
+                    LoopMode::Playlist => "🔁",
+                    LoopMode::Random => "🔀",
+                    LoopMode::PlaylistOnce => "⮕",
+                },
+                LoopModeDisplayBase::NerdFont => match mode {
+                    LoopMode::Track => nf_loop_icons::TRACK,
+                    LoopMode::Playlist => nf_loop_icons::PLAYLIST,
+                    LoopMode::Random => nf_loop_icons::RANDOM,
+                    LoopMode::PlaylistOnce => nf_loop_icons::PLAYLIST_ONCE,
+                },
+            },
+            Self::Custom(symbols) => match mode {
+                LoopMode::Track => &symbols.track,
+                LoopMode::Playlist => &symbols.playlist,
+                LoopMode::Random => &symbols.random,
+                LoopMode::PlaylistOnce => &symbols.playlist_once,
+            },
+        }
+    }
+}
+
+impl Default for LoopModeDisplay {
+    fn default() -> Self {
+        Self::Base(LoopModeDisplayBase::BaseSymbols)
+    }
+}
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub enum ColorTermusic {
     /// Reset to Terminal default (resulting color will depend on what context it is set)
@@ -153,10 +262,23 @@ pub struct StylePlaylist {
     /// Playlist current playing track symbol
     pub current_track_symbol: String,
 
-    /// If enabled use a symbol for the Loop-Mode, otherwise use text
-    ///
-    /// Example: true -> "Mode: 🔁"; false -> "Mode: playlist"
-    pub use_loop_mode_symbol: bool,
+    /// Display mode for loop/shuffle icons in the playlist header.
+    pub loop_mode_display: LoopModeDisplay,
+
+    /// Deprecated: reads from `use_loop_mode_symbol` in config for backward compat.
+    #[serde(skip_serializing, rename = "use_loop_mode_symbol")]
+    pub use_loop_mode_symbol_deprecated: Option<bool>,
+}
+
+impl StylePlaylist {
+    #[must_use]
+    pub fn effective_loop_mode_display(&self) -> LoopModeDisplay {
+        match self.use_loop_mode_symbol_deprecated {
+            Some(true) => LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols),
+            Some(false) => LoopModeDisplay::Base(LoopModeDisplayBase::Text),
+            None => self.loop_mode_display.clone(),
+        }
+    }
 }
 
 impl Default for StylePlaylist {
@@ -170,7 +292,8 @@ impl Default for StylePlaylist {
             highlight_symbol: "🚀".into(),
             current_track_symbol: "►".into(),
 
-            use_loop_mode_symbol: true,
+            loop_mode_display: LoopModeDisplay::default(),
+            use_loop_mode_symbol_deprecated: None,
         }
     }
 }
@@ -269,8 +392,8 @@ impl Default for StyleFallback {
 #[cfg(feature = "config-v1-compat")]
 mod v1_interop {
     use super::{
-        ColorTermusic, StyleFallback, StyleImportantPopup, StyleLibrary, StyleLyric, StylePlaylist,
-        StyleProgress, Styles,
+        ColorTermusic, LoopModeDisplay, LoopModeDisplayBase, StyleFallback, StyleImportantPopup,
+        StyleLibrary, StyleLyric, StylePlaylist, StyleProgress, Styles,
     };
     use crate::config::v1;
 
@@ -315,7 +438,11 @@ mod v1_interop {
 
     impl From<&v1::Settings> for StylePlaylist {
         fn from(value: &v1::Settings) -> Self {
-            let use_loop_mode_symbol = value.playlist_display_symbol;
+            let loop_mode_display = if value.playlist_display_symbol {
+                LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols)
+            } else {
+                LoopModeDisplay::Base(LoopModeDisplayBase::Text)
+            };
             let value = &value.style_color_symbol;
             Self {
                 foreground_color: value.playlist_foreground.into(),
@@ -324,7 +451,8 @@ mod v1_interop {
                 highlight_color: value.playlist_highlight.into(),
                 highlight_symbol: value.playlist_highlight_symbol.clone(),
                 current_track_symbol: value.currently_playing_track_symbol.clone(),
-                use_loop_mode_symbol,
+                loop_mode_display,
+                use_loop_mode_symbol_deprecated: None,
             }
         }
     }
@@ -411,7 +539,8 @@ mod v1_interop {
 
                 highlight_symbol: "🚀".into(),
                 current_track_symbol: "►".into(),
-                use_loop_mode_symbol: true,
+                loop_mode_display: LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols),
+                use_loop_mode_symbol_deprecated: None,
             };
             assert_eq!(converted.playlist, expected_playlist);
 
@@ -456,5 +585,32 @@ mod v1_interop {
                 }
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_serde_custom_loop_symbols_with_partial_config() {
+        let input = r#"{"track":"A"}"#;
+        let symbols: CustomLoopSymbols = serde_json::from_str(input).unwrap();
+        assert_eq!(symbols.track, "A");
+        assert_eq!(symbols.playlist, CustomLoopSymbols::default().playlist);
+        assert_eq!(symbols.random, CustomLoopSymbols::default().random);
+        assert_eq!(
+            symbols.playlist_once,
+            CustomLoopSymbols::default().playlist_once
+        );
+    }
+
+    #[test]
+    fn should_convert_base_display_to_custom_symbols() {
+        let nerd_font: CustomLoopSymbols = LoopModeDisplayBase::NerdFont.into();
+        assert_eq!(nerd_font.track, nf_loop_icons::TRACK);
+        assert_eq!(nerd_font.playlist, nf_loop_icons::PLAYLIST);
+        assert_eq!(nerd_font.random, nf_loop_icons::RANDOM);
+        assert_eq!(nerd_font.playlist_once, nf_loop_icons::PLAYLIST_ONCE);
     }
 }

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -40,7 +40,7 @@ impl LoopModeDisplay {
 
 impl Default for LoopModeDisplay {
     fn default() -> Self {
-        Self::Base(LoopModeDisplayBase::BaseSymbols)
+        Self::Base(LoopModeDisplayBase::default())
     }
 }
 
@@ -73,10 +73,11 @@ impl From<LoopModeDisplayBase> for CustomLoopSymbols {
 }
 
 /// Built-in loop mode display modes.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopModeDisplayBase {
     Text,
+    #[default]
     BaseSymbols,
     NerdFont,
 }

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -73,7 +73,7 @@ impl From<LoopModeDisplayBase> for CustomLoopSymbols {
 }
 
 /// Built-in loop mode display modes.
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LoopModeDisplayBase {
     Text,

--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -22,6 +22,46 @@ pub enum LoopModeDisplay {
     Custom(CustomLoopSymbols),
 }
 
+impl LoopModeDisplay {
+    #[must_use]
+    pub fn display(&self, mode: LoopMode) -> &str {
+        match self {
+            Self::Base(base) => match base {
+                LoopModeDisplayBase::Text => match mode {
+                    LoopMode::Track => "track",
+                    LoopMode::Playlist => "playlist",
+                    LoopMode::Random => "random",
+                    LoopMode::PlaylistOnce => "playlist once",
+                },
+                LoopModeDisplayBase::BaseSymbols => match mode {
+                    LoopMode::Track => "🔂",
+                    LoopMode::Playlist => "🔁",
+                    LoopMode::Random => "🔀",
+                    LoopMode::PlaylistOnce => "⮕",
+                },
+                LoopModeDisplayBase::NerdFont => match mode {
+                    LoopMode::Track => nf_loop_icons::TRACK,
+                    LoopMode::Playlist => nf_loop_icons::PLAYLIST,
+                    LoopMode::Random => nf_loop_icons::RANDOM,
+                    LoopMode::PlaylistOnce => nf_loop_icons::PLAYLIST_ONCE,
+                },
+            },
+            Self::Custom(symbols) => match mode {
+                LoopMode::Track => &symbols.track,
+                LoopMode::Playlist => &symbols.playlist,
+                LoopMode::Random => &symbols.random,
+                LoopMode::PlaylistOnce => &symbols.playlist_once,
+            },
+        }
+    }
+}
+
+impl Default for LoopModeDisplay {
+    fn default() -> Self {
+        Self::Base(LoopModeDisplayBase::BaseSymbols)
+    }
+}
+
 /// User-defined symbols for each loop mode.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
@@ -72,45 +112,6 @@ pub enum LoopModeDisplayBase {
     NerdFont,
 }
 
-impl LoopModeDisplay {
-    #[must_use]
-    pub fn display(&self, mode: LoopMode) -> &str {
-        match self {
-            Self::Base(base) => match base {
-                LoopModeDisplayBase::Text => match mode {
-                    LoopMode::Track => "track",
-                    LoopMode::Playlist => "playlist",
-                    LoopMode::Random => "random",
-                    LoopMode::PlaylistOnce => "playlist once",
-                },
-                LoopModeDisplayBase::BaseSymbols => match mode {
-                    LoopMode::Track => "🔂",
-                    LoopMode::Playlist => "🔁",
-                    LoopMode::Random => "🔀",
-                    LoopMode::PlaylistOnce => "⮕",
-                },
-                LoopModeDisplayBase::NerdFont => match mode {
-                    LoopMode::Track => nf_loop_icons::TRACK,
-                    LoopMode::Playlist => nf_loop_icons::PLAYLIST,
-                    LoopMode::Random => nf_loop_icons::RANDOM,
-                    LoopMode::PlaylistOnce => nf_loop_icons::PLAYLIST_ONCE,
-                },
-            },
-            Self::Custom(symbols) => match mode {
-                LoopMode::Track => &symbols.track,
-                LoopMode::Playlist => &symbols.playlist,
-                LoopMode::Random => &symbols.random,
-                LoopMode::PlaylistOnce => &symbols.playlist_once,
-            },
-        }
-    }
-}
-
-impl Default for LoopModeDisplay {
-    fn default() -> Self {
-        Self::Base(LoopModeDisplayBase::BaseSymbols)
-    }
-}
 #[derive(Copy, Clone, Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub enum ColorTermusic {
     /// Reset to Terminal default (resulting color will depend on what context it is set)

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -601,7 +601,7 @@ async fn execute_playlist_action(
         }
         cli::PlaylistAction::CycleLoop => {
             let mode = playback.cycle_loop().await?;
-            println!("Loop: {}", mode.display(false));
+            println!("Loop: {}", mode.display_text());
         }
     }
 

--- a/tui/src/ui/components/config_editor/general.rs
+++ b/tui/src/ui/components/config_editor/general.rs
@@ -23,7 +23,9 @@
  */
 use anyhow::Result;
 use termusiclib::config::v2::server::{Backend, ComProtocol, default_uds_socket_path};
-use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
+use termusiclib::config::v2::tui::theme::styles::{
+    ColorTermusic, LoopModeDisplay, LoopModeDisplayBase,
+};
 use termusiclib::config::v2::tui::{Alignment as XywhAlign, keys::Keys};
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use tui_realm_stdlib::components::{Input, Radio};
@@ -313,11 +315,22 @@ pub struct PlaylistDisplaySymbol {
 impl PlaylistDisplaySymbol {
     pub fn new(config: SharedTuiSettings) -> Self {
         let config_r = config.read();
-        let enabled = config_r.settings.theme.style.playlist.use_loop_mode_symbol;
-        let component = common_radio_comp(&config_r, " Use symbols for playlist loop mode? ")
-            .choices(["Yes", "No"])
+        let display = config_r
+            .settings
+            .theme
+            .style
+            .playlist
+            .effective_loop_mode_display();
+        let value = match &display {
+            LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols) => 0,
+            LoopModeDisplay::Base(LoopModeDisplayBase::NerdFont) => 1,
+            LoopModeDisplay::Base(LoopModeDisplayBase::Text) => 2,
+            LoopModeDisplay::Custom(_) => 3,
+        };
+        let component = common_radio_comp(&config_r, " Loop mode display mode? ")
+            .choices(["Base Symbols", "Nerd Font", "Text", "Custom"])
             .rewind(true)
-            .value(usize::from(!enabled));
+            .value(value);
 
         drop(config_r);
         Self { component, config }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -34,6 +34,7 @@ use termusiclib::config::v2::server::{
 };
 use termusiclib::config::v2::tui::Alignment as XywhAlign;
 use termusiclib::config::v2::tui::theme::ThemeColors;
+use termusiclib::config::v2::tui::theme::styles::{LoopModeDisplay, LoopModeDisplayBase};
 use termusiclib::utils::get_app_config_path;
 use tuirealm::application::Application;
 use tuirealm::props::{
@@ -656,15 +657,22 @@ impl Model {
             config_tui.settings.behavior.confirm_quit = matches!(exit_confirmation, 0);
         }
 
-        if let Ok(State::Single(StateValue::Usize(display_symbol))) = self.app.state(
+        if let Ok(State::Single(StateValue::Usize(display_idx))) = self.app.state(
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)),
         ) {
-            config_tui
-                .settings
-                .theme
-                .style
-                .playlist
-                .use_loop_mode_symbol = matches!(display_symbol, 0);
+            let playlist_style = &mut config_tui.settings.theme.style.playlist;
+            let display = match display_idx {
+                3 => match &playlist_style.loop_mode_display {
+                    LoopModeDisplay::Custom(_) => playlist_style.loop_mode_display.clone(),
+                    LoopModeDisplay::Base(base) => LoopModeDisplay::Custom(base.clone().into()),
+                },
+                1 => LoopModeDisplay::Base(LoopModeDisplayBase::NerdFont),
+                2 => LoopModeDisplay::Base(LoopModeDisplayBase::Text),
+                _ => LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols),
+            };
+            playlist_style.loop_mode_display = display;
+            // Clear the deprecated field so the new loop_mode_display takes effect immediately
+            playlist_style.use_loop_mode_symbol_deprecated = None;
         }
 
         if let Ok(State::Single(StateValue::String(random_track_quantity_str))) = self.app.state(

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -661,16 +661,15 @@ impl Model {
             &Id::ConfigEditor(IdConfigEditor::General(IdCEGeneral::PlaylistDisplaySymbol)),
         ) {
             let playlist_style = &mut config_tui.settings.theme.style.playlist;
-            let display = match display_idx {
-                3 => match &playlist_style.loop_mode_display {
-                    LoopModeDisplay::Custom(_) => playlist_style.loop_mode_display.clone(),
-                    LoopModeDisplay::Base(base) => LoopModeDisplay::Custom(base.clone().into()),
+            playlist_style.loop_mode_display = match display_idx {
+                3 => match std::mem::take(&mut playlist_style.loop_mode_display) {
+                    LoopModeDisplay::Custom(v) => LoopModeDisplay::Custom(v),
+                    LoopModeDisplay::Base(base) => LoopModeDisplay::Custom(base.into()),
                 },
                 1 => LoopModeDisplay::Base(LoopModeDisplayBase::NerdFont),
                 2 => LoopModeDisplay::Base(LoopModeDisplayBase::Text),
                 _ => LoopModeDisplay::Base(LoopModeDisplayBase::BaseSymbols),
             };
-            playlist_style.loop_mode_display = display;
             // Clear the deprecated field so the new loop_mode_display takes effect immediately
             playlist_style.use_loop_mode_symbol_deprecated = None;
         }

--- a/tui/src/ui/components/playlist/playlist_comp.rs
+++ b/tui/src/ui/components/playlist/playlist_comp.rs
@@ -826,20 +826,20 @@ impl Model {
     pub fn playlist_update_title(&mut self) {
         let playlist = self.playback.playlist.read();
         let duration = playlist.tracks().iter().filter_map(Track::duration).sum();
-        let display_symbol = self
+        let display = self
             .config_tui
             .read()
             .settings
             .theme
             .style
             .playlist
-            .use_loop_mode_symbol;
+            .effective_loop_mode_display();
         let loop_mode = self.config_server.read().settings.player.loop_mode;
         let title = format!(
             "\u{2500} Playlist \u{2500}\u{2500}\u{2524} Total {} tracks | {} | Mode: {} \u{251c}\u{2500}",
             playlist.len(),
             DurationFmtShort(duration),
-            loop_mode.display(display_symbol),
+            display.display(loop_mode),
         );
         drop(playlist);
         self.app


### PR DESCRIPTION
Adds a `LoopModeDisplay` enum replacing the old `use_loop_mode_symbol` bool, supporting:

- `text` — plain text ("track", "playlist", etc.)
- `base_symbols` — emoji (🔂, 🔁, 🔀, ⮕) — default
- `nerd_font` — Nerd Font icons (󰑖, 󰑘, 󰒟, 󰒞)
- `custom` — user-defined symbols per mode

The old `use_loop_mode_symbol` field is deprecated but still read for backward compatibility. Config editor updated with a 3-option radio (Custom must be set manually in tui.toml).

fixes #751