### PR TITLE
fix(lib::track::full_track): return empty lyric data instead of error

### DIFF
--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -1,19 +1,22 @@
-// Package downloaded lyrics from different websites and embed them into an MP3 file.
-// lrc file is used to parse lrc file into subtitle. Similar to subtitles package
-// [al:''Album where the song is from'']
-// [ar:''Lyrics artist'']
-// [by:''Creator of the LRC file'']
-// [offset:''+/- Overall timestamp adjustment in milliseconds, + shifts time up, - shifts down'']
-// [re:''The player or editor that creates LRC file'']
-// [ti:''Lyrics (song) title'']
-// [ve:''version of program'']
-// [ti:Let's Twist Again]
-// [ar:Chubby Checker oppure  Beatles, The]
-// [au:Written by Kal Mann / Dave Appell, 1961]
-// [al:Hits Of The 60's - Vol. 2 – Oldies]
-// [00:12.00]Lyrics beginning ...
-// [00:15.30]Some more lyrics ...
+//! Lyric(LRC) file parsing, writing and manipulating.
+//! Example LRC content:
+//! ```lrc
+//! [al:''Album where the song is from'']
+//! [ar:''Lyrics artist'']
+//! [by:''Creator of the LRC file'']
+//! [offset:''+/- Overall timestamp adjustment in milliseconds, + shifts time up, - shifts down'']
+//! [re:''The player or editor that creates LRC file'']
+//! [ti:''Lyrics (song) title'']
+//! [ve:''version of program'']
+//! [ti:Let's Twist Again]
+//! [ar:Chubby Checker oppure  Beatles, The]
+//! [au:Written by Kal Mann / Dave Appell, 1961]
+//! [al:Hits Of The 60's - Vol. 2 – Oldies]
+//! [00:12.00]Lyrics beginning ...
+//! [00:15.30]Some more lyrics ...
+//! ```
 use anyhow::Result;
+use std::convert::Infallible;
 use std::fmt::{Error as FmtError, Write};
 use std::str::FromStr;
 use std::time::Duration;
@@ -237,7 +240,7 @@ fn time_lrc(time_stamp: u64) -> impl std::fmt::Display {
 }
 
 impl FromStr for Lyric {
-    type Err = ();
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut offset: i64 = 0;

--- a/lib/src/songtag/lrc.rs
+++ b/lib/src/songtag/lrc.rs
@@ -44,6 +44,13 @@ pub struct Caption {
 }
 
 impl Lyric {
+    /// Checks if the stored captions array is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.captions.is_empty()
+    }
+
     /// Get the lyric text at `time` or next lowest (in seconds)
     ///
     /// `time` is adjusted by +2 seconds.

--- a/lib/src/track/full_track.rs
+++ b/lib/src/track/full_track.rs
@@ -482,27 +482,24 @@ impl Track {
                             lyrics: true,
                             ..Default::default()
                         },
-                    )
-                    .and_then(|result| {
-                        result
-                            .lyric_frames
-                            .filter(|frames| !frames.is_empty())
-                            .ok_or(anyhow::format_err!("Music metadata doesn't contain lyric."))
-                    })
-                    .or_else(|e| {
+                    )?
+                    .lyric_frames
+                    .unwrap_or_default();
+                    let lyric_frames = if !lyric_frames.is_empty() {
+                        lyric_frames
+                    } else if let path = path_key.with_extension("lrc")
+                        && path.is_file()
+                    {
                         // Try to load lyric from .lrc file named same as track file
-                        let path = path_key.with_extension("lrc");
-                        if path.is_file() {
-                            let lyric = std::fs::read_to_string(&path)?;
-                            Ok(vec![Id3Lyrics {
-                                text: lyric,
-                                lang: String::default(),
-                                description: format!("Loaded from {}", path.display()),
-                            }])
-                        } else {
-                            Err(e)
-                        }
-                    })?;
+                        let lyric = std::fs::read_to_string(&path).map_err(|e| Some(e.into()))?;
+                        vec![Id3Lyrics {
+                            text: lyric,
+                            lang: String::default(),
+                            description: format!("Loaded from {}", path.display()),
+                        }]
+                    } else {
+                        Vec::new()
+                    };
 
                     let parsed_lyric = lyric_frames
                         .first()

--- a/lib/src/track/full_track.rs
+++ b/lib/src/track/full_track.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use id3::frame::Lyrics as Id3Lyrics;
 use lofty::{file::FileType, picture::Picture};
 use lru::LruCache;
