### PR TITLE
fix(lib): add context on which database the migration failed.

### DIFF
--- a/lib/src/new_database/mod.rs
+++ b/lib/src/new_database/mod.rs
@@ -79,7 +79,7 @@ impl Database {
 
     /// Prepare the given Connection for usage.
     fn new_from_connection(conn: Connection) -> Result<Self> {
-        migrate::migrate(&conn).context("Database migration")?;
+        migrate::migrate(&conn).context("Database migration (library)")?;
 
         let conn = Arc::new(Mutex::new(conn));
         // for now limit to one worker at a time

--- a/lib/src/podcast/db/mod.rs
+++ b/lib/src/podcast/db/mod.rs
@@ -49,7 +49,7 @@ impl Database {
         db_path.push("data.db");
         let conn = Connection::open(&db_path)?;
 
-        migration::migrate(&conn).context("Database creation / migration")?;
+        migration::migrate(&conn).context("Database migration (podcast)")?;
 
         // SQLite defaults to foreign key support off
         conn.execute("PRAGMA foreign_keys=ON;", [])


### PR DESCRIPTION
This PR adds a simple suffix to the error context, so it is more clear on which database the error happened.

Though the errors were slightly different before, this makes it more clear.

re #762