### PR TITLE
fix(tui::ui::components::orx_music_library): fix "MusicLibData::new" not actually using the verified "cell"

### DIFF
--- a/tui/src/ui/components/orx_music_library/music_library.rs
+++ b/tui/src/ui/components/orx_music_library/music_library.rs
@@ -73,7 +73,7 @@ impl MusicLibData {
             is_dir,
             is_loading: false,
             is_error: false,
-            as_str: OnceCell::default(),
+            as_str: cell,
         }
     }
 }


### PR DESCRIPTION
I do not know how this slipped through.
Why did rust not warn about the variable practically being unused?

fixes #765