### PR TITLE
Fix Rust 1.98 new lint warnings

### DIFF
--- a/lib/src/songtag/kugou/mod.rs
+++ b/lib/src/songtag/kugou/mod.rs
@@ -45,7 +45,7 @@ impl SongTagService for Api {
         keywords: &str,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<SongTag>, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<Vec<SongTag>, super::service::SongTagServiceError<Self::Error>> {
         let offset_str = offset.to_string();
         let limit_str = limit.to_string();
 
@@ -78,7 +78,7 @@ impl SongTagService for Api {
     async fn get_lyrics(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<String, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<String, super::service::SongTagServiceError<Self::Error>> {
         if song.service_provider() != ServiceProvider::Kugou {
             return Err(SongTagServiceError::IncorrectService(
                 song.service_provider().to_string(),
@@ -138,7 +138,7 @@ impl SongTagService for Api {
     async fn get_picture(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<Picture, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<Picture, super::service::SongTagServiceError<Self::Error>> {
         if song.service_provider() != ServiceProvider::Kugou {
             return Err(SongTagServiceError::IncorrectService(
                 song.service_provider().to_string(),
@@ -194,7 +194,7 @@ impl SongTagService for Api {
     async fn download_recording(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<String, SongTagServiceError<Self::Error>> {
+    ) -> Result<String, SongTagServiceError<Self::Error>> {
         if song.service_provider() != ServiceProvider::Kugou {
             return Err(SongTagServiceError::IncorrectService(
                 song.service_provider().to_string(),

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -147,19 +147,20 @@ impl SongTagService for Api {
         }
     }
 
-    async fn download_recording(
+    fn download_recording(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<String, super::service::SongTagServiceError<Self::Error>> {
+    ) -> impl Future<Output = Result<String, super::service::SongTagServiceError<Self::Error>>>
+    {
         // this function is to get the url for downloading, which in migu does not require extra fetching
         // so if its available, use it, otherwise report "NotSupported"
         if let Some(UrlTypes::FreeDownloadable(url)) = song.url.as_ref() {
-            return Ok(url.clone());
+            return std::future::ready(Ok(url.clone()));
         }
 
-        Err(SongTagServiceError::NotSupported(
+        std::future::ready(Err(SongTagServiceError::NotSupported(
             SongTagServiceErrorWhere::DownloadRecording,
             Self::display_name(),
-        ))
+        )))
     }
 }

--- a/lib/src/songtag/migu/mod.rs
+++ b/lib/src/songtag/migu/mod.rs
@@ -46,7 +46,7 @@ impl SongTagService for Api {
         keywords: &str,
         offset: u32,
         limit: u32,
-    ) -> std::result::Result<Vec<SongTag>, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<Vec<SongTag>, super::service::SongTagServiceError<Self::Error>> {
         // let offset = offset.to_string();
         // let limit = limit.to_string();
 
@@ -74,7 +74,7 @@ impl SongTagService for Api {
     async fn get_lyrics(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<String, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<String, super::service::SongTagServiceError<Self::Error>> {
         if song.service_provider() != ServiceProvider::Migu {
             return Err(SongTagServiceError::IncorrectService(
                 song.service_provider().to_string(),
@@ -105,7 +105,7 @@ impl SongTagService for Api {
     async fn get_picture(
         &self,
         song: &SongTag,
-    ) -> std::result::Result<Picture, super::service::SongTagServiceError<Self::Error>> {
+    ) -> Result<Picture, super::service::SongTagServiceError<Self::Error>> {
         if song.service_provider() != ServiceProvider::Migu {
             return Err(SongTagServiceError::IncorrectService(
                 song.service_provider().to_string(),

--- a/playback/benches/async_ring.rs
+++ b/playback/benches/async_ring.rs
@@ -28,7 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         runtime.block_on(async {
             loop {
                 let data = [1u8; 256];
-                if prod.write_data(&data).await.is_err() {
+                if prod.write_data(&data).await.is_none() {
                     break;
                 }
             }

--- a/playback/src/backends/rusty/mod.rs
+++ b/playback/src/backends/rusty/mod.rs
@@ -411,7 +411,7 @@ async fn decode_task(mut decoder: Symphonia, mut prod: AsyncRingSourceProvider) 
                 // only check the result and advance the buffer if the send buffer is not 0-length
                 // as "written" in that case will be "Err".
                 if !exhausted_buffer {
-                    written.ok()?;
+                    written?;
                     decoder.advance_offset(decoder.get_buffer().len());
                 }
             },
@@ -426,12 +426,12 @@ async fn decode_task(mut decoder: Symphonia, mut prod: AsyncRingSourceProvider) 
         let spec_len = decoder.get_spec();
         if decoder.decode_once().is_none() {
             trace!("Sending decoder EOS");
-            prod.new_eos().await.ok()?;
+            prod.new_eos().await?;
             send_eos = true;
         }
         let new_spec = decoder.get_spec();
         if spec_len != new_spec {
-            prod.new_spec(&new_spec.0, new_spec.1).await.ok()?;
+            prod.new_spec(&new_spec.0, new_spec.1).await?;
         }
     }
 }

--- a/playback/src/backends/rusty/source/async_ring/mod.rs
+++ b/playback/src/backends/rusty/source/async_ring/mod.rs
@@ -72,15 +72,9 @@ impl AsyncRingSourceProvider {
     ///
     /// Returns [`Ok(count)`](Ok) if the message is written, with the length, [`Err`] if closed.
     ///
-    /// # Errors
-    ///
-    /// Ringbuffer closed and no more data available.
+    /// Returns [`None`] if the ring buffer is closed.
     #[allow(clippy::missing_panics_doc)] // https://github.com/rust-lang/rust-clippy/issues/14534
-    pub async fn new_spec(
-        &mut self,
-        spec: &AudioSpec,
-        current_span_len: usize,
-    ) -> Result<usize, ()> {
+    pub async fn new_spec(&mut self, spec: &AudioSpec, current_span_len: usize) -> Option<usize> {
         let mut msg_buf = [0; RingMsgWrite2::get_msg_size(MessageSpec::MESSAGE_SIZE)];
         // SAFETY: we allocated the exact necessary size, this can never fail
         // #[expect(
@@ -89,20 +83,18 @@ impl AsyncRingSourceProvider {
         // )]
         let _ = RingMsgWrite2::try_write_spec(spec, current_span_len, &mut msg_buf).unwrap();
 
-        self.inner.push_exact(&msg_buf).await.map_err(|_| ())?;
+        self.inner.push_exact(&msg_buf).await.ok()?;
 
-        Ok(msg_buf.len())
+        Some(msg_buf.len())
     }
 
     /// Write a new data message, without the buffer yet.
     ///
     /// Returns [`Ok(count)`](Ok) if the message is written, with the length, [`Err`] if closed.
     ///
-    /// # Errors
-    ///
-    /// Ringbuffer closed and no more data available.
+    /// Returns [`None`] if the ring buffer is closed.
     #[allow(clippy::missing_panics_doc)] // https://github.com/rust-lang/rust-clippy/issues/14534
-    async fn new_data(&mut self, length: usize) -> Result<usize, ()> {
+    async fn new_data(&mut self, length: usize) -> Option<usize> {
         let mut msg_buf = [0; RingMsgWrite2::get_msg_size(MessageDataFirst::MESSAGE_SIZE)];
         // SAFETY: we allocated the exact necessary size, this can never fail
         // #[expect(
@@ -111,11 +103,11 @@ impl AsyncRingSourceProvider {
         // )]
         let (data, _written) = RingMsgWrite2::try_write_data_first(length, &mut msg_buf).unwrap();
 
-        self.inner.push_exact(&msg_buf).await.map_err(|_| ())?;
+        self.inner.push_exact(&msg_buf).await.ok()?;
 
         self.data = Some(data);
 
-        Ok(msg_buf.len())
+        Some(msg_buf.len())
     }
 
     /// Write a buffer's content.
@@ -124,32 +116,28 @@ impl AsyncRingSourceProvider {
     ///
     /// Returns [`Ok(count)`](Ok) if the message is written, with the length, [`Err`] if closed.
     ///
-    /// # Errors
-    ///
-    /// Ringbuffer closed and no more data available.
-    async fn write_data_inner(&mut self, data: &[u8]) -> Result<usize, ()> {
+    /// Returns [`None`] if the ring buffer is closed.
+    async fn write_data_inner(&mut self, data: &[u8]) -> Option<usize> {
         let Some(msg) = &mut self.data else {
             unimplemented!("This should be checked outside of the function");
         };
 
         let buf = &data[msg.get_range()];
-        self.inner.push_exact(buf).await.map_err(|_| ())?;
+        self.inner.push_exact(buf).await.ok()?;
         msg.advance_read(buf.len());
 
-        Ok(buf.len())
+        Some(buf.len())
     }
 
     /// Write a given buffer as a data message.
     ///
     /// Returns [`Ok(count)`](Ok) if the message is written, with the length, [`Err`] if closed.
     ///
-    /// # Errors
-    ///
-    /// Ringbuffer closed and no more data available.
+    /// Returns [`None`] if the ring buffer is closed.
     #[allow(clippy::missing_panics_doc)] // https://github.com/rust-lang/rust-clippy/issues/14534
-    pub async fn write_data(&mut self, data: &[u8]) -> Result<usize, ()> {
+    pub async fn write_data(&mut self, data: &[u8]) -> Option<usize> {
         if data.is_empty() {
-            return Err(());
+            return None;
         }
 
         let mut written = 0;
@@ -167,18 +155,16 @@ impl AsyncRingSourceProvider {
 
         self.data.take();
 
-        Ok(written)
+        Some(written)
     }
 
     /// Write a EOS message.
     ///
     /// Returns [`Ok(count)`](Ok) if the message is written, with the length, [`Err`] if closed.
     ///
-    /// # Errors
-    ///
-    /// Ringbuffer closed and no more data available.
+    /// Returns [`None`] if the ring buffer is closed.
     #[allow(clippy::missing_panics_doc)] // https://github.com/rust-lang/rust-clippy/issues/14534
-    pub async fn new_eos(&mut self) -> Result<usize, ()> {
+    pub async fn new_eos(&mut self) -> Option<usize> {
         let mut msg_buf = [0; RingMsgWrite2::get_msg_size(0)];
         // SAFETY: we allocated the exact necessary size, this can never fail
         // #[expect(
@@ -187,9 +173,9 @@ impl AsyncRingSourceProvider {
         // )]
         let _ = RingMsgWrite2::try_write_eos(&mut msg_buf).unwrap();
 
-        self.inner.push_exact(&msg_buf).await.map_err(|_| ())?;
+        self.inner.push_exact(&msg_buf).await.ok()?;
 
-        Ok(msg_buf.len())
+        Some(msg_buf.len())
     }
 
     /// Wait until the seek channel is dropped([`None`]) or a seek is requested([`Some`]).
@@ -878,7 +864,7 @@ mod tests {
             let written = prod.new_eos().await.unwrap();
             assert_eq!(written, RingMsgWrite2::get_msg_size(0));
 
-            prod.write_data(&[]).await.unwrap_err();
+            assert!(prod.write_data(&[]).await.is_none());
 
             // just to prevent an infinitely running test due to a deadlock
             let res = tokio::time::timeout(Duration::from_secs(3), handle)

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -900,7 +900,7 @@ impl Model {
 
         if let Ok(paths) = std::fs::read_dir(path) {
             self.config_editor.themes.clear();
-            let mut paths: Vec<_> = paths.filter_map(std::result::Result::ok).collect();
+            let mut paths: Vec<_> = paths.filter_map(Result::ok).collect();
 
             paths.sort_by_cached_key(|k| get_pin_yin(&k.file_name().to_string_lossy()));
             for entry in paths {

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -756,7 +756,7 @@ impl Model {
             let all_items = walkdir::WalkDir::new(absolute_dir).follow_links(true);
             for record in all_items
                 .into_iter()
-                .filter_map(std::result::Result::ok)
+                .filter_map(Result::ok)
                 .filter(|p| is_playlist(p.path()))
             {
                 let full_path_name = record.path().to_string_lossy().to_string();

--- a/tui/src/ui/components/orx_music_library/model_ext.rs
+++ b/tui/src/ui/components/orx_music_library/model_ext.rs
@@ -163,7 +163,7 @@ impl Model {
         let mut idx: usize = 0;
         let search = format!("*{}*", input.to_lowercase());
         let search = wildmatch::WildMatch::new(&search);
-        for record in all_items.into_iter().filter_map(std::result::Result::ok) {
+        for record in all_items.into_iter().filter_map(Result::ok) {
             let file_name = record.path();
             if search.matches(&file_name.to_string_lossy().to_lowercase()) {
                 if idx > 0 {

--- a/tui/src/ui/components/orx_music_library/scanner.rs
+++ b/tui/src/ui/components/orx_music_library/scanner.rs
@@ -88,7 +88,7 @@ fn library_dir_tree_inner(path: &Path, depth: ScanDepth, is_dir: Option<bool>) -
         && let Ok(paths) = std::fs::read_dir(path)
     {
         let mut paths: Vec<(String, (PathBuf, bool))> = paths
-            .filter_map(std::result::Result::ok)
+            .filter_map(Result::ok)
             // filter out hidden files and files without playback
             .filter(|p| {
                 !p.file_name().to_string_lossy().starts_with('.')

--- a/tui/src/ui/model/youtube_options.rs
+++ b/tui/src/ui/model/youtube_options.rs
@@ -383,7 +383,7 @@ fn remove_downloaded_json(path: &Path, file_fullname: &str) {
     let files = walkdir::WalkDir::new(path).follow_links(true);
     for f in files
         .into_iter()
-        .filter_map(std::result::Result::ok)
+        .filter_map(Result::ok)
         .filter(|f| {
             let p = Path::new(f.file_name());
             p.extension().is_some_and(|ext| ext == "json")
@@ -422,7 +422,7 @@ fn embed_downloaded_lrc(path: &Path, file_fullname: &str) {
 
     for entry in files
         .into_iter()
-        .filter_map(std::result::Result::ok)
+        .filter_map(Result::ok)
         .filter(|f| f.file_type().is_file())
         .filter(|f| {
             let name = f.file_name();


### PR DESCRIPTION
This PR fixes all the new warnings with Rust 1.98.
Also removes the `std::result::` prefix where possible.