@@ -169,6 +169,15 @@ pub enum MediaTypes {
 pub struct LyricData {
     pub raw_lyrics: Vec<Id3Lyrics>,
     pub parsed_lyrics: Option<Lyric>,
+}
+
+impl LyricData {
+    /// Checks if `parsed_lyrics` is empty or not and if the parsed lyrics is empty.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.parsed_lyrics.as_ref().is_none_or(Lyric::is_empty)
+    }
 }
 
 type PictureCache = LruCache<PathBuf, Arc<Picture>>;
@@ -469,59 +478,28 @@ impl Track {
     /// Get the lyrics data for the current Track.
     ///
     /// Only works for Music Tracks.
-    pub fn get_lyrics(&self) -> Result<Option<Arc<LyricData>>> {
+    ///
+    /// This returns a empty [`LyricData`] object if there are no lyrics found.
+    ///
+    /// To force a re-fetch from disk, unset the path in the cache first with [`Self::unset_cache_for_path`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if and only if the track has some kind of read error, for example, but not limited to:
+    /// - If the current track is not a Music track
+    /// - If [`parse_metadata_from_file`] returns a error
+    pub fn get_lyrics(&self) -> Result<Arc<LyricData>> {
         let Some(track_data) = self.as_track() else {
             bail!("Track is not a Music Track!");
         };
 
-        let path_key = track_data.path().to_owned();
+        let path_key = track_data.path();
 
-        let res = LYRIC_CACHE.with_borrow_mut(|cache| {
+        LYRIC_CACHE.with_borrow_mut(|cache| {
             cache
-                .try_get_or_insert(path_key.clone(), || {
-                    let lyric_frames = parse_metadata_from_file(
-                        track_data.path(),
-                        MetadataOptions {
-                            lyrics: true,
-                            ..Default::default()
-                        },
-                    )?
-                    .lyric_frames
-                    .unwrap_or_default();
-                    let lyric_frames = if !lyric_frames.is_empty() {
-                        lyric_frames
-                    } else if let path = path_key.with_extension("lrc")
-                        && path.is_file()
-                    {
-                        // Try to load lyric from .lrc file named same as track file
-                        let lyric = std::fs::read_to_string(&path).map_err(|e| Some(e.into()))?;
-                        vec![Id3Lyrics {
-                            text: lyric,
-                            lang: String::default(),
-                            description: format!("Loaded from {}", path.display()),
-                        }]
-                    } else {
-                        Vec::new()
-                    };
-
-                    let parsed_lyric = lyric_frames
-                        .first()
-                        .and_then(|frame| Lyric::from_str(&frame.text).ok());
-
-                    Ok(Arc::new(LyricData {
-                        raw_lyrics: lyric_frames,
-                        parsed_lyrics: parsed_lyric,
-                    }))
-                })
+                .try_get_or_insert(path_key.to_owned(), || fetch_lyrics(path_key))
                 .cloned()
-        });
-
-        // this has to be done as LruCache::try_get_or_insert enforces that the Ok result is the value itself, no mapping can be done.
-        match res {
-            Ok(v) => Ok(Some(v)),
-            Err(None) => Ok(None),
-            Err(Some(err)) => Err(err),
-        }
+        })
     }
 
     /// Remove the given path from the Lyric parse cache, forcing a reload upon next access.
@@ -532,6 +510,52 @@ impl Track {
             cache.pop(path);
         });
     }
