### PR TITLE
Lint PR Commit style

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,28 @@
+# Not run as part of pre-commit checks because they don't handle sending the correct commit
+# range to `committed`
+name: Check PR Style
+on: [pull_request]
+
+permissions:
+  contents: read
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  committed:
+    name: Lint Commits
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+    - name: Lint Commits
+      uses: crate-ci/committed@faeed42f2e10c244533a01525f13c4d8b6ce383f # v1.1.11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ Specifically, we use:
 1. For types:
    - `feat`: Feature work, which would not fall into `refactor`, `fix` or `style`.
    - `fix`: A minor fix, which does not change much overall.
-   - `refactor`: A Code refactor that does not change the observable behavior of the code.
+   - `perf`: A change that does not change the observable behavior and is a performance fix.
+   - `refactor`: A Code refactor that does not change the observable behavior of the code. (except performance changes)
    - `style`: A style only change. (ex. `cargo clippy --fix`)
    - `deps`: A Dependency update. (includes updates necessary for breaking dependency updates)
    - `docs`: Documentation update. (ex. for `README`; code should use `style` instead)

--- a/committed.toml
+++ b/committed.toml
@@ -26,5 +26,6 @@ allowed_types = [
     "test",
     "deps",
     "revert",
+    "merge",
 ]
 allowed_scopes = []

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,30 @@
+# We currently dont enforce a subject or line length
+subject_length = 0
+hard_line_length = 0
+line_length = 0
+# We dont require the subject to be capitalized (automatically done in changelog generation)
+subject_capitalized = false
+# Subject lines are a headlines, they dont need punctuation
+subject_not_punctuated = true
+# For now, allow all subject writing
+imperative_subject = false
+# dont allow "!fixup" commits
+no_fixup = true
+# dont allow commits that contain "WIP"
+no_wip = true
+# We use merge commits; disabled for PRs though
+merge_commit = true
+style = "conventional"
+allowed_types = [
+    "fix",
+    "feat",
+    "chore",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "deps",
+    "revert",
+]
+allowed_scopes = []


### PR DESCRIPTION
This change adds `committed` as our commit linter.
For now this will only run in the CI for a PR.
This helps us enforce our CONTRIBUTING Commit message style and allows quick feedback without having to wait for a review (which might even miss this).

As a aside, adds a missing `perf` type for the commit messages.

re #708
Works in conjunction with #754 
closes #758 (showcase PR)