### PR TITLE
Use the subscription API for reloading theme

### DIFF
--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -6,12 +6,10 @@ use termusiclib::config::v2::tui::keys::KeyBinding;
 use termusiclib::config::v2::tui::theme::ThemeColors;
 use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
 use termusiclib::utils::get_app_config_path;
-use tuirealm::event::Event;
 
 use crate::ui::Model;
 use crate::ui::components::CEHeader;
 use crate::ui::ids::{Id, IdCETheme, IdConfigEditor, IdKey, IdKeyGlobal, IdKeyOther};
-use crate::ui::model::UserEvent;
 use crate::ui::msg::{
     CONFIG_EDITOR_TABS_ORDER, ConfigEditorLayout, ConfigEditorMsg, GENERAL_FOCUS_ORDER,
     KFGLOBAL_FOCUS_ORDER, KFMsg, KFOTHER_FOCUS_ORDER, Msg, THEME_COLOR_ITEM_FOCUS_ORDER_START,
@@ -127,16 +125,10 @@ impl Model {
         }
     }
 
-    /// Re-apply theme colors to components that bake style in at mount time
-    /// and don't otherwise re-read `config_tui` on every render (unlike e.g. Playlist).
+    /// Send a Mesasge to reload the theme on components that cannot simply be remounted without losing state.
+    #[inline]
     fn refresh_static_theme_components(&mut self) {
-        let ev = Event::User(UserEvent::Forward(Msg::ReloadTheme));
-
-        for id in [Id::Library, Id::Podcast, Id::Episode, Id::MessagePopup] {
-            if let Some(component) = self.app.get_component_mut(&id) {
-                component.on(&ev);
-            }
-        }
+        let _ = self.tx_to_main.send(Msg::ReloadTheme);
     }
 
     /// Preview theme at Table index

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -29,7 +29,6 @@ pub use footer::Footer;
 pub use labels::{DownloadSpinner, LabelGeneric, LabelSpan};
 pub use lyric::Lyric;
 pub use playlist::Playlist;
-pub use podcast::{EpisodeList, FeedsList};
 pub use popups::general_search::{GSInputPopup, GSTablePopup, Source};
 pub use progress::Progress;
 pub use tag_editor::*;

--- a/tui/src/ui/components/orx_music_library/model_ext.rs
+++ b/tui/src/ui/components/orx_music_library/model_ext.rs
@@ -22,7 +22,7 @@ use crate::ui::{
     tui_cmd::TuiCmd,
 };
 
-/// Get all subscriptions for the [`MusicLibrary`] Component.
+/// Get all subscriptions for the [`OrxMusicLibraryComponent`] Component.
 fn library_subs() -> Vec<Sub<Id, UserEvent>> {
     vec![
         Sub::new(
@@ -53,6 +53,10 @@ fn library_subs() -> Vec<Sub<Id, UserEvent>> {
             EventClause::User(UserEvent::Forward(Msg::Library(LIMsg::RequestCurrentPath(
                 LIReqNode::default(),
             )))),
+            SubClause::Always,
+        ),
+        Sub::new(
+            EventClause::User(UserEvent::Forward(Msg::ReloadTheme)),
             SubClause::Always,
         ),
     ]

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -20,6 +20,7 @@ use tuirealm::props::{
 };
 use tuirealm::props::{Borders, PropPayload, PropValue};
 use tuirealm::state::{State, StateValue};
+use tuirealm::subscription::{EventClause, Sub, SubClause};
 
 use crate::ui::Model;
 use crate::ui::ids::Id;
@@ -82,6 +83,14 @@ impl FeedsList {
         let moved = std::mem::take(&mut self.component);
         self.component = Self::apply_theme_style(moved, config);
     }
+}
+
+/// Get all subscriptions for the [`FeedsList`] Component.
+fn feedslist_subs() -> Vec<Sub<Id, UserEvent>> {
+    vec![Sub::new(
+        EventClause::User(UserEvent::Forward(Msg::ReloadTheme)),
+        SubClause::Always,
+    )]
 }
 
 impl AppComponent<Msg, UserEvent> for FeedsList {
@@ -275,6 +284,14 @@ impl EpisodeList {
     }
 }
 
+/// Get all subscriptions for the [`EpisodeList`] Component.
+fn episodelist_subs() -> Vec<Sub<Id, UserEvent>> {
+    vec![Sub::new(
+        EventClause::User(UserEvent::Forward(Msg::ReloadTheme)),
+        SubClause::Always,
+    )]
+}
+
 impl AppComponent<Msg, UserEvent> for EpisodeList {
     #[allow(clippy::too_many_lines)]
     fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
@@ -416,7 +433,7 @@ impl Model {
                 Msg::Podcast(PCMsg::PodcastBlurDown),
                 Msg::Podcast(PCMsg::PodcastBlurUp),
             )),
-            Vec::new(),
+            feedslist_subs(),
         )?;
 
         self.app.mount(
@@ -426,7 +443,7 @@ impl Model {
                 Msg::Podcast(PCMsg::EpisodeBlurDown),
                 Msg::Podcast(PCMsg::EpisodeBlurUp),
             )),
