### PR TITLE
Fix: correctly map "Foreground" and "Background" colors to "Reset"

### DIFF
--- a/lib/src/config/v2/tui/theme/styles.rs
+++ b/lib/src/config/v2/tui/theme/styles.rs
@@ -170,12 +170,16 @@ impl ColorTermusic {
     }
 }
 
-/// Mainly necessary for Native Theme
+/// Necessary for Native Theme
 impl From<ColorTermusic> for Color {
     fn from(value: ColorTermusic) -> Self {
         match value {
-            ColorTermusic::Reset => Color::Reset,
-            ColorTermusic::Background | ColorTermusic::Black => Color::Black,
+            // "Foreground" and "Background" color do not exist like that in ASCII color modes, and "Reset" is the only one to actually get those colors properly.
+            // Otherwise there is a mismatch between the terminal themes "Black" and "Background"; not all themes have them set the same.
+            ColorTermusic::Reset | ColorTermusic::Background | ColorTermusic::Foreground => {
+                Color::Reset
+            }
+            ColorTermusic::Black => Color::Black,
             ColorTermusic::Red => Color::Red,
             ColorTermusic::Green => Color::Green,
             ColorTermusic::Yellow => Color::Yellow,
@@ -190,7 +194,7 @@ impl From<ColorTermusic> for Color {
             ColorTermusic::LightBlue => Color::LightBlue,
             ColorTermusic::LightMagenta => Color::LightMagenta,
             ColorTermusic::LightCyan => Color::LightCyan,
-            ColorTermusic::Foreground | ColorTermusic::LightWhite => Color::White,
+            ColorTermusic::LightWhite => Color::White,
         }
     }
 }


### PR DESCRIPTION
As there are no analouges aside from "Reset".

BREAKING CHANGE: Using the native theme, "Foreground" and "Background" colors are now mapped according to the terminals "Foreground" and "Background" instead of into "White" and "Black".

Effectively this means that existing configs will now display differently, hence the "BREAKING CHANGE", but the old behavior can still be achieved by setting all "Foreground" values to "White" and all "Background" values to "Black".

fixes #755