+}
+
+/// Fetch the lyrics data for the given Track path.
+///
+/// This returns a empty [`LyricData`] object if there are no Lyrics found.
+///
+/// # Errors
+///
+/// Returns `Err` if and only if the track has some kind of read error, for example, but not limited to:
+/// - If [`parse_metadata_from_file`] returns a error
+fn fetch_lyrics(path: &Path) -> Result<Arc<LyricData>> {
+    let lyric_frames = parse_metadata_from_file(
+        path,
+        MetadataOptions {
+            lyrics: true,
+            ..Default::default()
+        },
+    )?;
+    let lyric_frames = lyric_frames.lyric_frames.unwrap_or_default();
+
+    let lyric_frames = if lyric_frames.is_empty()
+        && let lrc_path = path.with_extension("lrc")
+        && lrc_path.is_file()
+    {
+        // Try to load lyric from .lrc file named same as track file
+        #[expect(clippy::unnecessary_debug_formatting)] // we want the path to be escaped here
+        let lyric = std::fs::read_to_string(&lrc_path)
+            .with_context(|| format!("Reading lyric file {lrc_path:#?}"))?;
+        vec![Id3Lyrics {
+            text: lyric,
+            // we dont need to give extra metadata, as only the text is relevant below
+            lang: String::new(),
+            description: String::new(),
+        }]
+    } else {
+        lyric_frames
+    };
+
+    let parsed_lyric = lyric_frames
+        .first()
+        .and_then(|frame| Lyric::from_str(&frame.text).ok());
+
+    Ok(Arc::new(LyricData {
+        raw_lyrics: lyric_frames,
+        parsed_lyrics: parsed_lyric,
+    }))
 }
 
 impl PartialEq<PlaylistTrackSource> for &Track {

--- a/lib/src/track/full_track.rs
+++ b/lib/src/track/full_track.rs
@@ -162,6 +162,9 @@ pub enum MediaTypes {
     Podcast(PodcastTrackData),
 }
 
+/// Stores the Lyric data for the cache.
+///
+/// Invariant: `parsed_lyrics` needs to be present at struct creation time if there is going to be one.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LyricData {
     pub raw_lyrics: Vec<Id3Lyrics>,

--- a/lib/src/track/read_metadata.rs
+++ b/lib/src/track/read_metadata.rs
@@ -320,7 +320,11 @@ fn split_artists<'a>(
 
 /// Fetch all lyrics from the given Lofty tag into the given array.
 fn get_lyrics_from_tags(tag: &LoftyTag, lyric_frames: &mut Vec<Id3Lyrics>) {
-    let lyrics = tag.get_items(ItemKey::Lyrics);
+    // NOTE: despite what the lofty documentation currently says about "ItemKey::Lyrics" containg *both* synced and unsynced lyrics
+    // It *DOES NOT* contain unsynced lyrics!
+    // It seems like this mapping was removed in lofty 0.23.3 for id3v2, which are used for mp3.
+
+    let lyrics = tag.get_items(ItemKey::UnsyncLyrics);
     for lyric in lyrics {
         if let ItemValue::Text(lyrics_text) = lyric.value() {
             lyric_frames.push(Id3Lyrics {

--- a/lib/src/track/read_metadata.rs
+++ b/lib/src/track/read_metadata.rs
@@ -179,6 +179,14 @@ pub struct FileTimes {
 }
 
 /// Try to parse all specified metadata in the given `options`.
+///
+/// # Errors
+///
+/// Returns a error if:
+/// - Path does not exist
+/// - There is a read / seek error
+/// - lofty cannot determine the file type
+/// - The metadata contains invalid data
 pub fn parse_metadata_from_file(
     path: &Path,
     options: MetadataOptions<'_>,

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -307,12 +307,26 @@ impl Model {
                     return;
                 }
 
-                if let Ok(data) = track.get_lyrics()
-                    && data.parsed_lyrics.is_some()
-                {
+                let lyrics = match track.get_lyrics() {
+                    Err(err) => {
+                        // we want a escaped path here
+                        #[expect(clippy::unnecessary_debug_formatting)]
+                        {
+                            error!(
+                                "Failed fetching lyric data for {:#?}: {err}",
+                                track.as_track().unwrap().path()
+                            );
+                        }
+                        self.lyric_set_lyric(NO_LYRICS);
+                        return;
+                    }
+                    Ok(v) => v,
+                };
+
+                if lyrics.parsed_lyrics.is_some() {
                     self.current_track_lyric = Some(ExtraLyricData {
                         for_track: track.as_track().unwrap().path().to_owned(),
-                        data: (*data).clone(),
+                        data: (*lyrics).clone(),
                         selected_idx: 0,
                     });
                 } else {

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -307,7 +307,9 @@ impl Model {
                     return;
                 }
 
-                if let Ok(Some(data)) = track.get_lyrics() {
+                if let Ok(data) = track.get_lyrics()
+                    && data.parsed_lyrics.is_some()
+                {
                     self.current_track_lyric = Some(ExtraLyricData {
                         for_track: track.as_track().unwrap().path().to_owned(),
                         data: (*data).clone(),


### PR DESCRIPTION
> [#760](https://github.com/tramhao/termusic/pull/760#pullrequestreview-5030119226)
... so in the no-error case & no lyric case, we wanted to store the result so it is not tried again.

---

Since I really confused on the type `try_get_or_insert` returned: `Result<_, Option<Error>>` (I cannot understand why theres an Option)...

> I guess we should document what may get returned for future reference.

For now I use `.map_err(|e| Some(e.into()))` to be compatible with that type while I'd like to take some change if needed.