### PR TITLE
Use consistent mount / remount / umount handling

### DIFF
--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -45,9 +45,7 @@ impl Model {
             ConfigEditorMsg::ConfigChanged => self.config_editor.config_changed = true,
 
             ConfigEditorMsg::ConfigSaveOk => {
-                self.app
-                    .umount(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))
-                    .ok();
+                let _ = self.umount_config_save_popup();
                 match self.collect_config_data() {
                     Ok(()) => {
                         let res_server = ServerConfigVersionedDefaulted::save_config_path(
@@ -84,9 +82,7 @@ impl Model {
                 }
             }
             ConfigEditorMsg::ConfigSaveCancel => {
-                self.app
-                    .umount(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))
-                    .ok();
+                let _ = self.umount_config_save_popup();
                 self.umount_config_editor();
             }
 

--- a/tui/src/ui/components/config_editor/update.rs
+++ b/tui/src/ui/components/config_editor/update.rs
@@ -36,7 +36,8 @@ impl Model {
             ConfigEditorMsg::CloseOk => {
                 if self.config_editor.config_changed {
                     self.config_editor.config_changed = false;
-                    self.mount_config_save_popup();
+                    self.mount_config_save_popup()
+                        .expect("Expected ConfigSavePopup to mount correctly");
                 } else {
                     self.umount_config_editor();
                 }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -610,7 +610,7 @@ impl Model {
         Ok(())
     }
 
-    /// Mount quit popup
+    /// Mount the Config Save Popup.
     pub fn mount_config_save_popup(&mut self) -> Result<()> {
         self.app.remount(
             Id::ConfigEditor(IdConfigEditor::ConfigSavePopup),
@@ -619,6 +619,14 @@ impl Model {
         )?;
         self.app
             .active(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))?;
+
+        Ok(())
+    }
+
+    /// Unmount the Config Save Popup.
+    pub fn umount_config_save_popup(&mut self) -> Result<()> {
+        self.app
+            .umount(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))?;
 
         Ok(())
     }

--- a/tui/src/ui/components/config_editor/view.rs
+++ b/tui/src/ui/components/config_editor/view.rs
@@ -580,9 +580,11 @@ impl Model {
     pub fn umount_config_editor(&mut self) {
         self.playlist_reload();
         self.database_reload();
-        self.progress_reload();
+        self.remount_progress()
+            .expect("Expected Progress to remount correctly");
         self.mount_label_help();
-        self.lyric_reload();
+        self.remount_lyric()
+            .expect("Expected Lyric to remount correctly");
 
         self.umount_config_editor_components()
             .expect("Expected Config Editor Components to unmount correctly");
@@ -609,21 +611,16 @@ impl Model {
     }
 
     /// Mount quit popup
-    pub fn mount_config_save_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::ConfigEditor(IdConfigEditor::ConfigSavePopup),
-                    Box::new(ConfigSavePopup::new(self.config_tui.clone())),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .active(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))
-                .is_ok()
-        );
+    pub fn mount_config_save_popup(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::ConfigEditor(IdConfigEditor::ConfigSavePopup),
+            Box::new(ConfigSavePopup::new(self.config_tui.clone())),
+            vec![],
+        )?;
+        self.app
+            .active(&Id::ConfigEditor(IdConfigEditor::ConfigSavePopup))?;
+
+        Ok(())
     }
 
     #[allow(clippy::too_many_lines)]

--- a/tui/src/ui/components/database.rs
+++ b/tui/src/ui/components/database.rs
@@ -910,7 +910,7 @@ impl Model {
 
     /// Add all Results (from view `Result`) to the playlist.
     pub fn database_add_all_results(&mut self) {
-        self.umount_results_add_confirm_database();
+        let _ = self.umount_results_add_confirm_database();
         if !self.dw.search_results.is_empty() {
             let mut tracks = Vec::new();
             // clone once instead every value in every iteration
@@ -1058,24 +1058,26 @@ impl Model {
         self.general_search_update_show(Model::build_table(filtered_music, &self.config_tui));
     }
 
-    /// Mount the [`AddAlbumConfirm`] popup
-    pub fn mount_results_add_confirm_database(&mut self, criteria: SearchCriteria) {
-        self.app
-            .remount(
-                Id::DatabaseAddConfirmPopup,
-                Box::new(AddAlbumConfirm::new(
-                    self.config_tui.clone(),
-                    criteria.as_str(),
-                )),
-                Vec::new(),
-            )
-            .unwrap();
+    /// Mount the [`AddAlbumConfirm`] popup.
+    pub fn mount_results_add_confirm_database(&mut self, criteria: SearchCriteria) -> Result<()> {
+        self.app.remount(
+            Id::DatabaseAddConfirmPopup,
+            Box::new(AddAlbumConfirm::new(
+                self.config_tui.clone(),
+                criteria.as_str(),
+            )),
+            Vec::new(),
+        )?;
 
-        self.app.active(&Id::DatabaseAddConfirmPopup).unwrap();
+        self.app.active(&Id::DatabaseAddConfirmPopup)?;
+
+        Ok(())
     }
 
-    /// Unmount the [`AddAlbumConfirm`] popup
-    pub fn umount_results_add_confirm_database(&mut self) {
-        let _ = self.app.umount(&Id::DatabaseAddConfirmPopup);
+    /// Unmount the [`AddAlbumConfirm`] popup.
+    pub fn umount_results_add_confirm_database(&mut self) -> Result<()> {
+        self.app.umount(&Id::DatabaseAddConfirmPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/lyric.rs
+++ b/tui/src/ui/components/lyric.rs
@@ -134,18 +134,16 @@ impl AppComponent<Msg, UserEvent> for Lyric {
 
 impl Model {
     /// Remount and reload the lyrics from the current track.
-    pub fn lyric_reload(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Lyric,
-                    Box::new(Lyric::new(self.config_tui.clone())),
-                    Vec::new()
-                )
-                .is_ok()
-        );
+    pub fn remount_lyric(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::Lyric,
+            Box::new(Lyric::new(self.config_tui.clone())),
+            Vec::new(),
+        )?;
         self.lyric_update_title();
         self.lyric_update();
+
+        Ok(())
     }
 
     /// Force reload lyrics from file. For example after a Tag Editor exit.
@@ -159,7 +157,8 @@ impl Model {
             Track::unset_cache_for_path(track.path());
         }
 
-        self.lyric_reload();
+        self.remount_lyric()
+            .expect("Expected Lyric to remount correctly");
     }
 
     pub fn lyric_update_for_podcast_by_current_track(&mut self) {

--- a/tui/src/ui/components/mod.rs
+++ b/tui/src/ui/components/mod.rs
@@ -29,6 +29,6 @@ pub use footer::Footer;
 pub use labels::{DownloadSpinner, LabelGeneric, LabelSpan};
 pub use lyric::Lyric;
 pub use playlist::Playlist;
-pub use popups::general_search::{GSInputPopup, GSTablePopup, Source};
+pub use popups::general_search::Source;
 pub use progress::Progress;
 pub use tag_editor::*;

--- a/tui/src/ui/components/orx_music_library/model_ext.rs
+++ b/tui/src/ui/components/orx_music_library/model_ext.rs
@@ -124,15 +124,21 @@ impl Model {
     }
 
     /// Show a deletion confirmation for the currently selected node.
-    pub fn new_library_show_delete_confirm(&mut self, path: PathBuf, focus_node: Option<String>) {
+    pub fn new_library_show_delete_confirm(
+        &mut self,
+        path: PathBuf,
+        focus_node: Option<String>,
+    ) -> Result<()> {
         if path.is_file() {
-            self.mount_confirm_radio(path, focus_node);
+            self.mount_confirm_radio(path, focus_node)
+                .context("DeleteConfirmRadioPopup")
         } else {
             self.mount_confirm_input(
                 path,
                 focus_node,
                 "You're about to delete the whole directory.",
-            );
+            )
+            .context("DeleteConfirmInputPopup")
         }
     }
 

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use anyhow::Result;
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use tui_realm_stdlib::components::Input;
 use tuirealm::{
@@ -134,42 +135,43 @@ impl AppComponent<Msg, UserEvent> for DeleteConfirmInputPopup {
 }
 
 impl Model {
-    /// Mount a [`DeleteConfirmRadioPopup`] with [`Msg::DeleteConfirmCloseOk`] and [`Msg::DeleteConfirmCloseCancel`]
+    /// Mount a [`DeleteConfirmRadioPopup`] with specific Messages on ok & cancel
     /// as [`Id::DeleteConfirmRadioPopup`].
-    pub fn mount_confirm_radio(&mut self, path: PathBuf, focus_node: Option<String>) {
-        assert!(
-            self.app
-                .remount(
-                    Id::DeleteConfirmRadioPopup,
-                    Box::new(DeleteConfirmRadioPopup::new(
-                        self.config_tui.clone(),
-                        Msg::DeleteConfirm(DeleteConfirmMsg::CloseOk(path, focus_node)),
-                        Msg::DeleteConfirm(DeleteConfirmMsg::CloseCancel)
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::DeleteConfirmRadioPopup).is_ok());
+    pub fn mount_confirm_radio(&mut self, path: PathBuf, focus_node: Option<String>) -> Result<()> {
+        self.app.remount(
+            Id::DeleteConfirmRadioPopup,
+            Box::new(DeleteConfirmRadioPopup::new(
+                self.config_tui.clone(),
+                Msg::DeleteConfirm(DeleteConfirmMsg::CloseOk(path, focus_node)),
+                Msg::DeleteConfirm(DeleteConfirmMsg::CloseCancel),
+            )),
+            vec![],
+        )?;
+        self.app.active(&Id::DeleteConfirmRadioPopup)?;
+
+        Ok(())
     }
 
-    /// Mount a [`DeleteConfirmInputPopup`] with [`Msg::DeleteConfirmCloseOk`] and [`Msg::DeleteConfirmCloseCancel`]
+    /// Mount a [`DeleteConfirmInputPopup`] with specific Messages on ok & cancel
     /// as [`Id::DeleteConfirmInputPopup`].
-    pub fn mount_confirm_input(&mut self, path: PathBuf, focus_node: Option<String>, title: &str) {
-        assert!(
-            self.app
-                .remount(
-                    Id::DeleteConfirmInputPopup,
-                    Box::new(DeleteConfirmInputPopup::new(
-                        &self.config_tui.read(),
-                        title,
-                        Msg::DeleteConfirm(DeleteConfirmMsg::CloseOk(path, focus_node)),
-                        Msg::DeleteConfirm(DeleteConfirmMsg::CloseCancel)
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::DeleteConfirmInputPopup).is_ok());
+    pub fn mount_confirm_input(
+        &mut self,
+        path: PathBuf,
+        focus_node: Option<String>,
+        title: &str,
+    ) -> Result<()> {
+        self.app.remount(
+            Id::DeleteConfirmInputPopup,
+            Box::new(DeleteConfirmInputPopup::new(
+                &self.config_tui.read(),
+                title,
+                Msg::DeleteConfirm(DeleteConfirmMsg::CloseOk(path, focus_node)),
+                Msg::DeleteConfirm(DeleteConfirmMsg::CloseCancel),
+            )),
+            vec![],
+        )?;
+        self.app.active(&Id::DeleteConfirmInputPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/deleteconfirm.rs
+++ b/tui/src/ui/components/popups/deleteconfirm.rs
@@ -152,6 +152,13 @@ impl Model {
         Ok(())
     }
 
+    /// Umount the Delete Confirm Radio Popup.
+    pub fn umount_confirm_radio(&mut self) -> Result<()> {
+        self.app.umount(&Id::DeleteConfirmRadioPopup)?;
+
+        Ok(())
+    }
+
     /// Mount a [`DeleteConfirmInputPopup`] with specific Messages on ok & cancel
     /// as [`Id::DeleteConfirmInputPopup`].
     pub fn mount_confirm_input(
@@ -171,6 +178,13 @@ impl Model {
             vec![],
         )?;
         self.app.active(&Id::DeleteConfirmInputPopup)?;
+
+        Ok(())
+    }
+
+    /// Umount the Delete Confirm Input Popup.
+    pub fn umount_confirm_input(&mut self) -> Result<()> {
+        self.app.umount(&Id::DeleteConfirmInputPopup)?;
 
         Ok(())
     }

--- a/tui/src/ui/components/popups/error.rs
+++ b/tui/src/ui/components/popups/error.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 /**
  * MIT License
  *
@@ -91,21 +92,31 @@ impl AppComponent<Msg, UserEvent> for ErrorPopup {
 }
 
 impl Model {
-    /// Mount error and give focus to it
-    // This should likely be refactored to be "std::error::Error", but see https://github.com/dtolnay/anyhow/issues/63 on why it was easier this way
+    /// Mount error and give focus to it.
+    ///
+    /// # Panics
+    ///
+    /// If mounting the popup fails.
     pub fn mount_error_popup<E: Into<anyhow::Error>>(&mut self, err: E) {
-        assert!(
-            self.app
-                .remount(
-                    Id::ErrorPopup,
-                    Box::new(ErrorPopup::new(self.config_tui.clone(), err)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::ErrorPopup).is_ok());
+        // unlike other mount functions, this one wraps the actual mounting function and adds a expect
+        // because it is used in many more places.
+        self.mount_error_popup_inner(err)
+            .expect("Expected ErrorPopup to mount correctly");
     }
 
+    // This should likely be refactored to be "std::error::Error", but see https://github.com/dtolnay/anyhow/issues/63 on why it was easier this way
+    fn mount_error_popup_inner<E: Into<anyhow::Error>>(&mut self, err: E) -> Result<()> {
+        self.app.remount(
+            Id::ErrorPopup,
+            Box::new(ErrorPopup::new(self.config_tui.clone(), err)),
+            vec![],
+        )?;
+        self.app.active(&Id::ErrorPopup)?;
+
+        Ok(())
+    }
+
+    /// Unmount the error popup.
     pub fn umount_error_popup(&mut self) {
         self.app.umount(&Id::ErrorPopup).ok();
     }

--- a/tui/src/ui/components/popups/error.rs
+++ b/tui/src/ui/components/popups/error.rs
@@ -117,7 +117,9 @@ impl Model {
     }
 
     /// Unmount the error popup.
-    pub fn umount_error_popup(&mut self) {
-        self.app.umount(&Id::ErrorPopup).ok();
+    pub fn umount_error_popup(&mut self) -> Result<()> {
+        self.app.umount(&Id::ErrorPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/general_search.rs
+++ b/tui/src/ui/components/popups/general_search.rs
@@ -320,6 +320,38 @@ impl AppComponent<Msg, UserEvent> for GSTablePopup {
 }
 
 impl Model {
+    /// Mount / Remount a search popup for the provided source
+    pub fn mount_general_search(&mut self, source: Source) -> Result<()> {
+        self.app.remount(
+            Id::GeneralSearchInput,
+            Box::new(GSInputPopup::new(source.clone(), &self.config_tui.read())),
+            Vec::new(),
+        )?;
+        self.app.remount(
+            Id::GeneralSearchTable,
+            Box::new(GSTablePopup::new(source, self.config_tui.clone())),
+            Vec::new(),
+        )?;
+
+        self.app.active(&Id::GeneralSearchInput)?;
+        if let Err(e) = self.update_photo() {
+            self.mount_error_popup(e.context("update_photo"));
+        }
+
+        Ok(())
+    }
+
+    /// Unmount the General Search Popup.
+    pub fn umount_general_search(&mut self) -> Result<()> {
+        self.app.umount(&Id::GeneralSearchInput)?;
+        self.app.umount(&Id::GeneralSearchTable)?;
+        if let Err(e) = self.update_photo() {
+            self.mount_error_popup(e.context("update_photo"));
+        }
+
+        Ok(())
+    }
+
     pub fn general_search_update_show(&mut self, table: tuirealm::props::Table) {
         self.app
             .attr(

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -439,7 +439,7 @@ impl AppComponent<Msg, UserEvent> for HelpPopup {
 }
 
 impl Model {
-    /// Mount help popup
+    /// Mount the Help Popup.
     pub fn mount_help_popup(&mut self) -> Result<()> {
         self.app.remount(
             Id::HelpPopup,
@@ -450,6 +450,16 @@ impl Model {
             self.mount_error_popup(e.context("update_photo"));
         }
         self.app.active(&Id::HelpPopup)?;
+
+        Ok(())
+    }
+
+    /// Unmount the Help Popup.
+    pub fn umount_help_popup(&mut self) -> Result<()> {
+        self.app.umount(&Id::HelpPopup)?;
+        if let Err(e) = self.update_photo() {
+            self.mount_error_popup(e.context("update_photo"));
+        }
 
         Ok(())
     }

--- a/tui/src/ui/components/popups/help.rs
+++ b/tui/src/ui/components/popups/help.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 
+use anyhow::Result;
 use termusiclib::config::v2::tui::keys::KeyBinding;
 use termusiclib::config::v2::tui::theme::styles::ColorTermusic;
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
@@ -439,17 +440,17 @@ impl AppComponent<Msg, UserEvent> for HelpPopup {
 
 impl Model {
     /// Mount help popup
-    pub fn mount_help_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::HelpPopup,
-                    Box::new(HelpPopup::new(self.config_tui.clone())),
-                    vec![]
-                )
-                .is_ok()
-        );
-        self.update_photo().ok();
-        assert!(self.app.active(&Id::HelpPopup).is_ok());
+    pub fn mount_help_popup(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::HelpPopup,
+            Box::new(HelpPopup::new(self.config_tui.clone())),
+            vec![],
+        )?;
+        if let Err(e) = self.update_photo() {
+            self.mount_error_popup(e.context("update_photo"));
+        }
+        self.app.active(&Id::HelpPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/message.rs
+++ b/tui/src/ui/components/popups/message.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use termusiclib::config::{SharedTuiSettings, v2::tui::theme::styles::ColorTermusic};
 use tui_realm_stdlib::components::Paragraph;
 use tuirealm::{
@@ -92,21 +93,22 @@ impl AppComponent<Msg, UserEvent> for MessagePopup {
 }
 
 impl Model {
-    pub fn mount_message<T: Into<Title>, V: Into<TextStatic>>(&mut self, title: T, text: V) {
-        assert!(
-            self.app
-                .remount(
-                    Id::MessagePopup,
-                    Box::new(MessagePopup::new(&self.config_tui, title, text)),
-                    message_subs()
-                )
-                .is_ok()
-        );
+    /// Mount a message / notification, for example for current track information.
+    pub fn mount_message<T: Into<Title>, V: Into<TextStatic>>(
+        &mut self,
+        title: T,
+        text: V,
+    ) -> Result<()> {
+        self.app.remount(
+            Id::MessagePopup,
+            Box::new(MessagePopup::new(&self.config_tui, title, text)),
+            message_subs(),
+        )?;
+
+        Ok(())
     }
 
-    /// ### `umount_message`
-    ///
-    /// Umount error message
+    /// Umount the Message component
     pub fn umount_message(&mut self, _title: &str, text: &str) {
         if let Some(spans) = self
             .app

--- a/tui/src/ui/components/popups/message.rs
+++ b/tui/src/ui/components/popups/message.rs
@@ -109,7 +109,7 @@ impl Model {
     }
 
     /// Umount the Message component
-    pub fn umount_message(&mut self, _title: &str, text: &str) {
+    pub fn umount_message(&mut self, _title: &str, text: &str) -> Result<()> {
         if let Some(spans) = self
             .app
             .query(&Id::MessagePopup, Attribute::Text)
@@ -123,8 +123,10 @@ impl Model {
         {
             let d = &display_text.as_textspan().unwrap().content;
             if text.eq(d) {
-                self.app.umount(&Id::MessagePopup).ok();
+                self.app.umount(&Id::MessagePopup)?;
             }
         }
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/podcast.rs
+++ b/tui/src/ui/components/popups/podcast.rs
@@ -248,9 +248,7 @@ impl Model {
 
     /// Unmount the feed deletion confirmation via radio component.
     pub fn umount_feed_delete_confirm_radio(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::FeedDeleteConfirmRadioPopup) {
-            self.app.umount(&Id::FeedDeleteConfirmRadioPopup)?;
-        }
+        self.app.umount(&Id::FeedDeleteConfirmRadioPopup)?;
 
         Ok(())
     }
@@ -274,9 +272,7 @@ impl Model {
 
     /// Unmount the feeed deletion confirmation via input component.
     pub fn umount_feed_delete_confirm_input(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::FeedDeleteConfirmInputPopup) {
-            self.app.umount(&Id::FeedDeleteConfirmInputPopup)?;
-        }
+        self.app.umount(&Id::FeedDeleteConfirmInputPopup)?;
 
         Ok(())
     }
@@ -335,9 +331,7 @@ impl Model {
 
     /// Unmount the podcast search component.
     pub fn umount_podcast_search_table(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::PodcastSearchTablePopup) {
-            self.app.umount(&Id::PodcastSearchTablePopup)?;
-        }
+        self.app.umount(&Id::PodcastSearchTablePopup)?;
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
@@ -360,9 +354,7 @@ impl Model {
 
     /// Unmount the component to add a podcast.
     pub fn umount_podcast_add_popup(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::PodcastAddPopup) {
-            self.app.umount(&Id::PodcastAddPopup)?;
-        }
+        self.app.umount(&Id::PodcastAddPopup)?;
 
         Ok(())
     }

--- a/tui/src/ui/components/popups/podcast.rs
+++ b/tui/src/ui/components/popups/podcast.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use tui_realm_stdlib::{
     components::{Input, Table},
@@ -233,61 +234,66 @@ impl AppComponent<Msg, UserEvent> for PodcastSearchTablePopup {
 }
 
 impl Model {
-    pub fn mount_feed_delete_confirm_radio(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::FeedDeleteConfirmRadioPopup,
-                    Box::new(FeedDeleteConfirmRadioPopup::new(self.config_tui.clone())),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::FeedDeleteConfirmRadioPopup).is_ok());
+    /// Mount a confirmation box to confirm the deletion of a feed via 2 option.
+    pub fn mount_feed_delete_confirm_radio(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::FeedDeleteConfirmRadioPopup,
+            Box::new(FeedDeleteConfirmRadioPopup::new(self.config_tui.clone())),
+            vec![],
+        )?;
+        self.app.active(&Id::FeedDeleteConfirmRadioPopup)?;
+
+        Ok(())
     }
 
-    pub fn umount_feed_delete_confirm_radio(&mut self) {
+    /// Unmount the feed deletion confirmation via radio component.
+    pub fn umount_feed_delete_confirm_radio(&mut self) -> Result<()> {
         if self.app.mounted(&Id::FeedDeleteConfirmRadioPopup) {
-            assert!(self.app.umount(&Id::FeedDeleteConfirmRadioPopup).is_ok());
+            self.app.umount(&Id::FeedDeleteConfirmRadioPopup)?;
         }
-    }
-    pub fn mount_feed_delete_confirm_input(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::FeedDeleteConfirmInputPopup,
-                    Box::new(DeleteConfirmInputPopup::new(
-                        &self.config_tui.read(),
-                        "You're about the erase all feeds.",
-                        Msg::Podcast(PCMsg::FeedsDeleteCloseOk),
-                        Msg::Podcast(PCMsg::FeedsDeleteCloseCancel)
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::FeedDeleteConfirmInputPopup).is_ok());
-    }
-    pub fn umount_feed_delete_confirm_input(&mut self) {
-        if self.app.mounted(&Id::FeedDeleteConfirmInputPopup) {
-            assert!(self.app.umount(&Id::FeedDeleteConfirmInputPopup).is_ok());
-        }
+
+        Ok(())
     }
 
-    pub fn mount_podcast_search_table(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::PodcastSearchTablePopup,
-                    Box::new(PodcastSearchTablePopup::new(self.config_tui.clone())),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::PodcastSearchTablePopup).is_ok());
+    /// Mount a confirmation box to confirm the deletion of a feed via a specific input.
+    pub fn mount_feed_delete_confirm_input(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::FeedDeleteConfirmInputPopup,
+            Box::new(DeleteConfirmInputPopup::new(
+                &self.config_tui.read(),
+                "You're about the erase all feeds.",
+                Msg::Podcast(PCMsg::FeedsDeleteCloseOk),
+                Msg::Podcast(PCMsg::FeedsDeleteCloseCancel),
+            )),
+            vec![],
+        )?;
+        self.app.active(&Id::FeedDeleteConfirmInputPopup)?;
+
+        Ok(())
+    }
+
+    /// Unmount the feeed deletion confirmation via input component.
+    pub fn umount_feed_delete_confirm_input(&mut self) -> Result<()> {
+        if self.app.mounted(&Id::FeedDeleteConfirmInputPopup) {
+            self.app.umount(&Id::FeedDeleteConfirmInputPopup)?;
+        }
+
+        Ok(())
+    }
+
+    /// Mount the podcast search component
+    pub fn mount_podcast_search_table(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::PodcastSearchTablePopup,
+            Box::new(PodcastSearchTablePopup::new(self.config_tui.clone())),
+            vec![],
+        )?;
+        self.app.active(&Id::PodcastSearchTablePopup)?;
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
+
+        Ok(())
     }
 
     pub fn update_podcast_search_table(&mut self) {
@@ -326,32 +332,38 @@ impl Model {
             )
             .ok();
     }
-    pub fn umount_podcast_search_table(&mut self) {
+
+    /// Unmount the podcast search component.
+    pub fn umount_podcast_search_table(&mut self) -> Result<()> {
         if self.app.mounted(&Id::PodcastSearchTablePopup) {
-            assert!(self.app.umount(&Id::PodcastSearchTablePopup).is_ok());
+            self.app.umount(&Id::PodcastSearchTablePopup)?;
         }
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
+
+        Ok(())
     }
 
-    pub fn mount_podcast_add_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::PodcastAddPopup,
-                    Box::new(PodcastAddPopup::new(&self.config_tui.read())),
-                    vec![]
-                )
-                .is_ok()
-        );
+    /// Mount the component to add a podcast.
+    pub fn mount_podcast_add_popup(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::PodcastAddPopup,
+            Box::new(PodcastAddPopup::new(&self.config_tui.read())),
+            vec![],
+        )?;
 
-        assert!(self.app.active(&Id::PodcastAddPopup).is_ok());
+        self.app.active(&Id::PodcastAddPopup)?;
+
+        Ok(())
     }
 
-    pub fn umount_podcast_add_popup(&mut self) {
+    /// Unmount the component to add a podcast.
+    pub fn umount_podcast_add_popup(&mut self) -> Result<()> {
         if self.app.mounted(&Id::PodcastAddPopup) {
-            assert!(self.app.umount(&Id::PodcastAddPopup).is_ok());
+            self.app.umount(&Id::PodcastAddPopup)?;
         }
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/quit.rs
+++ b/tui/src/ui/components/popups/quit.rs
@@ -63,7 +63,7 @@ impl AppComponent<Msg, UserEvent> for QuitPopup {
 }
 
 impl Model {
-    /// Mount quit popup
+    /// Mount the Quit Popup.
     pub fn mount_quit_popup(&mut self) -> Result<()> {
         self.app.remount(
             Id::QuitPopup,
@@ -71,6 +71,13 @@ impl Model {
             vec![],
         )?;
         self.app.active(&Id::QuitPopup)?;
+
+        Ok(())
+    }
+
+    /// Unmount the Quit Popup.
+    pub fn umount_quit_popup(&mut self) -> Result<()> {
+        self.app.umount(&Id::QuitPopup)?;
 
         Ok(())
     }

--- a/tui/src/ui/components/popups/quit.rs
+++ b/tui/src/ui/components/popups/quit.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 /**
  * MIT License
  *
@@ -63,16 +64,14 @@ impl AppComponent<Msg, UserEvent> for QuitPopup {
 
 impl Model {
     /// Mount quit popup
-    pub fn mount_quit_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::QuitPopup,
-                    Box::new(QuitPopup::new(self.config_tui.clone())),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::QuitPopup).is_ok());
+    pub fn mount_quit_popup(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::QuitPopup,
+            Box::new(QuitPopup::new(self.config_tui.clone())),
+            vec![],
+        )?;
+        self.app.active(&Id::QuitPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/saveplaylist.rs
+++ b/tui/src/ui/components/popups/saveplaylist.rs
@@ -286,10 +286,8 @@ impl Model {
 
     /// Unount the [`SavePlaylistPopup`] component.
     pub fn umount_save_playlist(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::SavePlaylistPopup) {
-            self.app.umount(&Id::SavePlaylistPopup)?;
-            self.app.umount(&Id::SavePlaylistLabel)?;
-        }
+        self.app.umount(&Id::SavePlaylistPopup)?;
+        self.app.umount(&Id::SavePlaylistLabel)?;
 
         Ok(())
     }
@@ -308,9 +306,7 @@ impl Model {
 
     /// Unmount the overwrite confirmation dialog.
     pub fn umount_save_playlist_confirm(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::SavePlaylistConfirm) {
-            self.app.umount(&Id::SavePlaylistConfirm)?;
-        }
+        self.app.umount(&Id::SavePlaylistConfirm)?;
 
         Ok(())
     }

--- a/tui/src/ui/components/popups/sort.rs
+++ b/tui/src/ui/components/popups/sort.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use termusiclib::config::SharedTuiSettings;
 use termusiclib::player::{SortCriterion, SortDirection};
 use tui_realm_stdlib::components::Table;
@@ -258,22 +259,24 @@ impl AppComponent<Msg, UserEvent> for SortPopup {
 
 impl Model {
     /// Mount the sort popup, hiding the album cover behind it.
-    pub fn mount_sort_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::SortPopup,
-                    Box::new(SortPopup::new(&self.config_tui)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        self.update_photo().ok();
-        assert!(self.app.active(&Id::SortPopup).is_ok());
+    pub fn mount_sort_popup(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::SortPopup,
+            Box::new(SortPopup::new(&self.config_tui)),
+            vec![],
+        )?;
+        if let Err(e) = self.update_photo() {
+            self.mount_error_popup(e.context("update_photo"));
+        }
+        self.app.active(&Id::SortPopup)?;
+
+        Ok(())
     }
 
     /// Unmount the sort popup.
-    pub fn umount_sort_popup(&mut self) {
-        self.app.umount(&Id::SortPopup).ok();
+    pub fn umount_sort_popup(&mut self) -> Result<()> {
+        self.app.umount(&Id::SortPopup)?;
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -23,6 +23,7 @@
  */
 use std::path::PathBuf;
 
+use anyhow::Result;
 use termusiclib::config::{SharedTuiSettings, TuiOverlay};
 use tui_realm_stdlib::components::{Input, Table};
 use tui_realm_stdlib::prop_ext::CommonHighlight;
@@ -243,41 +244,51 @@ impl AppComponent<Msg, UserEvent> for YSTablePopup {
 }
 
 impl Model {
-    pub fn mount_youtube_search_input(&mut self, current_node: PathBuf) {
-        assert!(
-            self.app
-                .remount(
-                    Id::YoutubeSearchInputPopup,
-                    Box::new(YSInputPopup::new(&self.config_tui.read(), current_node)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::YoutubeSearchInputPopup).is_ok());
+    /// Mount the youtube search input component.
+    pub fn mount_youtube_search_input(&mut self, current_node: PathBuf) -> Result<()> {
+        self.app.remount(
+            Id::YoutubeSearchInputPopup,
+            Box::new(YSInputPopup::new(&self.config_tui.read(), current_node)),
+            vec![],
+        )?;
+        self.app.active(&Id::YoutubeSearchInputPopup)?;
+
+        Ok(())
     }
 
-    pub fn mount_youtube_search_table(&mut self, current_node: PathBuf) {
-        assert!(
-            self.app
-                .remount(
-                    Id::YoutubeSearchTablePopup,
-                    Box::new(YSTablePopup::new(self.config_tui.clone(), current_node)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::YoutubeSearchTablePopup).is_ok());
+    /// Unmount the youtube search input component.
+    pub fn umount_youtube_search_input(&mut self) -> Result<()> {
+        if self.app.mounted(&Id::YoutubeSearchInputPopup) {
+            self.app.umount(&Id::YoutubeSearchInputPopup)?;
+        }
+
+        Ok(())
+    }
+
+    /// Mount the youtube search table component.
+    pub fn mount_youtube_search_table(&mut self, current_node: PathBuf) -> Result<()> {
+        self.app.remount(
+            Id::YoutubeSearchTablePopup,
+            Box::new(YSTablePopup::new(self.config_tui.clone(), current_node)),
+            vec![],
+        )?;
+        self.app.active(&Id::YoutubeSearchTablePopup)?;
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
+
+        Ok(())
     }
 
-    pub fn umount_youtube_search_table_popup(&mut self) {
+    /// Unmount the youtube search table component.
+    pub fn umount_youtube_search_table_popup(&mut self) -> Result<()> {
         if self.app.mounted(&Id::YoutubeSearchTablePopup) {
-            assert!(self.app.umount(&Id::YoutubeSearchTablePopup).is_ok());
+            self.app.umount(&Id::YoutubeSearchTablePopup)?;
         }
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }
+
+        Ok(())
     }
 }

--- a/tui/src/ui/components/popups/youtube_search.rs
+++ b/tui/src/ui/components/popups/youtube_search.rs
@@ -258,9 +258,7 @@ impl Model {
 
     /// Unmount the youtube search input component.
     pub fn umount_youtube_search_input(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::YoutubeSearchInputPopup) {
-            self.app.umount(&Id::YoutubeSearchInputPopup)?;
-        }
+        self.app.umount(&Id::YoutubeSearchInputPopup)?;
 
         Ok(())
     }
@@ -282,9 +280,7 @@ impl Model {
 
     /// Unmount the youtube search table component.
     pub fn umount_youtube_search_table_popup(&mut self) -> Result<()> {
-        if self.app.mounted(&Id::YoutubeSearchTablePopup) {
-            self.app.umount(&Id::YoutubeSearchTablePopup)?;
-        }
+        self.app.umount(&Id::YoutubeSearchTablePopup)?;
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }

--- a/tui/src/ui/components/progress.rs
+++ b/tui/src/ui/components/progress.rs
@@ -1,6 +1,7 @@
 use std::ops::Div;
 use std::time::Duration;
 
+use anyhow::Result;
 use termusiclib::config::TuiOverlay;
 use termusiclib::player::RunningStatus;
 use termusiclib::track::DurationFmtShort;
@@ -86,17 +87,16 @@ fn title_format(
 }
 
 impl Model {
-    pub fn progress_reload(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Progress,
-                    Box::new(Progress::new(&self.config_tui.read())),
-                    Vec::new()
-                )
-                .is_ok()
-        );
+    /// Remount the Progress component
+    pub fn remount_progress(&mut self) -> Result<()> {
+        self.app.remount(
+            Id::Progress,
+            Box::new(Progress::new(&self.config_tui.read())),
+            Vec::new(),
+        )?;
         self.progress_update_title();
+
+        Ok(())
     }
 
     /// Update the [`Progress`] component's title.

--- a/tui/src/ui/components/tag_editor/view.rs
+++ b/tui/src/ui/components/tag_editor/view.rs
@@ -260,7 +260,8 @@ impl Model {
     /// Unmount all tag editor components.
     pub fn umount_tageditor(&mut self) {
         self.mount_label_help();
-        self.umount_tageditor_inner().unwrap();
+        self.umount_tageditor_inner()
+            .expect("Expected TagEditor to unmount correctly");
         if let Err(e) = self.update_photo() {
             self.mount_error_popup(e.context("update_photo"));
         }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -117,13 +117,11 @@ impl Model {
                     .expect("Expect SortPopup to mount correctly");
             }
             SortPopupMsg::Close => {
-                self.umount_sort_popup()
-                    .expect("Expect SortPopup to unmount correctly");
+                let _ = self.umount_sort_popup();
                 self.update_photo().ok();
             }
             SortPopupMsg::Selected(criterion, direction) => {
-                self.umount_sort_popup()
-                    .expect("Expect SortPopup to unmount correctly");
+                let _ = self.umount_sort_popup();
                 self.playlist_sort(criterion, direction);
                 self.update_photo().ok();
             }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -229,8 +229,7 @@ impl Model {
                     .expect("Expected PodcastAddPopup to mount correctly");
             }
             PCMsg::PodcastAddPopupCloseOk(url) => {
-                self.umount_podcast_add_popup()
-                    .expect("Expected PodcastAddPopup to unmount correctly");
+                let _ = self.umount_podcast_add_popup();
 
                 if url.starts_with("http") {
                     self.podcast_add(url);
@@ -241,8 +240,7 @@ impl Model {
                 }
             }
             PCMsg::PodcastAddPopupCloseCancel => {
-                self.umount_podcast_add_popup()
-                    .expect("Expected PodcastAddPopup to unmount correctly");
+                let _ = self.umount_podcast_add_popup();
             }
 
             PCMsg::SyncResult(msg) => self.podcast_handle_sync_result(msg),
@@ -297,34 +295,30 @@ impl Model {
                     .expect("Expected FeedDeleteConfirmRadioPopup to mount correctly");
             }
             PCMsg::FeedDeleteCloseOk => {
-                self.umount_feed_delete_confirm_radio()
-                    .expect("Expected FeedDeleteConfirmRadioPopup to unmount correctly");
+                let _ = self.umount_feed_delete_confirm_radio();
                 if let Err(e) = self.podcast_remove_feed() {
                     self.mount_error_popup(e.context("podcast remove feed"));
                 }
             }
             PCMsg::FeedDeleteCloseCancel => {
-                self.umount_feed_delete_confirm_radio()
-                    .expect("Expected FeedDeleteConfirmRadioPopup to unmount correctly");
+                let _ = self.umount_feed_delete_confirm_radio();
             }
             PCMsg::FeedsDeleteShow => {
                 self.mount_feed_delete_confirm_input()
                     .expect("Expected FeedDeleteConfirmInputPopup to mount correctly");
             }
             PCMsg::FeedsDeleteCloseOk => {
-                self.umount_feed_delete_confirm_input()
-                    .expect("Expected FeedDeleteConfirmInputPopup to unmount correctly");
+                let _ = self.umount_feed_delete_confirm_input();
                 if let Err(e) = self.podcast_remove_all_feeds() {
                     self.mount_error_popup(e.context("podcast remove all feeds"));
                 }
             }
             PCMsg::FeedsDeleteCloseCancel => {
-                self.umount_feed_delete_confirm_input()
-                    .expect("Expected FeedDeleteConfirmInputPopup to unmount correctly");
+                let _ = self.umount_feed_delete_confirm_input();
             }
-            PCMsg::SearchItunesCloseCancel => self
-                .umount_podcast_search_table()
-                .expect("Expected PodcastSearchTablePopup to unmount correctly"),
+            PCMsg::SearchItunesCloseCancel => {
+                let _ = self.umount_podcast_search_table();
+            }
             PCMsg::SearchItunesCloseOk(index) => {
                 if let Some(vec) = &self.podcast.search_results
                     && let Some(pod) = vec.get(index)
@@ -767,12 +761,10 @@ impl Model {
                     .expect("Expect YoutubeSearchInputPopup to mount correctly");
             }
             YSMsg::InputPopupCloseCancel => {
-                self.umount_youtube_search_input()
-                    .expect("Expect YoutubeSearchInputPopup to unmount correctly");
+                let _ = self.umount_youtube_search_input();
             }
             YSMsg::InputPopupCloseOk(url, current_node) => {
-                self.umount_youtube_search_input()
-                    .expect("Expect YoutubeSearchInputPopup to unmount correctly");
+                let _ = self.umount_youtube_search_input();
                 if url.starts_with("http") {
                     match self.youtube_dl(&url, &current_node) {
                         Ok(()) => {}
@@ -787,8 +779,7 @@ impl Model {
                 }
             }
             YSMsg::TablePopupCloseCancel => {
-                self.umount_youtube_search_table_popup()
-                    .expect("Expect YoutubeSearchTablePopup to unmount correctly");
+                let _ = self.umount_youtube_search_table_popup();
             }
             YSMsg::ReqNextPage => {
                 self.youtube_options_next_page();
@@ -1099,26 +1090,22 @@ impl Model {
                 }
             }
             SavePlaylistMsg::CloseCancel => {
-                self.umount_save_playlist()
-                    .expect("Expected SavePlaylist to unmount correctly");
+                let _ = self.umount_save_playlist();
             }
             SavePlaylistMsg::CloseOk(full_path) => {
-                self.umount_save_playlist()
-                    .expect("Expected SavePlaylist to unmount correctly");
+                let _ = self.umount_save_playlist();
                 if let Err(e) = self.playlist_save_m3u_before(full_path) {
                     self.mount_error_popup(e.context("save m3u playlist before"));
                 }
             }
             SavePlaylistMsg::OverwriteCancel => {
-                self.umount_save_playlist_confirm()
-                    .expect("Expected SavePlaylist to unmount correctly");
+                let _ = self.umount_save_playlist_confirm();
             }
             SavePlaylistMsg::OverwriteOk(filename) => {
                 if let Err(e) = self.playlist_save_m3u(filename) {
                     self.mount_error_popup(e.context("save m3u playlist"));
                 }
-                self.umount_save_playlist_confirm()
-                    .expect("Expected SavePlaylistConfirm to unmount correctly");
+                let _ = self.umount_save_playlist_confirm();
             }
 
             // handled by the component

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -91,9 +91,7 @@ impl Model {
     fn update_error_popup_msg(&mut self, msg: &ErrorPopupMsg) {
         match msg {
             ErrorPopupMsg::Close => {
-                if self.app.mounted(&Id::ErrorPopup) {
-                    self.umount_error_popup();
-                }
+                let _ = self.umount_error_popup();
             }
         }
     }
@@ -205,7 +203,7 @@ impl Model {
                     .expect("Expect MessagePopup to mount correctly");
             }
             NotificationMsg::MessageHide((title, text)) => {
-                self.umount_message(&title, &text);
+                let _ = self.umount_message(&title, &text);
             }
         }
     }

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -102,7 +102,8 @@ impl Model {
     fn update_help_popup_msg(&mut self, msg: &HelpPopupMsg) {
         match msg {
             HelpPopupMsg::Show => {
-                self.mount_help_popup();
+                self.mount_help_popup()
+                    .expect("Expect HelpPopup to mount correctly");
             }
             HelpPopupMsg::Close => {
                 if self.app.mounted(&Id::HelpPopup) {
@@ -117,14 +118,17 @@ impl Model {
     fn update_sort_popup_msg(&mut self, msg: SortPopupMsg) {
         match msg {
             SortPopupMsg::Show => {
-                self.mount_sort_popup();
+                self.mount_sort_popup()
+                    .expect("Expect SortPopup to mount correctly");
             }
             SortPopupMsg::Close => {
-                self.umount_sort_popup();
+                self.umount_sort_popup()
+                    .expect("Expect SortPopup to unmount correctly");
                 self.update_photo().ok();
             }
             SortPopupMsg::Selected(criterion, direction) => {
-                self.umount_sort_popup();
+                self.umount_sort_popup()
+                    .expect("Expect SortPopup to unmount correctly");
                 self.playlist_sort(criterion, direction);
                 self.update_photo().ok();
             }
@@ -136,7 +140,8 @@ impl Model {
         match msg {
             QuitPopupMsg::Show => {
                 if self.config_tui.read().settings.behavior.confirm_quit {
-                    self.mount_quit_popup();
+                    self.mount_quit_popup()
+                        .expect("Expect QuitPopup to unmount correctly");
                 } else {
                     self.quit = true;
                 }
@@ -199,7 +204,8 @@ impl Model {
     fn update_notification_msg(&mut self, msg: NotificationMsg) {
         match msg {
             NotificationMsg::MessageShow((title, text)) => {
-                self.mount_message(title, text);
+                self.mount_message(title, text)
+                    .expect("Expect MessagePopup to mount correctly");
             }
             NotificationMsg::MessageHide((title, text)) => {
                 self.umount_message(&title, &text);
@@ -223,18 +229,26 @@ impl Model {
             PCMsg::EpisodeBlurUp => {
                 self.app.active(&Id::Podcast).ok();
             }
-            PCMsg::PodcastAddPopupShow => self.mount_podcast_add_popup(),
+            PCMsg::PodcastAddPopupShow => {
+                self.mount_podcast_add_popup()
+                    .expect("Expected PodcastAddPopup to mount correctly");
+            }
             PCMsg::PodcastAddPopupCloseOk(url) => {
-                self.umount_podcast_add_popup();
+                self.umount_podcast_add_popup()
+                    .expect("Expected PodcastAddPopup to unmount correctly");
 
                 if url.starts_with("http") {
                     self.podcast_add(url);
                 } else {
                     self.podcast_search_itunes(&url);
-                    self.mount_podcast_search_table();
+                    self.mount_podcast_search_table()
+                        .expect("Expect PodcastSearchTablePopup to mount correctly");
                 }
             }
-            PCMsg::PodcastAddPopupCloseCancel => self.umount_podcast_add_popup(),
+            PCMsg::PodcastAddPopupCloseCancel => {
+                self.umount_podcast_add_popup()
+                    .expect("Expected PodcastAddPopup to unmount correctly");
+            }
 
             PCMsg::SyncResult(msg) => self.podcast_handle_sync_result(msg),
             PCMsg::DLResult(msg) => self.podcast_handle_dl_result(msg),
@@ -283,23 +297,39 @@ impl Model {
                     self.mount_error_popup(e.context("podcast episode delete"));
                 }
             }
-            PCMsg::FeedDeleteShow => self.mount_feed_delete_confirm_radio(),
+            PCMsg::FeedDeleteShow => {
+                self.mount_feed_delete_confirm_radio()
+                    .expect("Expected FeedDeleteConfirmRadioPopup to mount correctly");
+            }
             PCMsg::FeedDeleteCloseOk => {
-                self.umount_feed_delete_confirm_radio();
+                self.umount_feed_delete_confirm_radio()
+                    .expect("Expected FeedDeleteConfirmRadioPopup to unmount correctly");
                 if let Err(e) = self.podcast_remove_feed() {
                     self.mount_error_popup(e.context("podcast remove feed"));
                 }
             }
-            PCMsg::FeedDeleteCloseCancel => self.umount_feed_delete_confirm_radio(),
-            PCMsg::FeedsDeleteShow => self.mount_feed_delete_confirm_input(),
+            PCMsg::FeedDeleteCloseCancel => {
+                self.umount_feed_delete_confirm_radio()
+                    .expect("Expected FeedDeleteConfirmRadioPopup to unmount correctly");
+            }
+            PCMsg::FeedsDeleteShow => {
+                self.mount_feed_delete_confirm_input()
+                    .expect("Expected FeedDeleteConfirmInputPopup to mount correctly");
+            }
             PCMsg::FeedsDeleteCloseOk => {
-                self.umount_feed_delete_confirm_input();
+                self.umount_feed_delete_confirm_input()
+                    .expect("Expected FeedDeleteConfirmInputPopup to unmount correctly");
                 if let Err(e) = self.podcast_remove_all_feeds() {
                     self.mount_error_popup(e.context("podcast remove all feeds"));
                 }
             }
-            PCMsg::FeedsDeleteCloseCancel => self.umount_feed_delete_confirm_input(),
-            PCMsg::SearchItunesCloseCancel => self.umount_podcast_search_table(),
+            PCMsg::FeedsDeleteCloseCancel => {
+                self.umount_feed_delete_confirm_input()
+                    .expect("Expected FeedDeleteConfirmInputPopup to unmount correctly");
+            }
+            PCMsg::SearchItunesCloseCancel => self
+                .umount_podcast_search_table()
+                .expect("Expected PodcastSearchTablePopup to unmount correctly"),
             PCMsg::SearchItunesCloseOk(index) => {
                 if let Some(vec) = &self.podcast.search_results
                     && let Some(pod) = vec.get(index)
@@ -737,17 +767,16 @@ impl Model {
     fn update_youtube_search(&mut self, msg: YSMsg) {
         match msg {
             YSMsg::InputPopupShow(current_node) => {
-                self.mount_youtube_search_input(current_node);
+                self.mount_youtube_search_input(current_node)
+                    .expect("Expect YoutubeSearchInputPopup to mount correctly");
             }
             YSMsg::InputPopupCloseCancel => {
-                if self.app.mounted(&Id::YoutubeSearchInputPopup) {
-                    assert!(self.app.umount(&Id::YoutubeSearchInputPopup).is_ok());
-                }
+                self.umount_youtube_search_input()
+                    .expect("Expect YoutubeSearchInputPopup to unmount correctly");
             }
             YSMsg::InputPopupCloseOk(url, current_node) => {
-                if self.app.mounted(&Id::YoutubeSearchInputPopup) {
-                    assert!(self.app.umount(&Id::YoutubeSearchInputPopup).is_ok());
-                }
+                self.umount_youtube_search_input()
+                    .expect("Expect YoutubeSearchInputPopup to unmount correctly");
                 if url.starts_with("http") {
                     match self.youtube_dl(&url, &current_node) {
                         Ok(()) => {}
@@ -756,12 +785,14 @@ impl Model {
                         }
                     }
                 } else {
-                    self.mount_youtube_search_table(current_node);
+                    self.mount_youtube_search_table(current_node)
+                        .expect("Expect YoutubeSearchTablePopup to mount correctly");
                     self.youtube_options_search(url);
                 }
             }
             YSMsg::TablePopupCloseCancel => {
-                self.umount_youtube_search_table_popup();
+                self.umount_youtube_search_table_popup()
+                    .expect("Expect YoutubeSearchTablePopup to unmount correctly");
             }
             YSMsg::ReqNextPage => {
                 self.youtube_options_next_page();
@@ -958,7 +989,8 @@ impl Model {
     fn update_delete_confirmation(&mut self, msg: DeleteConfirmMsg) {
         match msg {
             DeleteConfirmMsg::Show(path, focus_node) => {
-                self.new_library_show_delete_confirm(path, focus_node);
+                self.new_library_show_delete_confirm(path, focus_node)
+                    .expect("Expect DeleteConfirm to mount correctly");
             }
             DeleteConfirmMsg::CloseCancel => {
                 if self.app.mounted(&Id::DeleteConfirmRadioPopup) {

--- a/tui/src/ui/model/update.rs
+++ b/tui/src/ui/model/update.rs
@@ -106,10 +106,7 @@ impl Model {
                     .expect("Expect HelpPopup to mount correctly");
             }
             HelpPopupMsg::Close => {
-                if self.app.mounted(&Id::HelpPopup) {
-                    self.app.umount(&Id::HelpPopup).ok();
-                }
-                self.update_photo().ok();
+                let _ = self.umount_help_popup();
             }
         }
     }
@@ -147,7 +144,7 @@ impl Model {
                 }
             }
             QuitPopupMsg::CloseCancel => {
-                self.app.umount(&Id::QuitPopup).ok();
+                let _ = self.umount_quit_popup();
             }
             QuitPopupMsg::CloseOk => {
                 self.quit = true;
@@ -725,11 +722,12 @@ impl Model {
             DBMsg::AddAllResultsConfirmShow => {
                 // dont try showing the popup if there is nothing to add
                 if !self.dw.search_results.is_empty() {
-                    self.mount_results_add_confirm_database(self.dw.criteria);
+                    self.mount_results_add_confirm_database(self.dw.criteria)
+                        .expect("Expected ResultAddConfirmPopup to mount correctly");
                 }
             }
             DBMsg::AddAllResultsConfirmCancel => {
-                self.umount_results_add_confirm_database();
+                let _ = self.umount_results_add_confirm_database();
             }
         }
     }
@@ -908,11 +906,7 @@ impl Model {
                 }
             }
             GSMsg::PopupCloseCancel => {
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
 
             GSMsg::PopupCloseLibraryAddPlaylist => {
@@ -922,30 +916,15 @@ impl Model {
             }
             GSMsg::PopupCloseOkLibraryLocate => {
                 self.general_search_after_library_select();
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
-
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
             GSMsg::PopupClosePlaylistPlaySelected => {
                 self.general_search_after_playlist_play_selected();
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
-
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
             GSMsg::PopupCloseOkPlaylistLocate => {
                 self.general_search_after_playlist_select();
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
-
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
             GSMsg::PopupCloseDatabaseAddPlaylist => {
                 if let Err(e) = self.general_search_after_database_add_playlist() {
@@ -961,12 +940,8 @@ impl Model {
                 if let Err(e) = self.general_search_after_episode_select() {
                     self.mount_error_popup(e.context("general search after episode select"));
                 }
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
                 self.podcast_focus_episode_list();
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
 
             GSMsg::PopupUpdateEpisode(input) => self.podcast_update_search_episode(input),
@@ -975,12 +950,8 @@ impl Model {
                 if let Err(e) = self.general_search_after_podcast_select() {
                     self.mount_error_popup(e.context("general search after podcast select"));
                 }
-                self.app.umount(&Id::GeneralSearchInput).ok();
-                self.app.umount(&Id::GeneralSearchTable).ok();
                 self.podcast_focus_podcast_list();
-                if let Err(e) = self.update_photo() {
-                    self.mount_error_popup(e.context("update_photo"));
-                }
+                let _ = self.umount_general_search();
             }
         }
     }
@@ -993,20 +964,12 @@ impl Model {
                     .expect("Expect DeleteConfirm to mount correctly");
             }
             DeleteConfirmMsg::CloseCancel => {
-                if self.app.mounted(&Id::DeleteConfirmRadioPopup) {
-                    let _drop = self.app.umount(&Id::DeleteConfirmRadioPopup);
-                }
-                if self.app.mounted(&Id::DeleteConfirmInputPopup) {
-                    let _drop = self.app.umount(&Id::DeleteConfirmInputPopup);
-                }
+                let _ = self.umount_confirm_radio();
+                let _ = self.umount_confirm_input();
             }
             DeleteConfirmMsg::CloseOk(path, focus_node) => {
-                if self.app.mounted(&Id::DeleteConfirmRadioPopup) {
-                    let _drop = self.app.umount(&Id::DeleteConfirmRadioPopup);
-                }
-                if self.app.mounted(&Id::DeleteConfirmInputPopup) {
-                    let _drop = self.app.umount(&Id::DeleteConfirmInputPopup);
-                }
+                let _ = self.umount_confirm_radio();
+                let _ = self.umount_confirm_input();
                 if let Err(e) = self.new_library_delete_node(&path, focus_node) {
                     self.mount_error_popup(e.context("library delete song"));
                 }

--- a/tui/src/ui/model/view.rs
+++ b/tui/src/ui/model/view.rs
@@ -14,8 +14,7 @@ use tuirealm::subscription::{EventClause, Sub, SubClause};
 use tuirealm::terminal::TerminalAdapter;
 
 use crate::ui::components::{
-    DBListCriteria, DownloadSpinner, Footer, GSInputPopup, GSTablePopup, Lyric, Playlist, Progress,
-    Source,
+    DBListCriteria, DownloadSpinner, Footer, Lyric, Playlist, Progress, Source,
 };
 use crate::ui::ids::{Id, IdConfigEditor, IdTagEditor};
 use crate::ui::model::ports::rx_main::PortRxMain;
@@ -323,52 +322,34 @@ impl Model {
         Self::view_popups(f, app);
     }
 
-    /// Mount / Remount a search popup for the provided source
-    fn mount_search(&mut self, source: Source) {
-        self.app
-            .remount(
-                Id::GeneralSearchInput,
-                Box::new(GSInputPopup::new(source.clone(), &self.config_tui.read())),
-                Vec::new(),
-            )
-            .unwrap();
-        self.app
-            .remount(
-                Id::GeneralSearchTable,
-                Box::new(GSTablePopup::new(source, self.config_tui.clone())),
-                Vec::new(),
-            )
-            .unwrap();
-
-        self.app.active(&Id::GeneralSearchInput).unwrap();
-        if let Err(e) = self.update_photo() {
-            self.mount_error_popup(e.context("update_photo"));
-        }
-    }
-
     #[inline]
     pub fn mount_search_library(&mut self, path: PathBuf) {
-        self.mount_search(Source::Library(path));
+        self.mount_general_search(Source::Library(path))
+            .expect("Expected GeneralSearch to mount correctly");
     }
 
     #[inline]
     pub fn mount_search_playlist(&mut self) {
-        self.mount_search(Source::Playlist);
+        self.mount_general_search(Source::Playlist)
+            .expect("Expected GeneralSearch to mount correctly");
     }
 
     #[inline]
     pub fn mount_search_database(&mut self) {
-        self.mount_search(Source::Database);
+        self.mount_general_search(Source::Database)
+            .expect("Expected GeneralSearch to mount correctly");
     }
 
     #[inline]
     pub fn mount_search_episode(&mut self) {
-        self.mount_search(Source::Episode);
+        self.mount_general_search(Source::Episode)
+            .expect("Expected GeneralSearch to mount correctly");
     }
 
     #[inline]
     pub fn mount_search_podcast(&mut self) {
-        self.mount_search(Source::Podcast);
+        self.mount_general_search(Source::Podcast)
+            .expect("Expected GeneralSearch to mount correctly");
     }
 
     pub fn mount_label_help(&mut self) {


### PR DESCRIPTION
This PR tries to clean-up the TUI `mount_`, `remount_` and `umount_` functions, signatures and calling convention.
In particular:
- remove `assert!`s, change to `Result`s
- in most cases ignore the `umount` result (as the only error is "Component not found", which means it is already unmounted)
- remove `mounted` check from umounts, as the result can just be ignored anyway
- move remainder mount, remount and umount calls to dedicated functions

Builts on-top of #770