### PR TITLE
fix(tui::ui::components): fix remainder of components not setting "inactive(bg)"

### DIFF
--- a/tui/src/ui/components/config_editor/key_combo.rs
+++ b/tui/src/ui/components/config_editor/key_combo.rs
@@ -893,7 +893,7 @@ impl KEModifierSelect {
             )
             .foreground(config_r.settings.theme.fallback_foreground())
             .background(config_r.settings.theme.fallback_background())
-            .inactive(Style::new().fg(config_r.settings.theme.fallback_foreground()))
+            .inactive(Style::new().bg(config_r.settings.theme.fallback_background()))
             .title(title.into().alignment(HorizontalAlignment::Left))
             .rewind(false)
             .highlight_style(

--- a/tui/src/ui/components/config_editor/mod.rs
+++ b/tui/src/ui/components/config_editor/mod.rs
@@ -59,7 +59,6 @@ impl CEHeader {
                 .choices(ConfigEditorLayout::choice_array())
                 .foreground(config.settings.theme.library_highlight())
                 .background(config.settings.theme.library_background())
-                // .inactive(Style::default().fg(config.settings.theme.library_highlight()))
                 .value(layout.to_array_idx()),
         };
 

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -38,7 +38,7 @@ impl Progress {
                 )
                 .background(config.settings.theme.progress_background())
                 .foreground(config.settings.theme.progress_foreground())
-                .inactive(Style::new().fg(config.settings.theme.progress_foreground()))
+                .inactive(Style::new().bg(config.settings.theme.progress_background()))
                 .label("Progress")
                 .title(
                     Title::from(" Status: Stopped | Volume: ?? | Speed: ??.? ")

--- a/tui/src/ui/components/tag_editor/te_input.rs
+++ b/tui/src/ui/components/tag_editor/te_input.rs
@@ -23,7 +23,7 @@ impl EditField {
             Input::default()
                 .foreground(config.settings.theme.library_foreground())
                 .background(config.settings.theme.library_background())
-                .inactive(Style::new().fg(config.settings.theme.library_foreground()))
+                .inactive(Style::new().bg(config.settings.theme.library_background()))
                 .borders(
                     Borders::default()
                         .color(config.settings.theme.library_border())


### PR DESCRIPTION
Specifically, this fixes backgrounds not matching light themes in tag editor input fields.

Noticed while checking #768.