-            Vec::new(),
+            episodelist_subs(),
         )?;
 
         Ok(())

--- a/tui/src/ui/components/podcast.rs
+++ b/tui/src/ui/components/podcast.rs
@@ -407,6 +407,31 @@ impl AppComponent<Msg, UserEvent> for EpisodeList {
 }
 
 impl Model {
+    /// Mount the Podcast View
+    pub fn mount_podcast(&mut self) -> Result<()> {
+        self.app.mount(
+            Id::Podcast,
+            Box::new(FeedsList::new(
+                self.config_tui.clone(),
+                Msg::Podcast(PCMsg::PodcastBlurDown),
+                Msg::Podcast(PCMsg::PodcastBlurUp),
+            )),
+            Vec::new(),
+        )?;
+
+        self.app.mount(
+            Id::Episode,
+            Box::new(EpisodeList::new(
+                self.config_tui.clone(),
+                Msg::Podcast(PCMsg::EpisodeBlurDown),
+                Msg::Podcast(PCMsg::EpisodeBlurUp),
+            )),
+            Vec::new(),
+        )?;
+
+        Ok(())
+    }
+
     #[allow(clippy::doc_markdown)]
     /// Search ITunes for podcasts and send it to `Model::tx_to_main` as [`Msg::Podcast`] and [`PCMsg::Search*`](PCMsg).
     ///

--- a/tui/src/ui/components/popups/message.rs
+++ b/tui/src/ui/components/popups/message.rs
@@ -7,6 +7,7 @@ use tuirealm::{
         AttrValueRef, Attribute, BorderType, Borders, HorizontalAlignment, PropPayloadRef,
         QueryResult, TextModifiers, TextStatic, Title,
     },
+    subscription::{EventClause, Sub, SubClause},
 };
 
 use crate::ui::ids::Id;
@@ -71,6 +72,14 @@ impl MessagePopup {
     }
 }
 
+/// Get all subscriptions for the [`MessagePopup`] Component.
+fn message_subs() -> Vec<Sub<Id, UserEvent>> {
+    vec![Sub::new(
+        EventClause::User(UserEvent::Forward(Msg::ReloadTheme)),
+        SubClause::Always,
+    )]
+}
+
 impl AppComponent<Msg, UserEvent> for MessagePopup {
     fn on(&mut self, ev: &Event<UserEvent>) -> Option<Msg> {
         if matches!(ev, Event::User(UserEvent::Forward(Msg::ReloadTheme))) {
@@ -89,7 +98,7 @@ impl Model {
                 .remount(
                     Id::MessagePopup,
                     Box::new(MessagePopup::new(&self.config_tui, title, text)),
-                    vec![]
+                    message_subs()
                 )
                 .is_ok()
         );

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -14,14 +14,14 @@ use tuirealm::subscription::{EventClause, Sub, SubClause};
 use tuirealm::terminal::TerminalAdapter;
 
 use crate::ui::components::{
-    DBListCriteria, DownloadSpinner, EpisodeList, FeedsList, Footer, GSInputPopup, GSTablePopup,
-    Lyric, Playlist, Progress, Source,
+    DBListCriteria, DownloadSpinner, Footer, GSInputPopup, GSTablePopup, Lyric, Playlist, Progress,
+    Source,
 };
 use crate::ui::ids::{Id, IdConfigEditor, IdTagEditor};
 use crate::ui::model::ports::rx_main::PortRxMain;
 use crate::ui::model::ports::stream_events::PortStreamEvents;
 use crate::ui::model::{Model, TermusicLayout, UserEvent};
-use crate::ui::msg::{Msg, PCMsg};
+use crate::ui::msg::Msg;
 use crate::ui::utils::{
     draw_area_in_absolute, draw_area_in_relative, draw_area_top_right_absolute,
 };
@@ -49,6 +49,7 @@ impl Model {
 
         self.mount_new_library()?;
         self.remount_database_search()?;
+        self.mount_podcast()?;
 
         self.app.mount(
             Id::Playlist,
@@ -69,25 +70,6 @@ impl Model {
             Vec::new(),
         )?;
 
-        self.app.mount(
-            Id::Podcast,
-            Box::new(FeedsList::new(
-                self.config_tui.clone(),
-                Msg::Podcast(PCMsg::PodcastBlurDown),
-                Msg::Podcast(PCMsg::PodcastBlurUp),
-            )),
-            Vec::new(),
-        )?;
-
-        self.app.mount(
-            Id::Episode,
-            Box::new(EpisodeList::new(
-                self.config_tui.clone(),
-                Msg::Podcast(PCMsg::EpisodeBlurDown),
-                Msg::Podcast(PCMsg::EpisodeBlurUp),
-            )),
-            Vec::new(),
-        )?;
         self.app.mount(
             Id::DownloadSpinner,
             Box::new(DownloadSpinner::new(&self.config_tui.read())),


### PR DESCRIPTION
Re https://github.com/tramhao/termusic/pull/768#discussion_r3889923362

#768 added a way to reload the theme, but did not make use of the subscription API. This PR changes that to have everything consistent and automatically populate out instead of changing a static list.

Tagging @theeasternfurry as you might be curious.